### PR TITLE
refactor: mirror-machine architecture + UI split + UX overhaul

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,36 +20,40 @@ src/
 ├── app.ts                   entry; mount()s <App>
 ├── app.css                  global tokens + base styles
 ├── components/
-│   ├── MachineTab.svelte    per-engine orchestrator
-│   ├── Tape.svelte          virtualized horizontal belt
+│   ├── MachineView.svelte   per-engine orchestrator (state + handlers)
+│   ├── TapesStack.svelte    multi-tape stack with shared head-thread
+│   ├── Tape.svelte          single horizontal belt (renders a turing.Tape)
 │   ├── ControlPanel.svelte  L/S/R + alphabet chips + Apply
+│   ├── Toolbar.svelte       Build/Step/Run/Stop + with-pause + examples menu
 │   ├── Editor.svelte        CodeMirror 6 wrapper + reset overlay
 │   ├── Log.svelte           log entries (desktop)
-│   └── IconButton.svelte    icon + optional label
+│   └── IconButton.svelte    shared corner-overlay icon button (reset / clear)
 └── lib/
-    ├── types.ts             Engine, Command, WorkerRequest/Response, MAX_STEPS
-    ├── runner.ts            main-thread worker wrapper, 5s timeout
-    ├── worker.ts            spawns user code via new Function inside worker
+    ├── types.ts             Engine, Command, Alphabets, WorkerRequest/Response, TapeSnapshot
+    ├── caps.ts              numeric caps: VIEWPORT_WIDTH, MAX_STEPS, WORKER_TIMEOUT_MS, MAX_TAPES
+    ├── machineRunner.ts     main-thread worker wrapper; WORKER_TIMEOUT_MS round-trip cap
+    ├── machineWorker.ts     spawns user code via new Function inside worker
     ├── demoLoop.ts          idle-mode random-command loop
     ├── autoStep.ts          paused-auto-step controller + parseInterval
     ├── completions.ts       CodeMirror autocomplete: machine namespace + locals
     ├── syntaxLinter.ts      Lezer-based syntax-error markers
     ├── persist.ts           localStorage helpers per engine
     ├── defaultCode.ts       starter Turing / Post snippets
-    ├── format.ts            describeCommand / formatTape / formatAlphabet
+    ├── format.ts            describeAppliedCommand / formatTape / commandsEntry / tapesEntry
     └── icons.ts             Tabler icon namespace (?raw imports)
 ```
 
-**`App.svelte`** picks the active engine from `?machine=` and renders one `<MachineTab engine={...}>` keyed by engine — switching engines unmounts and remounts the tab (kills CodeMirror undo, cheap CPU).
+**`App.svelte`** picks the active engine from `?machine=` and renders one `<MachineView engine={...}>` keyed by engine — switching engines unmounts and remounts the tab (kills CodeMirror undo, cheap CPU).
 
-**`MachineTab.svelte`** is the orchestrator. It owns:
+**`MachineView.svelte`** is the orchestrator (UI is split into `TapesStack`, `Toolbar`, `ControlPanel`, `Editor`, `Log`). It owns:
 
 - `executionMode` (`$state<ExecutionMode>`) — see state machine below
-- `entries`, `alphabet`, `lastSnapshot`, `halted`, `code`, `withPause`, `intervalText` — all `$state`
+- `logEntries`, `alphabets`, `lastSnapshots`, `halted`, `code`, `withPause`, `intervalText`, `demoBank` — all `$state` (multi-tape: `alphabets`/`lastSnapshots` are per-tape arrays)
 - `pendingOp: 'load' | 'run' | null` and `stepInFlight: boolean` — concurrency guards
-- `panelEnabled` / `applyVisible` / `takeControlVisible` / `loadDisabled` / `stepDisabled` / `runDisabled` — all `$derived` from the above (single source of truth for button-disabled state)
-- `$effect`s for the demo loop, auto-step loop, and belt-transitions toggle
-- `runner = new MachineRunner(engine)` and the `doLoad` / `doStep` / `doRun` / `takeControl` / `resetCodeToDefault` handlers
+- `panelEnabled` / `applyVisible` / `takeControlVisible` / `loadDisabled` / `stepDisabled` / `runDisabled` / `tapeCount` — all `$derived` (single source of truth for UI state)
+- `mirrorMachine` / `mirrorTapeBlock` — a real `TuringMachine` instance on the main thread that mirrors the worker's tape state. Built by `_buildMirrorMachine` after each `reloadWorker`; advanced one step at a time by `_runMirrorStep` (uses an `ifOtherSymbol` one-step `State` so the upstream library's transitions drive the visualization, not bespoke UI code). `renderFromMirror` hands each `mirrorTapeBlock.tapes[i]` to the matching `<Tape>` via `TapesStack.setFromTape(i, tape, …)`.
+- `$effect`s for the demo loop, auto-step loop, belt-transitions toggle, and a code-changed warning (debounced via `codeChangedWarned` flag — fires once per running session)
+- `runner = new MachineRunner(engine)` and the `doLoad` / `doStep` / `doRun` / `takeControl` / `stopMachine` / `resetCodeToSelected` handlers; `reloadWorker(source?)` is the shared "build worker + rebuild mirrorMachine" helper, taking optional source code (defaults to current `code`) so DEMO can run the canonical `selectedExample.code` regardless of editor state
 
 ## Execution modes
 
@@ -57,60 +61,89 @@ src/
 
 | Mode | Panel | Apply visible | Take control | Belt behavior |
 |---|---|---|---|---|
-| `DEMO` | disabled mirror | yes (flashes) | yes | timer-driven random commands; auto-stops on first user-clicked Load (`demoEnabled = false`) |
-| `MANUAL` | enabled | yes | hidden | user-driven via Apply |
+| `DEMO` | disabled mirror | yes (flashes) | yes | timer-driven random commands; loads `selectedExample.code` (canonical), not the editor's `code`. Auto-stops on first user-clicked Build (`demoEnabled = false`); Build also pulls a real-step "demo bank" via a temp worker for visually meaningful symbol writes. |
+| `MANUAL` | enabled | yes | hidden | user-driven via Apply (writes to `mirrorMachine` via the same `ifOtherSymbol` one-step path used by Step) |
 | `RUNNING_STEP` | disabled mirror | hidden | yes | one slide per Step click; also serves as the **paused** state for `RUNNING_AUTO` |
 | `RUNNING_AUTO` | disabled mirror | hidden | yes | timer-driven worker steps; Step button shows pause icon + "Pause" label; click → `RUNNING_STEP` |
 | `RUNNING_CONTINUOUS` | neutral cmd shown | hidden | hidden | snap-to-final, transitions off; per-step commands batch-logged after the worker returns |
-| `HALTED` | disabled mirror | hidden | yes | frozen at final state |
+| `HALTED` | disabled mirror | hidden | yes | frozen at final state. Build/Step/Run remain enabled — Step/Run reload-from-code on entry (the same path as MANUAL/DEMO), effectively restarting the machine without an explicit Build click. |
 
-Take control is the only entry into `MANUAL`. Once the user takes control, demo never restarts.
+Take control is the only entry into `MANUAL`. Once the user takes control, demo never restarts. From `MANUAL` (or `DEMO`/`HALTED`), Step and Run both call `reloadWorker(code)` first — the user's manual `Apply`s and code edits are reconciled by always rebuilding the worker + `mirrorMachine` from the current editor `code`.
+
+A `Stop` button is shown next to Run while `RUNNING_STEP` / `RUNNING_AUTO` (`stopVisible`); clicking it sets `executionMode = 'HALTED'` and reports `'stopped'`. The auto-step `$effect` cleans itself up when mode leaves `RUNNING_AUTO`.
 
 ## Worker contract
 
-All shapes are TS discriminated unions in `src/lib/types.ts`. Single canonical `Command = { movement: 'L'|'R'|'S'; symbol: string | null }` (`null` = "keep" — resolved symbol matched current).
+All shapes are TS discriminated unions in `src/lib/types.ts`. Single canonical `Command = { movement: 'L'|'R'|'S'; symbol: string | null }` (`null` = "keep" — resolved symbol matched current). All response payloads are **per-tape arrays** — N=1 for single-tape, N=K for K-tape (`tapeBlock.fromTapes([...K])`).
 
 | Request | Response |
 |---|---|
-| `{ type: 'load', engine, code }` | `{ type: 'loaded', tape, alphabet, halted, stepsApplied, nextCommand }` |
-| `{ type: 'step' }` | `{ type: 'stepped', tape, halted, command, nextCommand, stepsApplied }` |
-| `{ type: 'run', maxSteps? }` | `{ type: 'ran', tape, halted, truncated, commands, startStep, stepsApplied }` |
+| `{ type: 'build', engine, code }` | `{ type: 'built', tapes, alphabets, halted }` |
+| `{ type: 'step' }` | `{ type: 'stepped', halted, commands, nextCommands, stepsApplied }` |
+| `{ type: 'run', maxSteps? }` | `{ type: 'ran', tapes, truncated, commands, startStep, stepsApplied }` |
 
-On any failure: `{ type: 'error', message, stack }`.
+On any failure: `{ type: 'error', message, tapes? }`. When the worker errors mid-step / mid-run (typical case: no edge in the state graph for the current symbol), the response also carries the partial tape state. The runner wraps `error` responses in a `WorkerError` (custom class with a `tapes` field); `MachineView.svelte#failHalted` rebuilds the mirror and updates `lastSnapshots` from those tapes — without this, the user would see only the loaded tape and lose every step the worker actually applied before throwing.
 
-Worker assumes **single-tape** machines. Multi-tape machines throw a clear error from `commandFromYield` — see [GH issue #1](https://github.com/mellonis/machines-demo/issues/1) for tracking multi-tape display support.
+`stepped` deliberately omits `tapes` — applying a `Command` to a `Tape` is deterministic, so the main-thread `mirrorMachine` replays the worker's commands and is the source of truth for tape rendering during stepping. The worker only ships full tape state on `built` (initial state) and `ran` (final state after a continuous run, where replaying thousands of commands on the mirror would be wasteful).
+
+`TapeSnapshot = { symbols, position }` is the **wire format** carrying tape data across the worker boundary (not the UI's render input). `position` is the head index into `symbols`. Producer:
+
+- **Worker on `built` / `ran` / `error`** — full tape, no trim. Trimming would lose user-tape data outside the initial render window; once the user takes control and moves the head, blanks would appear where original symbols should be. `machineWorker.ts` does **not** mutate user `t.viewportWidth` (the library's `normalise()` would pad `t.symbols` and surprise user code), and just clones `t.symbols` plus `t.position`.
+
+The main thread converts each `TapeSnapshot` to a `turing.Tape` once via `_buildMirrorMachine` (constructs library tape, then sets `viewportWidth = VIEWPORT_WIDTH` via the **setter** so `normalise()` pads — the constructor stores `viewportWidth` raw, see [turing-machine-js#95](https://github.com/mellonis/turing-machine-js/issues/95)). Per-step rendering then hands the **library tape itself** to `Tape.svelte#setFromTape`, which reads `tape.viewport` (the library's slice/center math, length guaranteed to be `VIEWPORT_WIDTH`).
+
+**Caps** (all in `lib/caps.ts`):
+- `MAX_TAPES = 5` — multi-tape limit; the worker rejects loads with more tapes than the caret palette can color.
+- `MAX_STEPS = 100_000` — `run`-mode hard cap; if `runToEnd` reaches it before the machine halts, the response sets `truncated: true`. Same backstop as `WORKER_TIMEOUT_MS` but counts steps instead of wall-clock time, so a tight loop that never yields still terminates eventually.
+- `WORKER_TIMEOUT_MS = 5_000` — wall-clock cap on a single worker request. The `MachineRunner` schedules a `setTimeout` and kills the worker (terminate + respawn next request) if the round-trip exceeds it.
+- `VIEWPORT_WIDTH = 23` — see Tape section below.
+
+Tape derivation in `machineWorker.ts` prefers `tapeBlock.tapes` so a user adapting the single-tape default snippet to multi-tape doesn't silently see only tape 0.
 
 ## Tape (the belt)
 
-`Tape.svelte` renders 23 cells (`VISIBLE_CELLS = 19` desktop + 2 buffer each side); CSS `--visible-cells` shrinks the viewport to show fewer at smaller breakpoints (17 tablet, 11 phone) — extra cells fade behind the mask. The `apply()` method does the prep-shift trick: re-render with new head via `$state` mutation, `await tick()`, then snap-translate by ±1 cell without transition, force reflow, transition back to 0. `await tick()` is critical — `queueMicrotask` would race Svelte's scheduler.
+`Tape.svelte` renders `VIEWPORT_WIDTH = 23` cells (constant in `lib/caps.ts`, must be odd so the head sits at the exact middle); CSS `--visible-cells` shrinks the visual viewport to show fewer at smaller breakpoints (17 tablet, 11 phone) — extra cells fade behind the mask. The single render path is `setFromTape(tape, delta?, animate?)` — `tape` is a `turing.Tape` instance (the upstream library type; mirror tapes have `viewportWidth = VIEWPORT_WIDTH` set, so `tape.viewport` returns exactly the render window), `delta` is ±1/0 (the head movement), `animate` toggles the slide. `setFromTape(null)` clears.
 
-The head ▲ marker below each bottom belt is a **CSS-border triangle** (not a Unicode glyph) so its visible edges exactly match its box and `left:50%; translateX(-50%)` aligns pixel-perfect with the head-thread line. `.viewport` carries `background: var(--bg)` to mask the head-thread behind the stack across the whole tape row — without that, the 4px inter-cell gap passes through the head column during slide animations and exposes the line. `.cell.out-of-range` dims only border + symbol (not the whole cell via `opacity`) for the same masking reason.
+Cell shape is `Cell = { sym: string; blank: boolean }` — `sym` is the literal alphabet symbol (no UI substitution; the user's chosen blank glyph is rendered as-is), `blank` is a flag that tags cells holding `tape.alphabet.blankSymbol`. The flag drives a CSS sugar (`.cell.blank` — dim border, dim symbol opacity) so blank cells are visually distinct from non-blank ones **without overloading any specific character**. This means a user can put `'␣'` in their alphabet as a non-blank symbol with zero collision: blank cells render their actual blank glyph dimmed, the `'␣'` cells render at full opacity.
+
+The component owns no tape state of its own beyond the fixed-size `viewport: $state<Cell[]>` (length always `VIEWPORT_WIDTH`). The slide animation uses the prep-shift trick: write `viewport`, `await tick()`, snap-translate by ±1 cell without transition, force reflow, transition back to 0. `await tick()` is critical — `queueMicrotask` would race Svelte's scheduler.
+
+The head ▲ marker below each bottom belt is a **CSS-border triangle** (not a Unicode glyph) so its visible edges exactly match its box and `left:50%; translateX(-50%)` aligns pixel-perfect with the head-thread line. `.viewport` (CSS class on the outer wrapper, not the JS variable) carries `background: var(--bg)` to mask the head-thread behind the stack across the whole tape row — without that, the 4px inter-cell gap passes through the head column during slide animations and exposes the line.
+
+**Bundled examples use `'␣'` (U+2423 OPEN BOX) as the literal blank symbol in their alphabets.** Convention: pick a visible glyph for blank if you want to see blank cells out of the box; the demo no longer normalizes blanks to a special UI character.
 
 ## Multi-tape stack and head-thread connector
 
-`MachineTab.svelte` renders `tapeCount` tapes inside `.tapes-stack` (flex column, 4px gap). Only the bottom belt shows the ▲ marker (`showCaret={i === tapeCount - 1}`); each belt gets a per-instance `caretColor` from the 5-entry `CARET_COLORS` palette (length must match `MAX_TAPES` in `lib/types.ts`).
+`TapesStack.svelte` renders `tapeCount` tapes inside `.tapes-stack` (flex column, 4px gap). Only the bottom belt shows the ▲ marker (`showCaret={i === tapeCount - 1}`); each belt gets a per-instance `caretColor` from the 5-entry `CARET_COLORS` palette (length must match `MAX_TAPES` in `lib/caps.ts`). The stack owns its own per-tape refs and exposes an imperative API (`setFromTape(i, tape, delta?, animate?)`, `clearAll()`, `setTransitionsEnabled(on)`) — `MachineView.svelte` holds a `tapesStackRef` and calls these.
 
 A `.head-thread` div sits behind the stack as the first child of `.tapes-stack` and acts as a vertical connector from the top tape's caret box down to the bottom-belt ▲ marker. Implementation:
 - `position: absolute; top: 0; bottom: 4px; left: 50%; width: 2px; transform: translateX(-50%);` — the `bottom: 4px` lands the line at the marker's vertical center (CSS triangle is 8px tall).
-- `background` is a hard-stop `linear-gradient` built in `headThreadBackground` ($derived): paired stops `color[i] top, color[i] bot` per tape, so each tape row is solid in its color and transitions happen only in the inter-tape gap. Stops are pixel offsets driven by `--cell-h` and `--tape-gap` set on `.tapes-stack`.
+- `background` is a hard-stop `linear-gradient` built in `headThreadBackground` ($derived inside `TapesStack`): paired stops `color[i] top, color[i] bot` per tape, so each tape row is solid in its color and transitions happen only in the inter-tape gap. Stops are pixel offsets driven by `--cell-h` and `--tape-gap` set on `.tapes-stack`.
 - The line is masked invisibly through every tape row by `.viewport`'s opaque `--bg`; only the inter-tape gaps and the bottom-belt's 14px padding (where the marker lives) remain visible.
 
-**Coupling — keep in sync:** `MachineTab.svelte` duplicates Tape.svelte's responsive `--cell-h` (40 / 36 / 34 px at the same breakpoints) on `.tapes-stack` so the gradient stops align with actual tape positions. Touching either file's cell-height values means touching both.
+**Coupling — keep in sync:** `TapesStack.svelte` duplicates `Tape.svelte`'s responsive `--cell-h` (40 / 36 / 34 px at the same breakpoints) on `.tapes-stack` so the gradient stops align with actual tape positions. Touching either file's cell-height values means touching both.
 
 ## Conventions
 
 - **localStorage** keys `machines-demo:code:turing` / `machines-demo:code:post` persist editor contents (via `lib/persist.ts`, errors swallowed).
-- **`report(text, kind?)`** in MachineTab is the single log entry point — appends to `entries`. The latest entry doubles as the mobile status line via `latestEntry $derived`.
+- **`report(text, kind?)`** in MachineView is the single log entry point — appends to `logEntries`. `reportSeparator()` pushes a `{separator: true}` entry that `Log.svelte` renders as an `<hr>`; called before each Build / first-Step / Run so distinct sessions read as visually grouped. The mobile-status `latestEntry $derived` skips separator entries.
+- **CSS nesting** is used throughout (native, no preprocessor) — Vite's CSS pipeline handles it; supported by all evergreen browsers. Keep nesting shallow (≤2 levels) to preserve specificity readability.
+- **No UI substitution of alphabet symbols.** The user picks the blank glyph in their alphabet; the UI renders the literal symbol. CSS classes (`Tape.svelte#.cell.blank`, `ControlPanel.svelte#.cp-btn.blank`) provide visual hints (dim border / opacity) so blank cells remain recognisable regardless of which character was chosen — no character is reserved for "blank visualization", so no alphabet glyph collides with one.
+- **Upstream-bug workarounds carry an issue link.** When code shapes itself around a bug or quirk in `@turing-machine-js/machine` (or another upstream), add a `WORKAROUND for <repo>#<n> — when that lands, …` block describing what to revert once the upstream fix ships. Current entries:
+  - `MachineView.svelte#_buildMirrorMachine` — `viewportWidth` set via setter rather than constructor ([turing-machine-js#95](https://github.com/mellonis/turing-machine-js/issues/95)).
 - **Animation timings** are CSS variables in `app.css`: `--anim-belt-slide-ms`, `--anim-belt-enter-ms`, `--anim-belt-enter-delay-panel-ms`, `--anim-button-hover-ms`.
 - **Icons**: Tabler outline SVGs imported as raw strings (`?raw`) and rendered via `{@html}` — `eslint-plugin-svelte`'s `no-at-html-tags` is off because all sources are build-time, never user-controlled. The Web Worker is the security boundary for user code.
-- **`untrack(() => engine)`** at MachineTab/Editor init: engine is a prop but each MachineTab instance has a fixed engine (parent uses `{#key activeEngine}`); the untrack acknowledges the intentional one-time read and silences Svelte's reactive-prop warning.
+- **`untrack(() => engine)`** at MachineView/Editor init: engine is a prop but each MachineView instance has a fixed engine (parent uses `{#key activeEngine}`); the untrack acknowledges the intentional one-time read and silences Svelte's reactive-prop warning.
 - **`:global(...)`** in `Editor.svelte` styles is the official escape hatch for CodeMirror's third-party DOM (`.cm-editor`, `.cm-scroller`, etc.) — Svelte's CSS scoping would otherwise mangle the selectors.
+- **No static literal fallbacks in `var()`.** A `var()` fallback must itself be another CSS custom property (e.g. `var(--dot, var(--head))`) — never a hardcoded color, length, or time. Literals leak out of the design system and bypass theming. Two patterns satisfy this:
+  - **Globally-scoped tokens** (colors, surface vars, animation timings) — declared in `:root` in `app.css`. Optionally promoted to `@property` for type-checking and animatable customs (e.g. `@property --anim-button-hover-ms { syntax: '<time>'; inherits: true; initial-value: 120ms }`). When `@property`'s `initial-value` must mirror another token (it can't reference `var()`), document the coupling with a `/* follows --x — keep in sync when theming */` comment above the literal value.
+  - **Optional, per-element customs** (e.g. `--dot` in `ControlPanel.svelte`) — either fall back to another token at the read site (`var(--dot, var(--head))`) or declare a class-level default (`.tape-dot { --dot: var(--head); background: var(--dot) }`). Pick the class-level default when the same custom is read in multiple places, the inline fallback when it's a one-off.
 
 ## Editor
 
 - `svelte-codemirror-editor` (Svelte-5-native wrapper around CodeMirror 6) with `bind:value`.
-- Extensions: `javascript()` lang, `oneDark` theme, our `importsCompletion(engine)` (boost-99 machine identifiers + local-identifier completion source from `@codemirror/lang-javascript`), and a Lezer-based `syntaxLinter` for syntax-error markers before Load.
-- A small reset-to-default button overlays the editor's top-right corner (matches the log-clear pattern).
+- Extensions: `javascript()` lang, `oneDark` theme, our `importsCompletion(engine)` (boost-99 machine identifiers + local-identifier completion source from `@codemirror/lang-javascript`), and a Lezer-based `syntaxLinter` for syntax-error markers before Build.
+- A small reset-to-selected-example button overlays the editor's top-right corner; the log's clear button uses the same shared `IconButton.svelte` (corner-overlay variant) — both are absolutely positioned within their `position: relative` parent (`.editor` / `.log-panel`).
 
 ## Deploy
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ src/
 ├── app.ts                   # entry; mounts <App>
 ├── app.css                  # global tokens + base styles
 ├── components/
-│   ├── MachineTab.svelte    # per-engine orchestrator (one $state, derived disabled flags)
+│   ├── MachineView.svelte   # per-engine orchestrator (one $state, derived disabled flags)
 │   ├── Tape.svelte          # virtualized belt with prep-shift slide trick
 │   ├── ControlPanel.svelte  # L/S/R + alphabet chips + Apply
 │   ├── Editor.svelte        # CodeMirror wrapper + localStorage persist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "machines-demo",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "machines-demo",
-      "version": "1.0.0-alpha.1",
+      "version": "1.0.0-alpha.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machines-demo",
   "private": true,
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect x="1.5" y="1.5" width="29" height="29" rx="4" fill="#2a2c30" stroke="#ffd166" stroke-width="1"/>
-  <rect x="3" y="3" width="26" height="26" rx="3" fill="none" stroke="#ffd166" stroke-width="1"/>
+  <rect x="1.5" y="1.5" width="29" height="29" rx="4" fill="#2a2c30" stroke="#6ea8fe" stroke-width="1"/>
+  <rect x="3" y="3" width="26" height="26" rx="3" fill="none" stroke="#6ea8fe" stroke-width="1"/>
   <text x="16" y="22" text-anchor="middle" font-family="ui-monospace, 'SF Mono', Consolas, monospace" font-size="18" font-weight="500" fill="#e6e6e6">D</text>
-  <text x="16" y="30" text-anchor="middle" font-family="ui-monospace, 'SF Mono', Consolas, monospace" font-size="6" fill="#ffd166">▲</text>
+  <text x="16" y="30" text-anchor="middle" font-family="ui-monospace, 'SF Mono', Consolas, monospace" font-size="6" fill="#6ea8fe">▲</text>
 </svg>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import MachineTab from './components/MachineTab.svelte';
+  import MachineView from './components/MachineView.svelte';
   import { icons } from './lib/icons.ts';
   import { ENGINES, type Engine } from './lib/types.ts';
 
@@ -69,7 +69,7 @@
 
 <main>
   {#key activeEngine}
-    <MachineTab engine={activeEngine} />
+    <MachineView engine={activeEngine} />
   {/key}
 </main>
 
@@ -80,35 +80,47 @@
     gap: 24px;
     padding: 12px 24px;
     border-bottom: 1px solid var(--cell-border);
-  }
 
-  header h1 {
-    font-size: 16px;
-    margin: 0;
-    font-weight: 500;
-    letter-spacing: 0.04em;
-    color: var(--head-dim);
+    h1 {
+      font-size: 16px;
+      margin: 0;
+      font-weight: 500;
+      letter-spacing: 0.04em;
+      color: var(--accent);
+
+      .title-prefix {
+        @media (max-width: 768px) {
+          display: none;
+        }
+      }
+    }
+
+    @media (max-width: 768px) {
+      flex-wrap: wrap;
+      gap: 12px;
+      padding: 10px 14px;
+    }
   }
 
   .tabs {
     display: flex;
     gap: 4px;
-  }
 
-  .tabs button {
-    background: transparent;
-    border: 1px solid transparent;
-    color: var(--muted);
-    padding: 4px 14px;
-    font: inherit;
-    cursor: pointer;
-    border-radius: 6px;
-  }
+    button {
+      background: transparent;
+      border: 1px solid transparent;
+      color: var(--muted);
+      padding: 4px 14px;
+      font: inherit;
+      cursor: pointer;
+      border-radius: 6px;
 
-  .tabs button.active {
-    color: var(--fg);
-    background: var(--cell-bg);
-    border-color: var(--cell-border);
+      &.active {
+        color: var(--fg);
+        background: var(--cell-bg);
+        border-color: var(--cell-border);
+      }
+    }
   }
 
   .repo-link {
@@ -122,37 +134,25 @@
     color: var(--muted);
     text-decoration: none;
     transition: background-color var(--anim-button-hover-ms) ease, color var(--anim-button-hover-ms) ease;
-  }
 
-  .repo-link:hover {
-    background: rgba(255, 255, 255, 0.06);
-    color: var(--fg);
-  }
+    &:hover {
+      background: rgba(255, 255, 255, 0.06);
+      color: var(--fg);
+    }
 
-  .repo-link :global(svg) {
-    width: 18px;
-    height: 18px;
-    display: block;
+    :global(svg) {
+      width: 18px;
+      height: 18px;
+      display: block;
+    }
   }
 
   main {
     flex: 1;
     overflow: hidden;
     display: flex;
-  }
 
-  @media (max-width: 768px) {
-    header {
-      flex-wrap: wrap;
-      gap: 12px;
-      padding: 10px 14px;
-    }
-
-    header h1 .title-prefix {
-      display: none;
-    }
-
-    main {
+    @media (max-width: 768px) {
       overflow: auto;
     }
   }

--- a/src/app.css
+++ b/src/app.css
@@ -9,7 +9,6 @@
   --cell-bg: #2a2c30;
   --cell-border: #3a3d42;
   --head: #ffd166;
-  --head-dim: #cca84d;
   --error: #ff6b6b;
   --warn: #f0b400;
   --ok: #5fd068;

--- a/src/components/ControlPanel.svelte
+++ b/src/components/ControlPanel.svelte
@@ -1,23 +1,21 @@
 <script lang="ts">
   import { icons } from '../lib/icons.ts';
-  import type { Command, Movement } from '../lib/types.ts';
+  import type { Alphabets, Command, Movement } from '../lib/types.ts';
 
   type Props = {
-    alphabets: readonly (readonly string[])[];
+    alphabets: Alphabets;
     enabled: boolean;
-    visible: boolean;
     applyVisible: boolean;
     /** Show colored dot + "Tape N" label per row. Hidden for inherently
      * single-tape engines (Post) where the label is redundant. */
     showTapeLabels?: boolean;
     caretColors?: readonly string[];
-    onApply: (cmds: Command[]) => void;
+    onApply: (commands: Command[]) => void;
   };
 
   let {
     alphabets,
     enabled,
-    visible,
     applyVisible,
     showTapeLabels = true,
     caretColors,
@@ -25,7 +23,7 @@
   }: Props = $props();
 
   // Per-tape selection. Lengths follow `alphabets.length`. The $effect below
-  // resyncs whenever the tape count changes (new Load with different N).
+  // resyncs whenever the tape count changes (new Build with different N).
   let movements = $state<Movement[]>([]);
   let symbols = $state<(string | null)[]>([]);
 
@@ -37,45 +35,47 @@
     }
   });
 
+  // How long the Apply button stays in the `.pressed` (flash) state after a
+  // demo-driven apply. Long enough to read as a press, short enough to fall
+  // well within DEMO_REFLECT_DELAY_MS (700) so each tick's flash resolves
+  // before the next reflect.
+  const APPLY_FLASH_MS = 240;
+
   let flashing = $state(false);
-  let flashTimer: ReturnType<typeof setTimeout> | null = null;
+  let flashTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
   export function flashApply(): void {
     flashing = true;
-    if (flashTimer !== null) clearTimeout(flashTimer);
-    flashTimer = setTimeout(() => {
+    if (flashTimeoutId !== null) clearTimeout(flashTimeoutId);
+    flashTimeoutId = setTimeout(() => {
       flashing = false;
-      flashTimer = null;
-    }, 240);
+      flashTimeoutId = null;
+    }, APPLY_FLASH_MS);
   }
 
-  export function reflect(cmds: Command[]): void {
-    if (cmds.length !== alphabets.length) return;
-    movements = cmds.map((c) => c.movement);
-    symbols = cmds.map((c) => c.symbol);
+  export function reflect(commands: Command[]): void {
+    if (commands.length !== alphabets.length) return;
+    movements = commands.map((c) => c.movement);
+    symbols = commands.map((c) => c.symbol);
   }
 
   function selectMovement(i: number, m: Movement): void {
     if (!enabled) return;
-    const next = [...movements];
-    next[i] = m;
-    movements = next;
+    movements = movements.with(i, m);
   }
 
   function selectSymbol(i: number, s: string | null): void {
     if (!enabled) return;
-    const next = [...symbols];
-    next[i] = s;
-    symbols = next;
+    symbols = symbols.with(i, s);
   }
 
   function fireApply(): void {
     if (!enabled) return;
-    const cmds: Command[] = movements.map((mv, i) => ({
-      movement: mv,
+    const commands: Command[] = movements.map((movement, i) => ({
+      movement,
       symbol: symbols[i] ?? null,
     }));
-    onApply(cmds);
+    onApply(commands);
   }
 
   const MOVEMENT_BUTTONS: Array<{ code: Movement; svg: string; label: string }> = [
@@ -87,7 +87,6 @@
 
 <div
   class="control-panel"
-  class:hidden={!visible}
   class:disabled={!enabled}
   class:no-apply={!applyVisible}
 >
@@ -115,10 +114,15 @@
           >
             {@html icons.keep}
           </button>
+          <!-- `sym` not `symbol` — the latter shadows the built-in TS/JS
+               `symbol` type the upstream library uses for movement primitives.
+               No UI substitution: the button shows the literal alphabet
+               symbol, including whatever the user picked for blank. -->
           {#each alpha as sym, j (j)}
             <button
               type="button"
               class="cp-btn"
+              class:blank={j === 0}
               class:selected={symbols[i] === sym}
               title={j === 0 ? 'Write blank' : `Write ${sym}`}
               aria-label={showTapeLabels
@@ -126,7 +130,7 @@
                 : j === 0 ? 'Write blank' : `Write ${sym}`}
               onclick={() => selectSymbol(i, sym)}
             >
-              {j === 0 ? '␣' : sym}
+              {sym}
             </button>
           {/each}
         </div>
@@ -173,9 +177,16 @@
     border-radius: var(--surface-radius);
     background: var(--surface-bg);
     animation: enter var(--anim-belt-enter-ms) ease-out var(--anim-belt-enter-delay-panel-ms) backwards;
-  }
 
-  .control-panel.hidden { display: none; }
+    &.disabled .interactive {
+      opacity: 0.5;
+      pointer-events: none;
+    }
+
+    &.no-apply .apply-row {
+      display: none;
+    }
+  }
 
   .interactive {
     display: flex;
@@ -184,56 +195,72 @@
     transition: opacity 150ms ease;
   }
 
-  .control-panel.disabled .interactive {
-    opacity: 0.5;
-    pointer-events: none;
-  }
-
-  .control-panel.no-apply .apply-row {
-    display: none;
-  }
-
   .tape-row {
     display: flex;
     align-items: center;
     gap: 8px;
     flex-wrap: wrap;
     padding: 4px 0;
-  }
 
-  .tape-row + .tape-row {
-    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    & + & {
+      border-top: 1px solid rgba(255, 255, 255, 0.05);
+    }
   }
 
   .tape-dot {
+    /* Class-level default keeps `var(--dot)` resolvable without a fallback;
+       the inline `style="--dot: …"` from caretColors[i] overrides it when
+       a per-tape color is provided. */
+    --dot: var(--head);
     width: 10px;
     height: 10px;
     border-radius: 50%;
     flex-shrink: 0;
-    background: var(--dot, var(--head));
+    background: var(--dot);
   }
 
   .tape-label {
     font-size: 12px;
     color: var(--muted);
     min-width: 50px;
+
+    @media (max-width: 768px) {
+      min-width: 40px;
+    }
   }
 
   .row {
     display: flex;
     gap: 4px;
     flex-wrap: wrap;
-  }
 
-  .row.symbols {
-    flex: 1;
-    min-width: 0;
-  }
+    &.symbols {
+      flex: 1;
+      min-width: 0;
 
-  .row.movement {
-    margin-left: auto;
-    padding-left: 8px;
-    border-left: 1px solid rgba(255, 255, 255, 0.05);
+      /* Long alphabets shouldn't wrap a second row on a narrow phone — let
+         the symbols row scroll horizontally. */
+      @media (max-width: 768px) {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        scrollbar-width: none;
+        -webkit-overflow-scrolling: touch;
+
+        &::-webkit-scrollbar {
+          display: none;
+        }
+
+        .cp-btn {
+          flex-shrink: 0;
+        }
+      }
+    }
+
+    &.movement {
+      margin-left: auto;
+      padding-left: 8px;
+      border-left: 1px solid rgba(255, 255, 255, 0.05);
+    }
   }
 
   .apply-row {
@@ -262,31 +289,53 @@
       background-color var(--anim-button-hover-ms) ease,
       border-color var(--anim-button-hover-ms) ease,
       color var(--anim-button-hover-ms) ease;
-  }
 
-  .cp-btn:hover {
-    border-color: rgba(110, 168, 254, 0.5);
-    color: var(--accent);
-  }
+    &:hover {
+      border-color: rgba(110, 168, 254, 0.5);
+      color: var(--accent);
+    }
 
-  .cp-btn.selected {
-    background: rgba(110, 168, 254, 0.2);
-    border-color: var(--accent);
-    color: var(--accent);
-  }
+    /* Blank-symbol chip — matches Tape.svelte's `.cell.blank`: dim border +
+       dim glyph so the chip is recognisably "blank" regardless of which
+       character the user chose. Min-width keeps the chip a clickable size
+       even when the blank symbol is an invisible space. */
+    &.blank {
+      min-width: 30px;
+      border-color: color-mix(in srgb, rgba(255, 255, 255, 0.06) 40%, var(--cell-bg));
+      color: color-mix(in srgb, var(--fg) 40%, var(--cell-bg));
+    }
 
-  .cp-btn.pressed {
-    background: rgba(110, 168, 254, 0.4);
-    border-color: var(--accent);
-    color: var(--accent);
-    transform: scale(0.96);
-    transition: background-color 80ms ease, transform 80ms ease;
-  }
+    &.selected {
+      background: rgba(110, 168, 254, 0.2);
+      border-color: var(--accent);
+      color: var(--accent);
+    }
 
-  .cp-btn :global(svg) {
-    width: 16px;
-    height: 16px;
-    display: block;
+    &.pressed {
+      background: rgba(110, 168, 254, 0.4);
+      border-color: var(--accent);
+      color: var(--accent);
+      transform: scale(0.96);
+      transition: background-color 80ms ease, transform 80ms ease;
+    }
+
+    :global(svg) {
+      width: 16px;
+      height: 16px;
+      display: block;
+    }
+
+    @media (max-width: 768px) {
+      min-width: 28px;
+      height: 26px;
+      padding: 2px 6px;
+      font-size: 12px;
+
+      :global(svg) {
+        width: 14px;
+        height: 14px;
+      }
+    }
   }
 
   .apply {
@@ -296,40 +345,5 @@
   @keyframes enter {
     from { opacity: 0; transform: translateY(20px); }
     to   { opacity: 1; transform: translateY(0); }
-  }
-
-  @media (max-width: 768px) {
-    .tape-label {
-      min-width: 40px;
-    }
-
-    .cp-btn {
-      min-width: 28px;
-      height: 26px;
-      padding: 2px 6px;
-      font-size: 12px;
-    }
-
-    .cp-btn :global(svg) {
-      width: 14px;
-      height: 14px;
-    }
-
-    /* Long alphabets shouldn't wrap a second row in a narrow phone — let the
-       symbols row scroll horizontally. */
-    .row.symbols {
-      flex-wrap: nowrap;
-      overflow-x: auto;
-      scrollbar-width: none;
-      -webkit-overflow-scrolling: touch;
-    }
-
-    .row.symbols::-webkit-scrollbar {
-      display: none;
-    }
-
-    .row.symbols .cp-btn {
-      flex-shrink: 0;
-    }
   }
 </style>

--- a/src/components/Editor.svelte
+++ b/src/components/Editor.svelte
@@ -5,16 +5,16 @@
   import { importsCompletion } from '../lib/completions.ts';
   import { syntaxLinter } from '../lib/syntaxLinter.ts';
   import { saveCode } from '../lib/persist.ts';
-  import { icons } from '../lib/icons.ts';
+  import IconButton from './IconButton.svelte';
   import type { Engine } from '../lib/types.ts';
 
   type Props = {
     engine: Engine;
     code: string;
-    onreset: () => void;
+    onReset: () => void;
   };
 
-  let { engine, code = $bindable(), onreset }: Props = $props();
+  let { engine, code = $bindable(), onReset }: Props = $props();
 
   // Persist code to localStorage on every change. saveCode swallows quota /
   // private-mode errors internally.
@@ -27,15 +27,7 @@
 </script>
 
 <div class="editor">
-  <button
-    type="button"
-    class="reset"
-    onclick={onreset}
-    title="Reset code to selected example"
-    aria-label="Reset code to selected example"
-  >
-    {@html icons.resetCode}
-  </button>
+  <IconButton icon="resetCode" title="Reset code to selected example" onClick={onReset} />
   <CodeMirror
     bind:value={code}
     {lang}
@@ -52,48 +44,19 @@
     border: 1px solid var(--cell-border);
     border-radius: 6px;
     overflow: hidden;
-  }
 
-  .reset {
-    position: absolute;
-    top: 6px;
-    right: 6px;
-    z-index: 10;
-    width: 22px;
-    height: 22px;
-    padding: 0;
-    background: transparent;
-    border: none;
-    border-radius: 4px;
-    color: var(--muted);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+    :global(.cm-editor) {
+      height: 100%;
+      font-size: 13px;
+    }
 
-  .reset:hover {
-    background: rgba(255, 255, 255, 0.06);
-    color: var(--fg);
-  }
+    :global(.cm-editor.cm-focused) {
+      outline: none;
+    }
 
-  .reset :global(svg) {
-    width: 14px;
-    height: 14px;
-    display: block;
-  }
-
-  .editor :global(.cm-editor) {
-    height: 100%;
-    font-size: 13px;
-  }
-
-  .editor :global(.cm-editor.cm-focused) {
-    outline: none;
-  }
-
-  .editor :global(.cm-scroller) {
-    font-family: ui-monospace, 'SF Mono', Consolas, monospace;
-    line-height: 1.5;
+    :global(.cm-scroller) {
+      font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+      line-height: 1.5;
+    }
   }
 </style>

--- a/src/components/IconButton.svelte
+++ b/src/components/IconButton.svelte
@@ -3,31 +3,54 @@
 
   type Props = {
     icon: IconName;
-    label?: string;
     title?: string;
-    disabled?: boolean;
-    class?: string;
-    onclick?: (e: MouseEvent) => void;
+    onClick?: (e: MouseEvent) => void;
   };
 
-  let {
-    icon,
-    label,
-    title,
-    disabled = false,
-    class: cls = '',
-    onclick,
-  }: Props = $props();
+  let { icon, title, onClick }: Props = $props();
 </script>
 
 <button
   type="button"
-  class={cls}
-  {disabled}
-  {onclick}
+  class="overlay"
+  onclick={onClick}
   {title}
-  aria-label={title ?? label}
+  aria-label={title}
 >
   {@html icons[icon]}
-  {#if label}<span class="btn-label">{label}</span>{/if}
 </button>
+
+<style>
+  /* Corner-overlay icon button — sits at top-right of a position:relative
+     parent (editor box, log panel) as a tertiary action like reset / clear.
+     z-index lifts it above content that paints later in the DOM (CodeMirror
+     chrome, log entries). */
+  .overlay {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    z-index: 10;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    color: var(--muted);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.06);
+      color: var(--fg);
+    }
+
+    :global(svg) {
+      width: 14px;
+      height: 14px;
+      display: block;
+    }
+  }
+</style>

--- a/src/components/Log.svelte
+++ b/src/components/Log.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import { icons } from '../lib/icons.ts';
+  import IconButton from './IconButton.svelte';
   import type { LogEntry } from '../lib/log.ts';
 
   type Props = {
     entries: LogEntry[];
-    onclear: () => void;
+    onClear: () => void;
   };
 
-  let { entries, onclear }: Props = $props();
+  let { entries, onClear }: Props = $props();
 
   let scrollEl: HTMLDivElement | undefined;
 
@@ -19,50 +19,52 @@
 </script>
 
 <div class="log-panel">
-  <button
-    type="button"
-    class="clear"
-    onclick={onclear}
-    title="Clear log"
-    aria-label="Clear log"
-  >
-    {@html icons.eraser}
-  </button>
+  <IconButton icon="eraser" title="Clear log" onClick={onClear} />
   <div class="content" bind:this={scrollEl}>
     {#each entries as entry, i (i)}
-      <div class="line" class:error={entry.kind === 'error'} class:warn={entry.kind === 'warn'} class:ok={entry.kind === 'ok'}>
-        <div
-          class="head"
-          style={entry.color && !entry.kind ? `color: ${entry.color};` : undefined}
-        >{entry.text}</div>
-        {#if entry.rows && entry.rows.length > 0}
-          {#each entry.rows as row, j (j)}
-            <div class="row" style={row.color ? `color: ${row.color};` : undefined}>
-              {row.text}
-            </div>
-          {/each}
-        {/if}
-      </div>
+      {#if entry.separator}
+        <hr class="sep" />
+      {:else}
+        <div class="line" class:error={entry.kind === 'error'} class:warn={entry.kind === 'warn'} class:ok={entry.kind === 'ok'}>
+          <div
+            class="head"
+            style={entry.color && !entry.kind ? `color: ${entry.color};` : undefined}
+          >{entry.text}</div>
+          {#if entry.rows && entry.rows.length > 0}
+            {#each entry.rows as row, j (j)}
+              <div class="row" style={row.color ? `color: ${row.color};` : undefined}>
+                {row.text}
+              </div>
+            {/each}
+          {/if}
+        </div>
+      {/if}
     {/each}
   </div>
 </div>
 
 <style>
   /* Desktop only — on mobile the panel is hidden and the latest entry is
-     mirrored as a single-line status in MachineTab.svelte. */
+     mirrored as a single-line status in MachineView.svelte. */
 
   .log-panel {
     position: relative;
     flex: 1;
     min-height: 80px;
+    display: flex;
+    flex-direction: column;
     background: var(--editor-bg);
     border: 1px solid var(--cell-border);
     border-radius: var(--surface-radius);
+
+    @media (max-width: 768px) {
+      display: none;
+    }
   }
 
   .content {
-    position: absolute;
-    inset: 0;
+    flex: 1;
+    min-height: 0;
     overflow-y: auto;
     padding: 8px 10px;
     font-family: ui-monospace, 'SF Mono', Consolas, monospace;
@@ -70,37 +72,33 @@
     color: var(--muted);
   }
 
-  .clear {
-    position: absolute;
-    top: 6px;
-    right: 6px;
-    z-index: 1;
-    width: 22px;
-    height: 22px;
-    padding: 0;
-    background: transparent;
-    border: none;
-    border-radius: 4px;
-    color: var(--muted);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .clear:hover {
-    background: rgba(255, 255, 255, 0.06);
-    color: var(--fg);
-  }
-
-  .clear :global(svg) {
-    width: 14px;
-    height: 14px;
-    display: block;
-  }
-
+  /* Kind-marked entries get a left stripe in addition to header tinting so
+     they remain distinguishable even when the tape palette (red/green/…)
+     overlaps the kind colors (error/ok/…). The stripe is a structural cue
+     that doesn't rely on color uniqueness. */
   .line {
     padding: 1px 0;
+
+    &.error,
+    &.warn,
+    &.ok {
+      padding-left: 8px;
+      border-left: 3px solid transparent;
+    }
+
+    &.error { border-left-color: var(--error); }
+    &.warn  { border-left-color: var(--warn); }
+    &.ok    { border-left-color: var(--ok); }
+
+    &.error .head { color: var(--error); }
+    &.warn  .head { color: var(--warn); }
+    &.ok    .head { color: var(--ok); }
+  }
+
+  .sep {
+    border: none;
+    border-top: 1px solid var(--cell-border);
+    margin: 6px 0;
   }
 
   .head {
@@ -112,30 +110,5 @@
     white-space: pre-wrap;
     word-break: break-word;
     padding-left: 2px;
-  }
-
-  /* Kind-marked entries get a left stripe in addition to header tinting so
-     they remain distinguishable even when the tape palette (red/green/…)
-     overlaps the kind colors (error/ok/…). The stripe is a structural cue
-     that doesn't rely on color uniqueness. */
-  .line.error,
-  .line.warn,
-  .line.ok {
-    padding-left: 8px;
-    border-left: 3px solid transparent;
-  }
-
-  .line.error { border-left-color: var(--error); }
-  .line.warn  { border-left-color: var(--warn); }
-  .line.ok    { border-left-color: var(--ok); }
-
-  .line.error .head { color: var(--error); }
-  .line.warn  .head { color: var(--warn); }
-  .line.ok    .head { color: var(--ok); }
-
-  @media (max-width: 768px) {
-    .log-panel {
-      display: none;
-    }
   }
 </style>

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -1,19 +1,17 @@
 <script lang="ts">
   import { onDestroy, onMount, tick, untrack } from 'svelte';
-  import Tape from './Tape.svelte';
+  import TapesStack from './TapesStack.svelte';
+  import Toolbar from './Toolbar.svelte';
   import ControlPanel from './ControlPanel.svelte';
   import Log from './Log.svelte';
   import type { LogEntry, LogKind } from '../lib/log.ts';
-  import { MachineRunner } from '../lib/runner.ts';
-  import { type Command, type Engine, type TapeSnapshot } from '../lib/types.ts';
+  import { MachineRunner, WorkerError } from '../lib/machineRunner.ts';
+  import * as turing from '@turing-machine-js/machine';
+  import { VIEWPORT_WIDTH } from '../lib/caps.ts';
+  import { type Alphabets, type Command, type Engine, type TapeSnapshot } from '../lib/types.ts';
   import { startDemoLoop } from '../lib/demoLoop.ts';
   import { startAutoStep, parseInterval } from '../lib/autoStep.ts';
-  import {
-    alphabetsEntry,
-    appliedEntry,
-    stepEntry,
-    tapesEntry,
-  } from '../lib/format.ts';
+  import { commandsEntry, tapesEntry } from '../lib/format.ts';
   import {
     defaultExample,
     examples,
@@ -29,13 +27,11 @@
 
   /* ───── constants ───── */
 
-  const SYNTHETIC_ALPHABETS: readonly (readonly string[])[] = [
-    [' ', 'a', 'b', '*'],
-  ];
   const NEUTRAL_COMMAND: Command = { movement: 'S', symbol: null };
 
-  // Per-tape caret colors for multi-tape stacks. Length must match MAX_TAPES
-  // (worker rejects loads with more tapes than the palette can color).
+  const DEMO_BANK_SIZE = 50;
+
+  // Length must match MAX_TAPES — worker rejects loads with more tapes.
   const CARET_COLORS: readonly string[] = [
     '#6ea8fe', // blue
     '#ff6b6b', // red
@@ -59,15 +55,20 @@
   let userTookControl = $state(false);
   let demoEnabled = $state(true);
   let halted = $state(false);
-  let alphabets = $state<readonly (readonly string[])[]>(SYNTHETIC_ALPHABETS);
-  let entries = $state<LogEntry[]>([]);
+  let alphabets = $state<Alphabets>([]);
+  let logEntries = $state<LogEntry[]>([]);
   let lastSnapshots = $state<TapeSnapshot[] | null>(null);
   let pendingOp = $state<'load' | 'run' | null>(null);
   let stepInFlight = $state(false);
+  let demoBank = $state<Command[][] | null>(null);
+  let demoLoadSeq = 0;
+  let mirrorMachine: turing.TuringMachine | null = null;
+  let mirrorTapeBlock: turing.TapeBlock | null = null;
+  let codeChangedWarned = false;
   let withPause = $state(false);
   let intervalText = $state('1s');
   let workerLive = $state(false);
-  // engine is fixed for a MachineTab instance (parent remounts on engine change
+  // engine is fixed for a MachineView instance (parent remounts on engine change
   // via {#key activeEngine}). untrack() acknowledges we want a one-time read.
   const engineExamples = untrack(() => examples(engine));
   const initialExample = untrack(() => {
@@ -78,14 +79,12 @@
   let code = $state<string>(
     untrack(() => loadCode(engine) ?? initialExample.code),
   );
-  let examplesOpen = $state(false);
-  let examplesMenuEl: HTMLDivElement | undefined;
 
   const selectedExample = $derived(
     findExample(engine, selectedExampleId) ?? defaultExample(engine),
   );
 
-  let tapeRefs = $state<Array<ReturnType<typeof Tape> | undefined>>([]);
+  let tapesStackRef = $state<ReturnType<typeof TapesStack> | undefined>();
   let panelRef = $state<ReturnType<typeof ControlPanel> | undefined>();
 
   // Editor pulls in all of CodeMirror (~500 KB unzipped). Lazy-load it so the
@@ -103,26 +102,18 @@
 
   const intervalMs = $derived(parseInterval(intervalText));
   const intervalIsValid = $derived(intervalMs !== null);
-  const latestEntry = $derived(entries.length > 0 ? entries[entries.length - 1] : null);
+  // Skip separators — mobile status mirrors a meaningful message, not a divider.
+  const latestEntry = $derived.by(() => {
+    for (let i = logEntries.length - 1; i >= 0; i--) {
+      if (!logEntries[i].separator) return logEntries[i];
+    }
+    return null;
+  });
 
   // ControlPanel handles both single- and multi-tape via Command[]; tape
   // labels are only useful to disambiguate, so show them only when N > 1.
   const tapeCount = $derived(lastSnapshots?.length ?? 1);
   const showTapeLabels = $derived(tapeCount > 1);
-  // Hard-stop gradient: each tape row is solid color[i]; transitions happen
-  // only in the inter-tape gap. Stops are pixel offsets built from the
-  // .tapes-stack CSS vars (--cell-h, --tape-gap) so they track breakpoints.
-  const headThreadBackground = $derived.by(() => {
-    const colors = CARET_COLORS.slice(0, tapeCount);
-    if (colors.length === 1) return colors[0];
-    const stops: string[] = [];
-    for (let i = 0; i < colors.length; i++) {
-      const top = `calc(${i} * (var(--cell-h) + var(--tape-gap)))`;
-      const bot = `calc(${i} * (var(--cell-h) + var(--tape-gap)) + var(--cell-h))`;
-      stops.push(`${colors[i]} ${top}`, `${colors[i]} ${bot}`);
-    }
-    return `linear-gradient(to bottom, ${stops.join(', ')})`;
-  });
   const panelEnabled = $derived(executionMode === 'MANUAL');
   const applyVisible = $derived(
     executionMode === 'DEMO' || executionMode === 'MANUAL',
@@ -133,9 +124,10 @@
   const beltTransitionsOn = $derived(executionMode !== 'RUNNING_CONTINUOUS');
 
   const loadDisabled = $derived(pendingOp !== null);
+  // Step/Run stay enabled in HALTED — they reload-from-code on entry, which
+  // also clears `halted`. Disabling would just force an extra Build click.
   const stepDisabled = $derived(
     pendingOp !== null ||
-      halted ||
       !workerLive ||
       executionMode === 'RUNNING_CONTINUOUS',
   );
@@ -144,13 +136,11 @@
   // Soft-debounced inside doStep() instead.
   const runDisabled = $derived(
     pendingOp !== null ||
-      halted ||
       !workerLive ||
       executionMode === 'RUNNING_AUTO' ||
       executionMode === 'RUNNING_CONTINUOUS' ||
       (withPause && !intervalIsValid),
   );
-
   /* ───── log helpers ───── */
 
   function report(textOrEntry: string | LogEntry, kind?: LogKind): void {
@@ -160,22 +150,37 @@
         : kind
           ? { ...textOrEntry, kind }
           : textOrEntry;
-    entries = [...entries, entry];
+    logEntries = [...logEntries, entry];
   }
 
   function appendBatch(items: LogEntry[]): void {
     if (items.length === 0) return;
-    entries = [...entries, ...items];
+    logEntries = [...logEntries, ...items];
+  }
+
+  // Visually divides log activity per session (Build / Step / Run). Skipped
+  // when the log is empty so we don't open with a stranded divider.
+  function reportSeparator(): void {
+    if (logEntries.length === 0) return;
+    logEntries = [...logEntries, { text: '', separator: true }];
   }
 
   function clearLog(): void {
-    entries = [];
+    logEntries = [];
   }
 
   /* ───── side-effect handlers (one source of truth on error) ───── */
 
   function failHalted(err: unknown): void {
     const msg = err instanceof Error ? err.message : String(err);
+    // Worker errored mid-step / mid-run. If it shipped a partial tape state,
+    // sync the mirror + display to it so the user sees where execution stuck
+    // (otherwise we'd strand them on the loaded tape).
+    if (err instanceof WorkerError && err.tapes && err.tapes.length > 0) {
+      lastSnapshots = err.tapes;
+      _buildMirrorMachine(err.tapes, alphabets);
+      setAllFromMirror();
+    }
     report(`error: ${msg}`, 'error');
     halted = true;
     executionMode = 'HALTED';
@@ -183,19 +188,112 @@
 
   /* ───── load / step / run ───── */
 
-  function applyToAll(commands: Command[], opts: { animate: boolean }): void {
-    commands.forEach((cmd, i) => {
-      void tapeRefs[i]?.apply(cmd, opts);
+  function _buildMirrorMachine(tapes: TapeSnapshot[], alphabets: Alphabets): void {
+    const libAlphabets = alphabets.map((syms) => new turing.Alphabet([...syms]));
+    // Mirror exactly what the worker had — full `symbols` and absolute head
+    // `position` — so the user can navigate beyond the initial window
+    // without blanks where original symbols should be. `viewportWidth` is
+    // ours to pick (the mirror is internal, no user code observes it); set
+    // it via the setter (NOT the constructor) so the library's `normalise()`
+    // pads `#symbols` to satisfy the viewport — the constructor stores
+    // `viewportWidth` without normalising, so a user tape of e.g. 4 cells
+    // would leave `.viewport` returning only 4 cells.
+    //
+    // WORKAROUND for mellonis/turing-machine-js#95 — when that lands, the
+    // `viewportWidth` field can move into the `new turing.Tape({...})` call
+    // and the post-construction setter assignment can be deleted.
+    const libTapes = tapes.map((snap, i) => {
+      const tape = new turing.Tape({
+        alphabet: libAlphabets[i],
+        symbols: [...snap.symbols],
+        position: snap.position,
+      });
+      tape.viewportWidth = VIEWPORT_WIDTH;
+      return tape;
+    });
+    mirrorTapeBlock = turing.TapeBlock.fromTapes(libTapes);
+    mirrorMachine = new turing.TuringMachine({ tapeBlock: mirrorTapeBlock });
+  }
+
+  function _runMirrorStep(commands: Command[]): void {
+    if (!mirrorMachine || !mirrorTapeBlock) return;
+    const oneStep = new turing.State({
+      [turing.ifOtherSymbol]: {
+        command: commands.map((command) => ({
+          symbol: command.symbol !== null ? command.symbol : turing.symbolCommands.keep,
+          movement:
+            command.movement === 'L' ? turing.movements.left
+            : command.movement === 'R' ? turing.movements.right
+            : turing.movements.stay,
+        })),
+        nextState: turing.haltState,
+      },
+    });
+    mirrorMachine.run({ initialState: oneStep });
+  }
+
+  // Push the current mirror tapes into the visible <Tape> instances. Used
+  // after `_buildMirrorMachine` (Build / Run-end / error-recovery) to seed
+  // the UI; does not animate.
+  function setAllFromMirror(): void {
+    if (!mirrorTapeBlock) return;
+    mirrorTapeBlock.tapes.forEach((tape, i) => {
+      tapesStackRef?.setFromTape(i, tape);
     });
   }
 
-  function setAllFromSnapshots(snaps: TapeSnapshot[]): void {
-    snaps.forEach((s, i) => tapeRefs[i]?.setFromSnapshot(s));
+  // Per-step render path — used in DEMO, MANUAL Apply, and RUNNING_*
+  // (except RUNNING_CONTINUOUS, which rebuilds in one shot). Advances the
+  // mirror with `commands`, then has each <Tape> read its updated mirror
+  // tape's `.viewport` and play the slide animation if requested.
+  function renderFromMirror(commands: Command[], animate: boolean): void {
+    if (!mirrorTapeBlock) return;
+    _runMirrorStep(commands);
+    mirrorTapeBlock.tapes.forEach((tape, i) => {
+      const command = commands[i];
+      const delta = (command?.movement === 'L' ? -1 : command?.movement === 'R' ? 1 : 0) as -1 | 0 | 1;
+      tapesStackRef?.setFromTape(i, tape, delta, animate);
+    });
   }
 
-  function reflectToActivePanel(cmds: Command[] | null): void {
-    if (!cmds || cmds.length === 0) return;
-    panelRef?.reflect(cmds);
+  // Reloads the worker + rebuilds mirrorMachine. `source` defaults to the
+  // current editor `code`; `doLoad` passes `selectedExample.code` instead for
+  // non-user-initiated DEMO loads. Does NOT change executionMode or demoBank
+  // — callers own those.
+  async function reloadWorker(source: string = code): Promise<boolean> {
+    pendingOp = 'load';
+    try {
+      const res = await runner.build(source);
+      workerLive = true;
+      alphabets = res.alphabets;
+      lastSnapshots = res.tapes;
+      halted = res.halted;
+      _buildMirrorMachine(res.tapes, res.alphabets);
+      await tick();
+      setAllFromMirror();
+      return true;
+    } catch (err) {
+      workerLive = false;
+      alphabets = [];
+      tapesStackRef?.clearAll();
+      lastSnapshots = null;
+      halted = true;
+      const msg = err instanceof Error ? err.message : String(err);
+      report(`error: ${msg}`, 'error');
+      return false;
+    } finally {
+      pendingOp = null;
+    }
+  }
+
+  function stopMachine(): void {
+    executionMode = 'HALTED';
+    report('stopped', 'warn');
+  }
+
+  function reflectToActivePanel(commands: Command[] | null): void {
+    if (!commands || commands.length === 0) return;
+    panelRef?.reflect(commands);
   }
 
   function reflectNeutral(): void {
@@ -204,39 +302,49 @@
   }
 
   async function doLoad({ userInitiated = false } = {}): Promise<void> {
+    const seq = ++demoLoadSeq;
     if (userInitiated) demoEnabled = false;
-    report('loading…');
-    pendingOp = 'load';
+    demoBank = null;
+    reportSeparator();
+    report(userInitiated ? 'loading…' : 'demo machine is loading…');
+
+    // For DEMO (initial / non-user load), always run the canonical example —
+    // user's persisted edits in the editor may be incomplete or broken; the
+    // demo should always show a working machine. Build button uses live code.
+    const source = userInitiated ? code : selectedExample.code;
+    const ok = await reloadWorker(source);
+
+    executionMode = userTookControl ? 'MANUAL' : 'DEMO';
+
+    if (!ok) return;
+
+    // Tape refs are bound by {#each tapes}: wait one tick for new
+    // <Tape> instances to mount before reflecting panel state.
+    appendBatch(tapesEntry(lastSnapshots!, alphabets, CARET_COLORS));
+    report(halted ? 'loaded — halted immediately' : 'loaded — ready', 'ok');
+    await tick();
+    if (userTookControl) reflectNeutral();
+
+    // Build demo bank using a separate worker — main runner is never touched,
+    // so Take Control → Apply works at any point without racing this.
+    if (!userTookControl && !halted && demoEnabled && workerLive) {
+      void buildDemoBank(seq, source);
+    }
+  }
+
+  async function buildDemoBank(seq: number, source: string): Promise<void> {
+    const tempRunner = new MachineRunner(engine);
     try {
-      const res = await runner.load(code);
-      workerLive = true;
-      alphabets = res.alphabets;
-      lastSnapshots = res.tapes;
-      // Tape refs are bound by {#each tapes}: wait one tick for the new
-      // <Tape> instances to mount before pushing snapshots into them.
-      await tick();
-      setAllFromSnapshots(res.tapes);
-      halted = res.halted;
-      appendBatch([
-        alphabetsEntry(res.alphabets, CARET_COLORS),
-        tapesEntry(res.tapes, CARET_COLORS),
-      ]);
-      report(res.halted ? 'loaded — halted immediately' : 'loaded — ready', 'ok');
-      executionMode = userTookControl ? 'MANUAL' : 'DEMO';
-      // Wait one tick so the right panel has mounted/swapped before reflect.
-      await tick();
-      reflectToActivePanel(res.nextCommands);
-    } catch (err) {
-      workerLive = false;
-      alphabets = SYNTHETIC_ALPHABETS;
-      tapeRefs.forEach((r) => r?.clear());
-      lastSnapshots = null;
-      halted = true;
-      const msg = err instanceof Error ? err.message : String(err);
-      report(`error: ${msg}`, 'error');
-      executionMode = userTookControl ? 'MANUAL' : 'DEMO';
+      await tempRunner.build(source);
+      const bankRes = await tempRunner.run(DEMO_BANK_SIZE);
+      // Discard if a newer load has started since we began.
+      if (bankRes.commands.length > 0 && seq === demoLoadSeq) {
+        demoBank = bankRes.commands;
+      }
+    } catch {
+      // ignore — demo falls back to random commands
     } finally {
-      pendingOp = null;
+      tempRunner.terminate();
     }
   }
 
@@ -251,10 +359,23 @@
     // belt animation does NOT block — the user can click again as soon as the
     // worker returns (~ms), even mid-slide.
     if (stepInFlight) return;
+
+    // First step from any non-RUNNING_STEP mode (DEMO / MANUAL / HALTED):
+    // reload so mirrorMachine and worker start from the current code (user
+    // may have edited it; HALTED entry effectively restarts the machine).
     if (executionMode !== 'RUNNING_STEP') {
-      if (lastSnapshots) setAllFromSnapshots(lastSnapshots);
+      reportSeparator();
+      report('loading…');
+      const ok = await reloadWorker();
+      if (!ok) {
+        executionMode = userTookControl ? 'MANUAL' : 'DEMO';
+        return;
+      }
       executionMode = 'RUNNING_STEP';
+      codeChangedWarned = false;
+      reflectNeutral();
     }
+
     stepInFlight = true;
     let res;
     try {
@@ -265,36 +386,48 @@
     } finally {
       stepInFlight = false;
     }
-    lastSnapshots = res.tapes;
     halted = res.halted;
     if (res.halted) {
       report(`halted after ${res.stepsApplied} step(s)`, 'ok');
       executionMode = 'HALTED';
     } else {
-      report(stepEntry(res.stepsApplied, res.commands, CARET_COLORS));
+      report(commandsEntry(res.commands, { stepNumber: res.stepsApplied }, CARET_COLORS));
     }
     if (res.commands) {
-      applyToAll(res.commands, { animate: true });
+      renderFromMirror(res.commands, true);
       // Show what's queued for the *next* click, not what just applied.
       // Keeps panel state consistent under rapid clicks.
       if (res.nextCommands) reflectToActivePanel(res.nextCommands);
       else reflectNeutral();
-    } else {
-      setAllFromSnapshots(res.tapes);
     }
   }
 
   async function doRun(): Promise<void> {
     if (withPause) {
-      if (executionMode !== 'RUNNING_STEP' && lastSnapshots) {
-        setAllFromSnapshots(lastSnapshots);
+      // Resume auto-stepping from current RUNNING_STEP position without reload.
+      if (executionMode !== 'RUNNING_STEP') {
+        reportSeparator();
+        report('loading…');
+        const ok = await reloadWorker();
+        if (!ok) {
+          executionMode = userTookControl ? 'MANUAL' : 'DEMO';
+          return;
+        }
       }
       executionMode = 'RUNNING_AUTO';
+      codeChangedWarned = false;
       report(`auto-stepping every ${intervalMs}ms`);
       // Auto-step loop is started by the $effect that watches executionMode.
       return;
     }
-    if (lastSnapshots) setAllFromSnapshots(lastSnapshots);
+
+    reportSeparator();
+    report('loading…');
+    const ok = await reloadWorker();
+    if (!ok) {
+      executionMode = userTookControl ? 'MANUAL' : 'DEMO';
+      return;
+    }
     reflectNeutral();
     executionMode = 'RUNNING_CONTINUOUS';
     report('running…');
@@ -302,13 +435,14 @@
     try {
       const res = await runner.run();
       lastSnapshots = res.tapes;
-      setAllFromSnapshots(res.tapes);
+      _buildMirrorMachine(res.tapes, alphabets);
+      setAllFromMirror();
       halted = true;
       reflectNeutral();
       if (res.commands.length > 0) {
         appendBatch(
-          res.commands.map((cmds, i) =>
-            stepEntry(res.startStep + i + 1, cmds, CARET_COLORS),
+          res.commands.map((commands, i) =>
+            commandsEntry(commands, { stepNumber: res.startStep + i + 1 }, CARET_COLORS),
           ),
         );
       }
@@ -328,11 +462,12 @@
   function takeControl(): void {
     userTookControl = true;
     executionMode = 'MANUAL';
+    reflectNeutral();
   }
 
-  function onApply(cmds: Command[]): void {
-    applyToAll(cmds, { animate: true });
-    report(appliedEntry(cmds, CARET_COLORS));
+  function onApply(commands: Command[]): void {
+    renderFromMirror(commands, true);
+    report(commandsEntry(commands, 'applied', CARET_COLORS));
   }
 
   function resetCodeToSelected(): void {
@@ -342,30 +477,12 @@
   function pickExample(ex: Example): void {
     selectedExampleId = ex.id;
     code = ex.code;
-    examplesOpen = false;
   }
 
   // Persist the selected example id (separate from the editor code) so the
   // reset button keeps targeting the chosen source across reloads.
   $effect(() => {
     saveExampleId(engine, selectedExampleId);
-  });
-
-  // Close dropdown on outside click / Escape — only while open.
-  $effect(() => {
-    if (!examplesOpen) return;
-    const onPointer = (e: MouseEvent): void => {
-      if (!examplesMenuEl?.contains(e.target as Node)) examplesOpen = false;
-    };
-    const onKey = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') examplesOpen = false;
-    };
-    document.addEventListener('mousedown', onPointer);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onPointer);
-      document.removeEventListener('keydown', onKey);
-    };
   });
 
   /* ───── effects ─────
@@ -377,12 +494,13 @@
   $effect(() => {
     if (executionMode !== 'DEMO' || !demoEnabled) return;
     return startDemoLoop({
-      reflect: (cmds) => panelRef?.reflect(cmds),
-      apply: (cmds) => {
+      reflect: (commands) => panelRef?.reflect(commands),
+      apply: (commands) => {
         panelRef?.flashApply();
-        applyToAll(cmds, { animate: true });
+        renderFromMirror(commands, true);
       },
       getAlphabets: () => alphabets,
+      getBank: () => demoBank,
     });
   });
 
@@ -391,20 +509,17 @@
       return startAutoStep(intervalMs, async () => {
         try {
           const res = await runner.step();
-          lastSnapshots = res.tapes;
           halted = res.halted;
           if (executionMode !== 'RUNNING_AUTO') return;
           if (res.commands) {
             reflectToActivePanel(res.commands);
-            applyToAll(res.commands, { animate: true });
-          } else {
-            setAllFromSnapshots(res.tapes);
+            renderFromMirror(res.commands, true);
           }
           if (res.halted) {
             report(`halted after ${res.stepsApplied} step(s)`, 'ok');
             executionMode = 'HALTED';
           } else {
-            report(stepEntry(res.stepsApplied, res.commands, CARET_COLORS));
+            report(commandsEntry(res.commands, { stepNumber: res.stepsApplied }, CARET_COLORS));
           }
         } catch (err) {
           failHalted(err);
@@ -414,7 +529,19 @@
   });
 
   $effect(() => {
-    tapeRefs.forEach((r) => r?.setTransitionsEnabled(beltTransitionsOn));
+    tapesStackRef?.setTransitionsEnabled(beltTransitionsOn);
+  });
+
+  $effect(() => {
+    void code;  // subscribe; value unused (read happens via untrack below)
+    untrack(() => {
+      if (executionMode === 'RUNNING_STEP' || executionMode === 'RUNNING_AUTO') {
+        if (!codeChangedWarned) {
+          codeChangedWarned = true;
+          report('code changed — current execution continues from loaded state', 'warn');
+        }
+      }
+    });
   });
 
   /* ───── lifecycle ───── */
@@ -430,27 +557,19 @@
 
 <section class="tab">
   <div class="panel-tape">
-    <div class="tapes-stack">
-      <div class="head-thread" style:background={headThreadBackground}></div>
-      {#each Array(tapeCount) as _, i}
-        <Tape
-          bind:this={tapeRefs[i]}
-          showCaret={i === tapeCount - 1}
-          caretColor={CARET_COLORS[i]}
-        />
-      {/each}
-    </div>
+    <TapesStack bind:this={tapesStackRef} {tapeCount} caretColors={CARET_COLORS} />
 
-    <ControlPanel
-      bind:this={panelRef}
-      {alphabets}
-      enabled={panelEnabled}
-      visible={true}
-      {applyVisible}
-      {showTapeLabels}
-      caretColors={CARET_COLORS}
-      {onApply}
-    />
+    <div class="panel-enter-clip">
+      <ControlPanel
+        bind:this={panelRef}
+        {alphabets}
+        enabled={panelEnabled}
+        {applyVisible}
+        {showTapeLabels}
+        caretColors={CARET_COLORS}
+        {onApply}
+      />
+    </div>
 
     {#if takeControlVisible}
       <button class="take-control" type="button" onclick={takeControl}>
@@ -459,64 +578,26 @@
       </button>
     {/if}
 
-    <Log {entries} onclear={clearLog} />
+    <Log entries={logEntries} onClear={clearLog} />
   </div>
 
   <div class="panel-editor">
-    <div class="controls">
-      <div class="examples-menu" bind:this={examplesMenuEl}>
-        <button
-          type="button"
-          class="icon-only"
-          aria-label="Example code sources"
-          aria-haspopup="menu"
-          aria-expanded={examplesOpen}
-          title="Example code sources"
-          onclick={() => (examplesOpen = !examplesOpen)}
-        >
-          {@html icons.examples}
-        </button>
-        {#if examplesOpen}
-          <ul class="dropdown" role="menu">
-            {#each engineExamples as ex (ex.id)}
-              <li role="none">
-                <button
-                  type="button"
-                  role="menuitem"
-                  class:selected={ex.id === selectedExampleId}
-                  onclick={() => pickExample(ex)}
-                >
-                  {ex.title}
-                </button>
-              </li>
-            {/each}
-          </ul>
-        {/if}
-      </div>
-      <button type="button" disabled={loadDisabled} onclick={() => doLoad({ userInitiated: true })}>
-        {@html icons.load}<span class="btn-label">Load</span>
-      </button>
-      <button type="button" disabled={stepDisabled} onclick={doStep}>
-        {@html executionMode === 'RUNNING_AUTO' ? icons.pause : icons.step}
-        <span class="btn-label">{executionMode === 'RUNNING_AUTO' ? 'Pause' : 'Step'}</span>
-      </button>
-      <button type="button" disabled={runDisabled} onclick={doRun}>
-        {@html icons.run}<span class="btn-label">Run</span>
-      </button>
-      <label class="checkbox">
-        <input type="checkbox" bind:checked={withPause} disabled={runDisabled} />
-        <span>with pause</span>
-      </label>
-      {#if withPause}
-        <input
-          type="text"
-          class="interval-input"
-          class:invalid={!intervalIsValid}
-          bind:value={intervalText}
-          placeholder="1s"
-        />
-      {/if}
-    </div>
+    <Toolbar
+      {executionMode}
+      {loadDisabled}
+      {stepDisabled}
+      {runDisabled}
+      {intervalIsValid}
+      examples={engineExamples}
+      {selectedExampleId}
+      bind:withPause
+      bind:intervalText
+      onBuild={() => doLoad({ userInitiated: true })}
+      onStep={doStep}
+      onRun={doRun}
+      onStop={stopMachine}
+      onPickExample={pickExample}
+    />
     <div
       class="status"
       class:error={latestEntry?.kind === 'error'}
@@ -528,7 +609,7 @@
     {#await editorPromise}
       <div class="editor-loading">Loading editor…</div>
     {:then Editor}
-      <Editor {engine} bind:code onreset={resetCodeToSelected} />
+      <Editor {engine} bind:code onReset={resetCodeToSelected} />
     {:catch err}
       <div class="editor-error">Failed to load editor: {err.message}</div>
     {/await}
@@ -539,10 +620,18 @@
 <style>
   .tab {
     flex: 1;
+    min-height: 0;
     display: grid;
     grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr;
     gap: 0;
     overflow: hidden;
+
+    @media (max-width: 768px) {
+      grid-template-columns: 1fr;
+      grid-template-rows: auto 1fr;
+      overflow: visible;
+    }
   }
 
   .panel-tape {
@@ -553,45 +642,18 @@
     border-right: 1px solid var(--cell-border);
     overflow: hidden;
     min-height: 0;
+
+    @media (max-width: 768px) {
+      padding: 16px 16px 24px;
+      border-right: none;
+      border-bottom: 1px solid var(--cell-border);
+    }
   }
 
-  /* Tight inter-belt spacing for multi-tape stacks; the bottom belt's
-     padding-bottom (reserving the ▲ marker) is preserved, while non-bottom
-     belts drop their padding (Tape's `.no-caret` rule). */
-  .tapes-stack {
-    /* --cell-h mirrors Tape.svelte's responsive cell height; --tape-gap is
-       the flex gap between belts. Both feed the head-thread gradient stops. */
-    --cell-h: 40px;
-    --tape-gap: 4px;
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: var(--tape-gap);
-    animation: enter var(--anim-belt-enter-ms) ease-out backwards;
-  }
-
-  @media (max-width: 768px) {
-    .tapes-stack { --cell-h: 36px; }
-  }
-  @media (max-width: 480px) {
-    .tapes-stack { --cell-h: 34px; }
-  }
-
-  /* Vertical thread connecting per-tape caret boxes through the inter-belt
-     gaps and down to the ▲ marker. Sits behind tapes and is masked by the
-     opaque .viewport in each Tape, so visually it only renders in the gap
-     regions and the bottom belt's padding-bottom (where the marker lives).
-     The thread terminates at the marker's vertical center (CSS triangle is
-     8px tall in Tape.svelte, so 4px = half). The marker paints over the
-     overlapping segment and shares the gradient's bottom color. */
-  .head-thread {
-    position: absolute;
-    top: 0;
-    bottom: 4px;
-    left: 50%;
-    width: 2px;
-    transform: translateX(-50%);
-    pointer-events: none;
+  /* Clips the control-panel's enter animation so translateY(20px) can't
+     visually spill into the Take Control button's space below. */
+  .panel-enter-clip {
+    overflow: hidden;
   }
 
   @keyframes enter {
@@ -609,6 +671,11 @@
        content size (CodeMirror's full code height); without it the grid
        row stretches to fit and the editor never has internal scroll. */
     min-height: 0;
+
+    @media (max-width: 768px) {
+      padding: 16px;
+      min-height: 60vh;
+    }
   }
 
   .take-control {
@@ -631,149 +698,20 @@
       background-color var(--anim-button-hover-ms) ease,
       border-color var(--anim-button-hover-ms) ease,
       color var(--anim-button-hover-ms) ease;
-  }
 
-  .take-control:hover {
-    background: rgba(95, 208, 104, 0.14);
-    border-color: var(--ok);
-    color: var(--ok);
-  }
+    &:hover {
+      background: rgba(95, 208, 104, 0.14);
+      border-color: var(--ok);
+      color: var(--ok);
+    }
 
-  .take-control :global(svg) {
-    width: 16px;
-    height: 16px;
-    display: block;
-    flex-shrink: 0;
-    opacity: 0.85;
-  }
-
-  .controls {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .controls button {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    background: var(--cell-bg);
-    border: 1px solid var(--cell-border);
-    color: var(--fg);
-    padding: 6px 14px;
-    font: inherit;
-    cursor: pointer;
-    border-radius: 6px;
-  }
-
-  .controls button:hover:not(:disabled) {
-    border-color: var(--accent);
-    color: var(--accent);
-  }
-
-  .controls button:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-
-  .controls button :global(svg) {
-    width: 16px;
-    height: 16px;
-    display: block;
-    flex-shrink: 0;
-  }
-
-  /* Examples dropdown — anchored to its trigger via position:relative on the
-     wrapper. The button is icon-only; the menu floats below it. */
-  .examples-menu {
-    position: relative;
-    display: inline-flex;
-  }
-
-  .controls .examples-menu .icon-only {
-    padding: 6px 8px;
-  }
-
-  .dropdown {
-    position: absolute;
-    top: calc(100% + 4px);
-    left: 0;
-    z-index: 20;
-    list-style: none;
-    margin: 0;
-    padding: 4px;
-    min-width: 220px;
-    /* Opaque: --surface-bg has alpha and would let the editor code show
-       through when the dropdown overlays CodeMirror. */
-    background: var(--cell-bg);
-    border: 1px solid var(--surface-border, var(--cell-border));
-    border-radius: 6px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
-  }
-
-  .dropdown li {
-    list-style: none;
-  }
-
-  .dropdown button {
-    display: block;
-    width: 100%;
-    text-align: left;
-    background: transparent;
-    border: none;
-    color: var(--fg);
-    padding: 6px 10px;
-    font: inherit;
-    font-size: 13px;
-    border-radius: 4px;
-    cursor: pointer;
-  }
-
-  .dropdown button:hover {
-    background: rgba(110, 168, 254, 0.14);
-    color: var(--accent);
-  }
-
-  .dropdown button.selected {
-    color: var(--accent);
-    background: rgba(110, 168, 254, 0.18);
-  }
-
-  .checkbox {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 13px;
-    color: var(--muted);
-    cursor: pointer;
-    user-select: none;
-  }
-
-  .checkbox input {
-    accent-color: var(--accent);
-    margin: 0;
-  }
-
-  .interval-input {
-    width: 64px;
-    background: var(--cell-bg);
-    border: 1px solid var(--cell-border);
-    color: var(--fg);
-    padding: 4px 8px;
-    font: inherit;
-    font-size: 13px;
-    border-radius: 4px;
-  }
-
-  .interval-input:focus {
-    outline: none;
-    border-color: var(--accent);
-  }
-
-  .interval-input.invalid {
-    border-color: var(--error);
-    color: var(--error);
+    :global(svg) {
+      width: 16px;
+      height: 16px;
+      display: block;
+      flex-shrink: 0;
+      opacity: 0.85;
+    }
   }
 
   .version {
@@ -815,43 +753,13 @@
     overflow: hidden;
     text-overflow: ellipsis;
     min-height: 1.2em;
-  }
 
-  .status.error { color: var(--error); }
-  .status.warn  { color: var(--warn); }
-  .status.ok    { color: var(--ok); }
+    &.error { color: var(--error); }
+    &.warn  { color: var(--warn); }
+    &.ok    { color: var(--ok); }
 
-  @media (max-width: 768px) {
-    .tab {
-      grid-template-columns: 1fr;
-      grid-template-rows: auto 1fr;
-      overflow: visible;
-    }
-
-    .panel-tape {
-      padding: 16px 16px 24px;
-      border-right: none;
-      border-bottom: 1px solid var(--cell-border);
-    }
-
-    .panel-editor {
-      padding: 16px;
-      min-height: 60vh;
-    }
-
-    .status {
+    @media (max-width: 768px) {
       display: block;
-    }
-
-    .controls button {
-      padding: 4px 10px;
-      font-size: 13px;
-      gap: 4px;
-    }
-
-    .controls button :global(svg) {
-      width: 14px;
-      height: 14px;
     }
   }
 </style>

--- a/src/components/Tape.svelte
+++ b/src/components/Tape.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { tick } from 'svelte';
-  import type { Command, TapeSnapshot } from '../lib/types.ts';
+  import * as turing from '@turing-machine-js/machine';
+  import { VIEWPORT_WIDTH } from '../lib/caps.ts';
 
   // showCaret: render the head ▲ marker and reserve room below the belt.
   // For multi-tape stacks, only the bottom belt sets this true so the heads
@@ -10,64 +11,42 @@
   type Props = { showCaret?: boolean; caretColor?: string };
   let { showCaret = true, caretColor }: Props = $props();
 
-  // Belt geometry. CSS owns dimensions (cell-w, cell-gap, visible-cells); JS
-  // only owns counts that matter for indexing the cell array — keeping a
-  // single source of truth for cell width avoided a stale-inline-style bug
-  // where the responsive CSS calc was overridden by hardcoded JS values.
-  // VISIBLE_CELLS is the desktop count; mobile CSS shrinks the viewport to
-  // show fewer cells (the rest fade out via the mask). DOM always renders the
-  // full TOTAL_CELLS regardless of breakpoint.
-  const VISIBLE_CELLS = 19; // odd; head sits at exact middle
-  const BUFFER_CELLS = 2;
-  const TOTAL_CELLS = VISIBLE_CELLS + BUFFER_CELLS * 2;
-  const MIDDLE_INDEX = (TOTAL_CELLS - 1) / 2;
+  // Per-cell shape — `sym` is the literal alphabet symbol the user defined
+  // (no UI substitution). `blank` flags cells holding the alphabet's blank,
+  // so CSS can dim them without conflating with whatever character the user
+  // chose for blank.
+  type Cell = { sym: string; blank: boolean };
 
-  let symbols = $state<string[]>([]);
-  let head = $state(0);
-  let blank = $state(' ');
+  // The rendered window — exactly `VIEWPORT_WIDTH` reactive cells. DOM
+  // always renders all of them; mobile CSS shrinks --visible-cells so the
+  // edges fade behind the mask. `setFromTape` reassigns `viewport` to a
+  // `VIEWPORT_WIDTH`-long array (length guaranteed because the parent sets
+  // `viewportWidth = VIEWPORT_WIDTH` on every tape).
+  const blankCell = (): Cell => ({ sym: '', blank: true });
+  let viewport = $state<Cell[]>(new Array(VIEWPORT_WIDTH).fill(null).map(blankCell));
 
   let stripEl: HTMLDivElement | undefined;
 
-  export function setFromSnapshot(snap: TapeSnapshot | null): void {
-    if (!snap) {
-      symbols = [];
-      head = 0;
+  // Single render path. Reads the upstream tape's `.viewport` (the library
+  // does the slice/center math; we just copy). `null` clears the window.
+  // `delta` (±1/0) drives the prep-shift slide when `animate` is true.
+  // `sym` (not `symbol`) avoids shadowing the built-in TS/JS `symbol` type
+  // used by the upstream library for movement primitives.
+  export async function setFromTape(
+    tape: turing.Tape | null,
+    delta: -1 | 0 | 1 = 0,
+    animate = false,
+  ): Promise<void> {
+    if (!tape) {
+      viewport = new Array(VIEWPORT_WIDTH).fill(null).map(blankCell);
       return;
     }
-    symbols = [...snap.symbols];
-    head = snap.position;
-    blank = snap.blank;
+    const blank = tape.alphabet.blankSymbol;
+    viewport = tape.viewport.map((sym) => ({ sym, blank: sym === blank }));
+    if (animate && delta !== 0) await _animateSlide(delta);
   }
 
-  export function clear(): void {
-    symbols = [];
-    head = 0;
-  }
-
-  /**
-   * Apply a command. With `animate: true` performs the prep-shift trick:
-   * re-render with new head, snap-translate by ±1 cell without transition,
-   * force reflow, then translate back to 0 with transition on — produces
-   * a smooth slide.
-   *
-   * `await tick()` ensures the reactive head/symbols update has flushed to
-   * the DOM before we manipulate transform; without it Svelte 5's microtask
-   * scheduling can prep-shift against stale cell positions.
-   */
-  export async function apply(
-    cmd: Command,
-    { animate = false }: { animate?: boolean } = {},
-  ): Promise<void> {
-    const delta = cmd.movement === 'L' ? -1 : cmd.movement === 'R' ? 1 : 0;
-    if (cmd.symbol !== null) {
-      const next = [...symbols];
-      next[head] = cmd.symbol;
-      symbols = next;
-    }
-    head += delta;
-
-    if (!animate || delta === 0 || !stripEl) return;
-
+  async function _animateSlide(delta: -1 | 0 | 1): Promise<void> {
     await tick();
     if (!stripEl) return;
     stripEl.classList.remove('transitions-on');
@@ -86,15 +65,6 @@
       stripEl.style.transform = 'translateX(0)';
     }
   }
-
-  function cellInfo(i: number): { display: string; isBlank: boolean; isOutOfRange: boolean } {
-    const abs = head + (i - MIDDLE_INDEX);
-    const raw = symbols[abs];
-    const isOutOfRange = raw === undefined;
-    const isBlank = isOutOfRange || raw === blank;
-    const display = isBlank ? '␣' : raw;
-    return { display, isBlank, isOutOfRange };
-  }
 </script>
 
 <div
@@ -105,10 +75,9 @@
   <div class="viewport">
     <div class="center">
       <div class="strip transitions-on" bind:this={stripEl}>
-        {#each Array(TOTAL_CELLS) as _cell, i}
-          {@const c = cellInfo(i)}
-          <div class="cell" class:out-of-range={c.isOutOfRange}>
-            <span class="sym">{c.display}</span>
+        {#each viewport as cell}
+          <div class="cell" class:blank={cell.blank}>
+            <span class="sym">{cell.sym}</span>
           </div>
         {/each}
       </div>
@@ -132,33 +101,47 @@
     justify-content: center;
     font-family: ui-monospace, 'SF Mono', Consolas, monospace;
     padding-bottom: 14px;
-  }
 
-  /* ▲ marker below the head cell. CSS-border triangle (not a Unicode glyph)
-     so its visible edges exactly match its box — `left:50%; translateX(-50%)`
-     then aligns it pixel-perfect with the head-thread line. Lives on the
-     outer wrapper because the viewport has overflow:hidden. */
-  .ui-belt::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 0;
-    height: 0;
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
-    border-bottom: 8px solid var(--head);
-  }
+    /* ▲ marker below the head cell. CSS-border triangle (not a Unicode glyph)
+       so its visible edges exactly match its box — `left:50%; translateX(-50%)`
+       then aligns it pixel-perfect with the head-thread line. Lives on the
+       outer wrapper because the viewport has overflow:hidden. */
+    &::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 0;
+      height: 0;
+      border-left: 5px solid transparent;
+      border-right: 5px solid transparent;
+      border-bottom: 8px solid var(--head);
+    }
 
-  /* Multi-tape stack: non-bottom belts drop the marker and the room reserved
-     for it, so the stack reads as one continuous column of heads. */
-  .ui-belt.no-caret {
-    padding-bottom: 0;
-  }
+    /* Multi-tape stack: non-bottom belts drop the marker and the room reserved
+       for it, so the stack reads as one continuous column of heads. */
+    &.no-caret {
+      padding-bottom: 0;
 
-  .ui-belt.no-caret::after {
-    content: none;
+      &::after {
+        content: none;
+      }
+    }
+
+    /* Tablet / large mobile (single-column layout, lots of horizontal room). */
+    @media (max-width: 768px) {
+      --cell-w: 28px;
+      --cell-h: 36px;
+      --visible-cells: 17;
+    }
+
+    /* Phone-sized — fewer cells, smaller cells to fit ≤480px viewports. */
+    @media (max-width: 480px) {
+      --cell-w: 26px;
+      --cell-h: 34px;
+      --visible-cells: 11;
+    }
   }
 
   .viewport {
@@ -200,10 +183,10 @@
     align-items: center;
     height: 100%;
     transform: translateX(0);
-  }
 
-  .strip.transitions-on {
-    transition: transform var(--anim-belt-slide-ms) ease;
+    &.transitions-on {
+      transition: transform var(--anim-belt-slide-ms) ease;
+    }
   }
 
   .cell {
@@ -219,20 +202,24 @@
     border-radius: 4px;
     font-size: 16px;
     white-space: pre;
+
+    /* Visual hint for blank cells — independent of which character the user
+       chose for blank. Dimmed border + dimmed symbol distinguish them
+       without normalizing the displayed character (so a user-defined `'␣'`
+       symbol in the alphabet stays visually distinct from a blank cell). */
+    &.blank {
+      border-color: color-mix(in srgb, var(--cell-border) 40%, var(--cell-bg));
+
+      .sym { opacity: 0.4; }
+    }
+
+    @media (max-width: 768px) {
+      font-size: 14px;
+    }
   }
 
   .sym {
     pointer-events: none;
-  }
-
-  /* Cells beyond the actual tape range — visually dim to hint "infinite blank".
-     Dim only border + symbol; the cell bg must stay opaque so the head-thread
-     line behind the stack is masked rather than bleeding through. */
-  .cell.out-of-range {
-    border-color: color-mix(in srgb, var(--cell-border) 40%, var(--cell-bg));
-  }
-  .cell.out-of-range .sym {
-    opacity: 0.4;
   }
 
   .caret {
@@ -246,27 +233,5 @@
     border-radius: 4px;
     box-shadow: 0 0 0 1px var(--head) inset;
     pointer-events: none;
-  }
-
-  /* Tablet / large mobile (single-column layout, but lots of horizontal room).
-     Belt was way too narrow at ~757px under the old phone-tuned mobile rules. */
-  @media (max-width: 768px) {
-    .ui-belt {
-      --cell-w: 28px;
-      --cell-h: 36px;
-      --visible-cells: 17;
-    }
-    .cell {
-      font-size: 14px;
-    }
-  }
-
-  /* Phone-sized — fewer cells, smaller cells to actually fit ≤480px viewports. */
-  @media (max-width: 480px) {
-    .ui-belt {
-      --cell-w: 26px;
-      --cell-h: 34px;
-      --visible-cells: 11;
-    }
   }
 </style>

--- a/src/components/TapesStack.svelte
+++ b/src/components/TapesStack.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import type * as turing from '@turing-machine-js/machine';
+  import Tape from './Tape.svelte';
+
+  type Props = {
+    tapeCount: number;
+    caretColors: readonly string[];
+  };
+  let { tapeCount, caretColors }: Props = $props();
+
+  let tapeRefs = $state<Array<ReturnType<typeof Tape> | undefined>>([]);
+
+  // Hard-stop gradient: each tape row is solid color[i]; transitions happen
+  // only in the inter-tape gap. Stops are pixel offsets built from the
+  // .tapes-stack CSS vars (--cell-h, --tape-gap) so they track breakpoints.
+  const headThreadBackground = $derived.by(() => {
+    const colors = caretColors.slice(0, tapeCount);
+    if (colors.length === 1) return colors[0];
+    const stops: string[] = [];
+    for (let i = 0; i < colors.length; i++) {
+      const top = `calc(${i} * (var(--cell-h) + var(--tape-gap)))`;
+      const bot = `calc(${i} * (var(--cell-h) + var(--tape-gap)) + var(--cell-h))`;
+      stops.push(`${colors[i]} ${top}`, `${colors[i]} ${bot}`);
+    }
+    return `linear-gradient(to bottom, ${stops.join(', ')})`;
+  });
+
+  // Imperative API — parent advances the mirror, then asks the matching
+  // <Tape> child to render its updated viewport. We don't take per-tape
+  // refs across the boundary; this stack owns them.
+  export function setFromTape(
+    i: number,
+    tape: turing.Tape | null,
+    delta: -1 | 0 | 1 = 0,
+    animate = false,
+  ): void {
+    void tapeRefs[i]?.setFromTape(tape, delta, animate);
+  }
+
+  export function clearAll(): void {
+    tapeRefs.forEach((r) => void r?.setFromTape(null));
+  }
+
+  export function setTransitionsEnabled(on: boolean): void {
+    tapeRefs.forEach((r) => r?.setTransitionsEnabled(on));
+  }
+</script>
+
+<div class="tapes-stack">
+  <div class="head-thread" style:background={headThreadBackground}></div>
+  {#each Array(tapeCount) as _, i}
+    <Tape
+      bind:this={tapeRefs[i]}
+      showCaret={i === tapeCount - 1}
+      caretColor={caretColors[i]}
+    />
+  {/each}
+</div>
+
+<style>
+  /* Tight inter-belt spacing for multi-tape stacks; the bottom belt's
+     padding-bottom (reserving the ▲ marker) is preserved, while non-bottom
+     belts drop their padding (Tape's `.no-caret` rule). */
+  .tapes-stack {
+    /* --cell-h mirrors Tape.svelte's responsive cell height; --tape-gap is
+       the flex gap between belts. Both feed the head-thread gradient stops. */
+    --cell-h: 40px;
+    --tape-gap: 4px;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: var(--tape-gap);
+    animation: enter var(--anim-belt-enter-ms) ease-out backwards;
+
+    @media (max-width: 768px) { --cell-h: 36px; }
+    @media (max-width: 480px) { --cell-h: 34px; }
+  }
+
+  /* Vertical thread connecting per-tape caret boxes through the inter-belt
+     gaps and down to the ▲ marker. Sits behind tapes and is masked by the
+     opaque .viewport in each Tape, so visually it only renders in the gap
+     regions and the bottom belt's padding-bottom (where the marker lives).
+     The thread terminates at the marker's vertical center (CSS triangle is
+     8px tall in Tape.svelte, so 4px = half). The marker paints over the
+     overlapping segment and shares the gradient's bottom color. */
+  .head-thread {
+    position: absolute;
+    top: 0;
+    bottom: 4px;
+    left: 50%;
+    width: 2px;
+    transform: translateX(-50%);
+    pointer-events: none;
+  }
+
+  @keyframes enter {
+    from { opacity: 0; transform: translateY(20px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+</style>

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -1,0 +1,295 @@
+<script lang="ts">
+  import { icons } from '../lib/icons.ts';
+  import type { Example } from '../lib/defaultCode.ts';
+
+  // Execution-mode strings the toolbar cares about. Kept loose (string union
+  // matching MachineView's ExecutionMode) so we don't duplicate the type.
+  type Mode =
+    | 'DEMO' | 'MANUAL'
+    | 'RUNNING_STEP' | 'RUNNING_AUTO' | 'RUNNING_CONTINUOUS'
+    | 'HALTED';
+
+  type Props = {
+    executionMode: Mode;
+    loadDisabled: boolean;
+    stepDisabled: boolean;
+    runDisabled: boolean;
+    intervalIsValid: boolean;
+    examples: readonly Example[];
+    selectedExampleId: string;
+    withPause: boolean;
+    intervalText: string;
+    onBuild: () => void;
+    onStep: () => void;
+    onRun: () => void;
+    onStop: () => void;
+    onPickExample: (ex: Example) => void;
+  };
+
+  let {
+    executionMode,
+    loadDisabled,
+    stepDisabled,
+    runDisabled,
+    intervalIsValid,
+    examples,
+    selectedExampleId,
+    withPause = $bindable(),
+    intervalText = $bindable(),
+    onBuild,
+    onStep,
+    onRun,
+    onStop,
+    onPickExample,
+  }: Props = $props();
+
+  // Examples dropdown — fully owned here so the outside-click and Escape
+  // handlers stay colocated with the menu they close.
+  let examplesOpen = $state(false);
+  let examplesMenuEl: HTMLDivElement | undefined;
+
+  function pick(ex: Example): void {
+    onPickExample(ex);
+    examplesOpen = false;
+  }
+
+  // Close dropdown on outside click / Escape — only while open.
+  $effect(() => {
+    if (!examplesOpen) return;
+    const onPointer = (e: MouseEvent): void => {
+      if (!examplesMenuEl?.contains(e.target as Node)) examplesOpen = false;
+    };
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') examplesOpen = false;
+    };
+    document.addEventListener('mousedown', onPointer);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onPointer);
+      document.removeEventListener('keydown', onKey);
+    };
+  });
+
+  // with-pause / interval are configuration for the *next* Run; meaningless
+  // mid-run, so hide them in the running modes (they'd just be inert chrome).
+  const configVisible = $derived(
+    executionMode !== 'RUNNING_AUTO' && executionMode !== 'RUNNING_CONTINUOUS',
+  );
+  const stopVisible = $derived(
+    executionMode === 'RUNNING_STEP' || executionMode === 'RUNNING_AUTO',
+  );
+</script>
+
+<div class="toolbar">
+  <div class="examples-menu" bind:this={examplesMenuEl}>
+    <button
+      type="button"
+      class="icon-only"
+      aria-label="Example code sources"
+      aria-haspopup="menu"
+      aria-expanded={examplesOpen}
+      title="Example code sources"
+      onclick={() => (examplesOpen = !examplesOpen)}
+    >
+      {@html icons.examples}
+    </button>
+    {#if examplesOpen}
+      <ul class="dropdown" role="menu">
+        {#each examples as ex (ex.id)}
+          <li role="none">
+            <button
+              type="button"
+              role="menuitem"
+              class:selected={ex.id === selectedExampleId}
+              onclick={() => pick(ex)}
+            >
+              {ex.title}
+            </button>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+  <button type="button" disabled={loadDisabled} onclick={onBuild}>
+    {@html icons.build}<span class="btn-label">Build</span>
+  </button>
+  <button type="button" disabled={stepDisabled} onclick={onStep}>
+    {@html executionMode === 'RUNNING_AUTO' ? icons.pause : icons.step}
+    <span class="btn-label">{executionMode === 'RUNNING_AUTO' ? 'Pause' : 'Step'}</span>
+  </button>
+  <button type="button" disabled={runDisabled} onclick={onRun}>
+    {@html icons.run}<span class="btn-label">Run</span>
+  </button>
+  {#if configVisible}
+    <label class="checkbox">
+      <input type="checkbox" bind:checked={withPause} disabled={runDisabled} />
+      <span>with pause</span>
+    </label>
+    {#if withPause}
+      <input
+        type="text"
+        class="interval-input"
+        class:invalid={!intervalIsValid}
+        bind:value={intervalText}
+        placeholder="1s"
+      />
+    {/if}
+  {/if}
+  {#if stopVisible}
+    <button type="button" class="stop-btn" onclick={onStop}>
+      {@html icons.stop}<span class="btn-label">Stop</span>
+    </button>
+  {/if}
+</div>
+
+<style>
+  .toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+
+    button {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      background: var(--cell-bg);
+      border: 1px solid var(--cell-border);
+      color: var(--fg);
+      padding: 6px 14px;
+      font: inherit;
+      cursor: pointer;
+      border-radius: 6px;
+
+      &:hover:not(:disabled) {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+
+      &:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+
+      :global(svg) {
+        width: 16px;
+        height: 16px;
+        display: block;
+        flex-shrink: 0;
+      }
+
+      @media (max-width: 768px) {
+        padding: 4px 10px;
+        font-size: 13px;
+        gap: 4px;
+
+        :global(svg) {
+          width: 14px;
+          height: 14px;
+        }
+      }
+    }
+  }
+
+  .stop-btn {
+    border-color: rgba(255, 107, 107, 0.4);
+    color: rgba(255, 107, 107, 0.8);
+
+    &:hover {
+      border-color: var(--error) !important;
+      color: var(--error) !important;
+    }
+  }
+
+  /* Examples dropdown — anchored to its trigger via position:relative on the
+     wrapper. The button is icon-only; the menu floats below it. */
+  .examples-menu {
+    position: relative;
+    display: inline-flex;
+  }
+
+  .toolbar .examples-menu .icon-only {
+    padding: 6px 8px;
+  }
+
+  .dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: 20;
+    list-style: none;
+    margin: 0;
+    padding: 4px;
+    min-width: 220px;
+    /* Opaque: --surface-bg has alpha and would let the editor code show
+       through when the dropdown overlays CodeMirror. */
+    background: var(--cell-bg);
+    border: 1px solid var(--surface-border);
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+
+    li {
+      list-style: none;
+    }
+
+    button {
+      display: block;
+      width: 100%;
+      text-align: left;
+      background: transparent;
+      border: none;
+      color: var(--fg);
+      padding: 6px 10px;
+      font: inherit;
+      font-size: 13px;
+      border-radius: 4px;
+      cursor: pointer;
+
+      &:hover {
+        background: rgba(110, 168, 254, 0.14);
+        color: var(--accent);
+      }
+
+      &.selected {
+        color: var(--accent);
+        background: rgba(110, 168, 254, 0.18);
+      }
+    }
+  }
+
+  .checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: var(--muted);
+    cursor: pointer;
+    user-select: none;
+
+    input {
+      accent-color: var(--accent);
+      margin: 0;
+    }
+  }
+
+  .interval-input {
+    width: 64px;
+    background: var(--cell-bg);
+    border: 1px solid var(--cell-border);
+    color: var(--fg);
+    padding: 4px 8px;
+    font: inherit;
+    font-size: 13px;
+    border-radius: 4px;
+
+    &:focus {
+      outline: none;
+      border-color: var(--accent);
+    }
+
+    &.invalid {
+      border-color: var(--error);
+      color: var(--error);
+    }
+  }
+</style>

--- a/src/lib/caps.ts
+++ b/src/lib/caps.ts
@@ -1,0 +1,26 @@
+/* Numeric caps shared between the worker and the main thread. Pulled out of
+ * types.ts so that file is purely type definitions; these are runtime values
+ * that backstop user code (step limit, wall-clock limit), bound the UI
+ * (tape count for the caret palette), and pin the rendering window
+ * (`VIEWPORT_WIDTH` lives here because the upstream library's `Tape` honors
+ * it as a runtime configuration value, not a type-level constant). */
+
+/** Tape rendering window — the upstream `Tape`'s `viewportWidth`. Must be odd
+ *  so the head sits at the exact middle (`(VIEWPORT_WIDTH - 1) / 2`). Both
+ *  the worker and `Tape.svelte` depend on this being the same number; the
+ *  upstream library's `normalise()` pads tape symbols to fill it. */
+export const VIEWPORT_WIDTH = 23;
+
+/** Step backstop: `runToEnd` stops here even if the machine hasn't halted,
+ *  setting `truncated: true` on the `ran` response. Complements
+ *  `WORKER_TIMEOUT_MS` (steps vs. wall-clock). */
+export const MAX_STEPS = 100_000;
+
+/** Wall-clock backstop: `MachineRunner` kills the worker if a single request
+ *  doesn't reply within this window (handles infinite loops in user code that
+ *  never yield, beyond what `MAX_STEPS` catches). */
+export const WORKER_TIMEOUT_MS = 5_000;
+
+/** UI-side cap on tape count. `CARET_COLORS` (in `MachineView.svelte`) must
+ *  have at least this many entries; the worker rejects loads with more. */
+export const MAX_TAPES = 5;

--- a/src/lib/defaultCode.ts
+++ b/src/lib/defaultCode.ts
@@ -21,7 +21,7 @@ const {
   haltState, ifOtherSymbol, movements,
 } = imports;
 
-const alphabet = new Alphabet([' ', 'a', 'b', 'c', '*']);
+const alphabet = new Alphabet(['␣', 'a', 'b', 'c', '*']);
 const tape = new Tape({ alphabet, symbols: ['a', 'b', 'c', 'b', 'a'] });
 const tapeBlock = TapeBlock.fromTapes([tape]);
 const machine = new TuringMachine({ tapeBlock });
@@ -58,7 +58,7 @@ const {
   haltState, movements,
 } = imports;
 
-const alphabet = new Alphabet([' ', 'a', 'b']);
+const alphabet = new Alphabet(['␣', 'a', 'b']);
 const t0 = new Tape({ alphabet, symbols: ['a', 'b', 'a', 'b'] });
 const t1 = new Tape({ alphabet, symbols: [] });
 const tapeBlock = TapeBlock.fromTapes([t0, t1]);
@@ -67,19 +67,19 @@ const machine = new TuringMachine({ tapeBlock });
 const { symbol } = tapeBlock;
 
 const initialState = new State({
-  [symbol(['a', ' '])]: {
+  [symbol(['a', '␣'])]: {
     command: [
       { symbol: 'a', movement: movements.right },
       { symbol: 'a', movement: movements.right },
     ],
   },
-  [symbol(['b', ' '])]: {
+  [symbol(['b', '␣'])]: {
     command: [
       { symbol: 'b', movement: movements.right },
       { symbol: 'b', movement: movements.right },
     ],
   },
-  [symbol([' ', ' '])]: {
+  [symbol(['␣', '␣'])]: {
     command: [
       { movement: movements.stay },
       { movement: movements.stay },

--- a/src/lib/demoLoop.ts
+++ b/src/lib/demoLoop.ts
@@ -1,12 +1,12 @@
-import { MOVEMENTS, type Command } from './types.ts';
+import { MOVEMENTS, type Alphabets, type Command } from './types.ts';
 
 export const DEMO_INTERVAL_MS = 1600;
 export const DEMO_REFLECT_DELAY_MS = 700;
 
 const KEEP_PROBABILITY = 0.4;
 
-function pickRandom<T>(arr: readonly T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)];
+function pickRandom<T>(array: readonly T[]): T {
+  return array[Math.floor(Math.random() * array.length)];
 }
 
 function randomCommand(alphabet: readonly string[]): Command {
@@ -16,9 +16,12 @@ function randomCommand(alphabet: readonly string[]): Command {
 }
 
 export type DemoCallbacks = {
-  reflect: (cmds: Command[]) => void;
-  apply: (cmds: Command[]) => void;
-  getAlphabets: () => readonly (readonly string[])[];
+  reflect: (commands: Command[]) => void;
+  apply: (commands: Command[]) => void;
+  getAlphabets: () => Alphabets;
+  /** If provided and returns a non-empty array, each tick picks a random entry
+   *  instead of generating fake commands from the alphabet. */
+  getBank?: () => Command[][] | null;
 };
 
 /**
@@ -28,15 +31,24 @@ export type DemoCallbacks = {
  *
  * Always array-shape — single-tape engines (Post) just see length-1 arrays.
  */
-export function startDemoLoop(cb: DemoCallbacks): () => void {
-  let applyTimer: ReturnType<typeof setTimeout> | null = null;
+export function startDemoLoop(callbacks: DemoCallbacks): () => void {
+  let applyTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
   const tick = (): void => {
-    const cmds = cb.getAlphabets().map((a) => randomCommand(a));
-    cb.reflect(cmds);
-    applyTimer = setTimeout(() => {
-      applyTimer = null;
-      cb.apply(cmds);
+    const bank = callbacks.getBank?.();
+    let commands: Command[];
+    if (bank && bank.length > 0) {
+      // Use real symbol writes from the bank; randomize movements for visual
+      // variety (real machine steps are movement-biased, e.g. all-R counters).
+      const entry = bank[Math.floor(Math.random() * bank.length)];
+      commands = entry.map((command) => ({ ...command, movement: pickRandom(MOVEMENTS) }));
+    } else {
+      commands = callbacks.getAlphabets().map((a) => randomCommand(a));
+    }
+    callbacks.reflect(commands);
+    applyTimeoutId = setTimeout(() => {
+      applyTimeoutId = null;
+      callbacks.apply(commands);
     }, DEMO_REFLECT_DELAY_MS);
   };
 
@@ -45,6 +57,6 @@ export function startDemoLoop(cb: DemoCallbacks): () => void {
 
   return () => {
     clearInterval(intervalId);
-    if (applyTimer !== null) clearTimeout(applyTimer);
+    if (applyTimeoutId !== null) clearTimeout(applyTimeoutId);
   };
 }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,23 +1,34 @@
-import type { Command, TapeSnapshot } from './types.ts';
+import type { Alphabets, Command, TapeSnapshot } from './types.ts';
 import type { LogEntry } from './log.ts';
 
-function describeOne(cmd: Command): string {
-  const sym = cmd.symbol === null ? 'keep' : `wrote '${cmd.symbol === ' ' ? '␣' : cmd.symbol}'`;
-  const mv = cmd.movement === 'L' ? 'left' : cmd.movement === 'R' ? 'right' : 'stay';
-  return `${sym} + ${mv}`;
+function describeAppliedCommand(command: Command): string {
+  // Display symbol — literal char from the alphabet (no UI substitution; the
+  // user controls what their blank looks like via the alphabet definition).
+  // Single-quote-wrap so an invisible blank (e.g. literal space) still reads
+  // as something on a log line. `sym` (not `symbol`) avoids shadowing the
+  // built-in TS/JS `symbol` type used by the upstream library's movement
+  // primitives.
+  const sym = command.symbol === null ? 'kept' : `wrote '${command.symbol}'`;
+  const movement = command.movement === 'L' ? 'moved left' : command.movement === 'R' ? 'moved right' : 'stayed';
+  // Paper-style shorthand: `<sym>/<mvmt>`. Actual symbols wrap in single
+  // quotes so a literal `*` (valid alphabet symbol) reads as `'*'` and stays
+  // distinct from the bare `*` wildcard used for "kept" (no write).
+  const shortSym = command.symbol === null ? '*' : `'${command.symbol}'`;
+  return `${sym} + ${movement} (${shortSym}/${command.movement})`;
 }
 
-export function formatAlphabet(alphabet: readonly string[]): string {
-  return alphabet.map((s, i) => (i === 0 ? '␣' : `'${s}'`)).join(', ');
+/** Quoted, comma-separated rest-of-alphabet (excludes the blank at index 0). */
+function alphabetRest(alphabet: readonly string[]): string {
+  return alphabet.slice(1).map((s) => `'${s}'`).join(', ');
 }
 
 export function formatTape(tape: TapeSnapshot): string {
+  // No UI substitution — the user controls their blank glyph. We bracket
+  // the head; `[<blank-char>]` may render an invisible space if blank=' ',
+  // but that's the user's chosen symbol.
   return tape.symbols
-    .map((sym, i) => {
-      const display = sym === tape.blank ? '␣' : sym;
-      return i === tape.position ? `[${display}]` : display;
-    })
-    .join(' ');
+    .map((sym, i) => (i === tape.position ? `[${sym}]` : sym))
+    .join('');
 }
 
 /* ───── log entries ─────
@@ -26,68 +37,67 @@ export function formatTape(tape: TapeSnapshot): string {
  * via the `colors` palette so each tape's row reads in its caret color.
  */
 
-export function alphabetsEntry(
-  alphabets: readonly (readonly string[])[],
-  colors?: readonly string[],
-): LogEntry {
-  if (alphabets.length === 1) {
-    return { text: `alphabet: ${formatAlphabet(alphabets[0])}`, color: colors?.[0] };
-  }
-  return {
-    text: 'alphabets:',
-    rows: alphabets.map((a, i) => ({
-      text: `- Tape ${i + 1}: ${formatAlphabet(a)}`,
-      color: colors?.[i],
-    })),
-  };
-}
-
+/**
+ * Log entries describing each tape's full definition: blank, alphabet, and
+ * current tape symbols. Single-tape: three sibling lines. Multi-tape: one
+ * entry per tape with a `Tape N:` header and `- blank` / `- alphabet` /
+ * `- tape` on indented rows, so a tape's full definition reads as one
+ * grouped chunk in the log. Returned as an array; callers spread it into
+ * `appendBatch`.
+ */
 export function tapesEntry(
   tapes: readonly TapeSnapshot[],
+  alphabets: Alphabets,
   colors?: readonly string[],
-): LogEntry {
+): LogEntry[] {
+  // Blank symbol per tape is `alphabets[i][0]`, quoted on the log line so an
+  // invisible space still reads as `' '`.
+  const blankFor = (i: number): string => `'${alphabets[i]?.[0] ?? ''}'`;
   if (tapes.length === 1) {
-    return { text: `tape: ${formatTape(tapes[0])}`, color: colors?.[0] };
+    return [
+      { text: `blank: ${blankFor(0)}`, color: colors?.[0] },
+      { text: `alphabet: ${alphabetRest(alphabets[0]) || '(empty)'}`, color: colors?.[0] },
+      { text: `tape: ${formatTape(tapes[0])}`, color: colors?.[0] },
+    ];
   }
-  return {
-    text: 'tapes:',
-    rows: tapes.map((t, i) => ({
-      text: `- Tape ${i + 1}: ${formatTape(t)}`,
-      color: colors?.[i],
-    })),
-  };
+  return tapes.map((t, i) => ({
+    text: `Tape ${i + 1}:`,
+    color: colors?.[i],
+    rows: [
+      { text: `- blank: ${blankFor(i)}`, color: colors?.[i] },
+      { text: `- alphabet: ${alphabetRest(alphabets[i] ?? []) || '(empty)'}`, color: colors?.[i] },
+      { text: `- tape: ${formatTape(t)}`, color: colors?.[i] },
+    ],
+  }));
 }
 
-export function stepEntry(
-  stepNumber: number,
-  cmds: Command[] | null,
-  colors?: readonly string[],
-): LogEntry {
-  if (!cmds || cmds.length === 0) return { text: `step ${stepNumber}:` };
-  if (cmds.length === 1) {
-    return { text: `step ${stepNumber}: ${describeOne(cmds[0])}`, color: colors?.[0] };
-  }
-  return {
-    text: `step ${stepNumber}:`,
-    rows: cmds.map((c, i) => ({
-      text: `- Tape ${i + 1}: ${describeOne(c)}`,
-      color: colors?.[i],
-    })),
-  };
-}
+/**
+ * Where the commands came from, used as the entry header. A step carries its
+ * 1-based step number (`step N:`); a manual `Apply` is the literal `'applied'`
+ * (no extra data — `applied:` header).
+ */
+export type CommandsApplication = { stepNumber: number } | 'applied';
 
-export function appliedEntry(
-  cmds: readonly Command[],
+/**
+ * One log entry describing applied commands — replaces the previous
+ * `stepEntry` / `appliedEntry` split. Single-tape: header followed by inline
+ * description (`step 3: wrote 'a' + moved right ('a'/R)`). Multi-tape:
+ * header on its own line and `- Tape N: …` rows per tape.
+ */
+export function commandsEntry(
+  commands: readonly Command[] | null,
+  application: CommandsApplication,
   colors?: readonly string[],
 ): LogEntry {
-  if (cmds.length === 0) return { text: 'applied:' };
-  if (cmds.length === 1) {
-    return { text: `applied: ${describeOne(cmds[0])}`, color: colors?.[0] };
+  const prefix = application === 'applied' ? 'applied' : `step ${application.stepNumber}`;
+  if (!commands || commands.length === 0) return { text: `${prefix}:` };
+  if (commands.length === 1) {
+    return { text: `${prefix}: ${describeAppliedCommand(commands[0])}`, color: colors?.[0] };
   }
   return {
-    text: 'applied:',
-    rows: cmds.map((c, i) => ({
-      text: `- Tape ${i + 1}: ${describeOne(c)}`,
+    text: `${prefix}:`,
+    rows: commands.map((command, i) => ({
+      text: `- Tape ${i + 1}: ${describeAppliedCommand(command)}`,
       color: colors?.[i],
     })),
   };

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -1,33 +1,35 @@
-import arrowLeft from '@tabler/icons/outline/arrow-narrow-left.svg?raw';
-import arrowRight from '@tabler/icons/outline/arrow-narrow-right.svg?raw';
-import stay from '@tabler/icons/outline/keyframe-align-horizontal.svg?raw';
-import keep from '@tabler/icons/outline/keyframe-align-vertical.svg?raw';
 import apply from '@tabler/icons/outline/corner-down-left.svg?raw';
-import load from '@tabler/icons/outline/reload.svg?raw';
-import run from '@tabler/icons/outline/player-play.svg?raw';
-import step from '@tabler/icons/outline/player-skip-forward.svg?raw';
-import pause from '@tabler/icons/outline/player-pause.svg?raw';
-import takeControl from '@tabler/icons/outline/device-gamepad-2.svg?raw';
+import build from '@tabler/icons/outline/hammer.svg?raw';
 import eraser from '@tabler/icons/outline/eraser.svg?raw';
-import resetCode from '@tabler/icons/outline/arrow-back-up.svg?raw';
-import github from '@tabler/icons/outline/brand-github.svg?raw';
 import examples from '@tabler/icons/outline/file-code.svg?raw';
+import github from '@tabler/icons/outline/brand-github.svg?raw';
+import keep from '@tabler/icons/outline/keyframe-align-vertical.svg?raw';
+import left from '@tabler/icons/outline/arrow-narrow-left.svg?raw';
+import pause from '@tabler/icons/outline/player-pause.svg?raw';
+import resetCode from '@tabler/icons/outline/arrow-back-up.svg?raw';
+import right from '@tabler/icons/outline/arrow-narrow-right.svg?raw';
+import run from '@tabler/icons/outline/player-play.svg?raw';
+import stay from '@tabler/icons/outline/keyframe-align-horizontal.svg?raw';
+import step from '@tabler/icons/outline/player-skip-forward.svg?raw';
+import stop from '@tabler/icons/outline/player-stop.svg?raw';
+import takeControl from '@tabler/icons/outline/device-gamepad-2.svg?raw';
 
 export const icons = {
-  left: arrowLeft,
-  right: arrowRight,
-  stay,
-  keep,
   apply,
-  load,
-  run,
-  step,
-  pause,
-  takeControl,
+  build,
   eraser,
-  resetCode,
-  github,
   examples,
+  github,
+  keep,
+  left,
+  pause,
+  resetCode,
+  right,
+  run,
+  stay,
+  step,
+  stop,
+  takeControl,
 } as const;
 
 export type IconName = keyof typeof icons;

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -17,4 +17,7 @@ export type LogEntry = {
   /** Optional structured per-tape rows, rendered below the header. */
   rows?: LogRow[];
   kind?: LogKind;
+  /** Renders as a horizontal divider instead of a text row. Used to visually
+   * group log activity per Build/Step/Run session. */
+  separator?: boolean;
 };

--- a/src/lib/machineRunner.ts
+++ b/src/lib/machineRunner.ts
@@ -1,14 +1,30 @@
-import MachineWorker from './worker.ts?worker';
+import MachineWorker from './machineWorker.ts?worker';
+import { MAX_STEPS, WORKER_TIMEOUT_MS } from './caps.ts';
 import {
-  MAX_STEPS,
-  WORKER_TIMEOUT_MS,
+  type BuiltResponse,
   type Engine,
-  type LoadedResponse,
   type RanResponse,
   type SteppedResponse,
+  type TapeSnapshot,
   type WorkerRequest,
   type WorkerResponse,
 } from './types.ts';
+
+/**
+ * Thrown when the worker rejected with `{ type: 'error' }`. Carries the
+ * partial `tapes` snapshot from the worker (when present) so the main thread
+ * can mirror the state where execution actually stuck — the alternative is
+ * the user seeing the loaded tape with no record of the steps that ran.
+ */
+export class WorkerError extends Error {
+  readonly tapes: TapeSnapshot[] | null;
+
+  constructor(message: string, tapes: TapeSnapshot[] | null) {
+    super(message);
+    this.name = 'WorkerError';
+    this.tapes = tapes;
+  }
+}
 
 type Pending = {
   resolve: (data: WorkerResponse) => void;
@@ -33,8 +49,10 @@ export class MachineRunner {
   }
 
   private spawnWorker(): void {
-    // B2: an in-flight request must be rejected before we tear down the worker,
-    //     otherwise its timer fires later and corrupts state for the next request.
+    // Reject any in-flight request before tearing down the worker. Without
+    // this, the pending request's timeout would survive the worker swap and
+    // fire later — clearing `this.pending` and rejecting whatever new request
+    // had taken its slot.
     this.rejectPending(new Error('superseded by new worker'));
     if (this.worker) {
       this.worker.terminate();
@@ -51,7 +69,7 @@ export class MachineRunner {
     this.pending = null;
     clearTimeout(p.timer);
     if (data.type === 'error') {
-      p.reject(new Error(data.message));
+      p.reject(new WorkerError(data.message, data.tapes ?? null));
     } else {
       p.resolve(data);
     }
@@ -66,7 +84,7 @@ export class MachineRunner {
   }
 
   private send(msg: WorkerRequest, timeoutMs: number = WORKER_TIMEOUT_MS): Promise<WorkerResponse> {
-    if (!this.worker) throw new Error('worker not spawned — call load() first');
+    if (!this.worker) throw new Error('worker not spawned — call build() first');
     if (this.pending) throw new Error('previous request still pending');
 
     return new Promise<WorkerResponse>((resolve, reject) => {
@@ -83,10 +101,10 @@ export class MachineRunner {
     });
   }
 
-  async load(code: string): Promise<LoadedResponse> {
+  async build(code: string): Promise<BuiltResponse> {
     this.spawnWorker();
-    const r = await this.send({ type: 'load', engine: this.engine, code });
-    if (r.type !== 'loaded') throw new Error(`unexpected response: ${r.type}`);
+    const r = await this.send({ type: 'build', engine: this.engine, code });
+    if (r.type !== 'built') throw new Error(`unexpected response: ${r.type}`);
     return r;
   }
 

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -11,9 +11,8 @@
 import * as turing from '@turing-machine-js/machine';
 import * as post from '@post-machine-js/machine';
 
+import { MAX_STEPS, MAX_TAPES } from './caps.ts';
 import {
-  MAX_STEPS,
-  MAX_TAPES,
   type Command,
   type Engine,
   type Movement,
@@ -77,6 +76,10 @@ function movementCode(m: symbol): Movement {
 }
 
 function commandsFromYield(y: MachineYield): Command[] {
+  // `mv` is a JS Symbol primitive (the upstream library encodes movements as
+  // unique Symbols — `turing.movements.left/right/stay`). Kept short here to
+  // avoid shadowing the surrounding string-typed `movement` (the wire-format
+  // 'L' | 'R' | 'S' code).
   return y.movements.map((mv, i) => {
     const movement = movementCode(mv);
     const written = y.nextSymbols[i];
@@ -86,10 +89,16 @@ function commandsFromYield(y: MachineYield): Command[] {
 }
 
 function snapshotTapes(): TapeSnapshot[] {
+  // Sent on `loaded` (initial state), `ran` (post-run state — halted or
+  // truncated), and `error` (partial state when a step / run threw mid-flight,
+  // e.g. no edge in the state graph for the current symbol). Full tape — no
+  // trim — so the main-thread mirror starts from the user's exact tape and
+  // the user can navigate beyond the initial window without blanks appearing
+  // where original symbols should be. We don't mutate `t.viewportWidth`
+  // either; user tapes stay at the library default.
   return tapes.map((t) => ({
     symbols: [...t.symbols],
     position: t.position,
-    blank: t.alphabet.blankSymbol,
   }));
 }
 
@@ -97,7 +106,7 @@ function snapshotAlphabets(): string[][] {
   return tapes.map((t) => [...t.alphabet.symbols]);
 }
 
-function load(engine: Engine, code: string): void {
+function build(engine: Engine, code: string): void {
   reset();
   const imports: Record<string, unknown> =
     engine === 'post' ? { ...post } : { ...turing };
@@ -174,7 +183,7 @@ function step(): { commands: Command[] | null; nextCommands: Command[] | null } 
 }
 
 function runToEnd(maxSteps: number): { commands: Command[][]; truncated: boolean; startStep: number } {
-  if (!generator) throw new Error('not loaded');
+  if (!generator) throw new Error('not built');
   const startStep = stepsApplied;
   const commands: Command[][] = [];
   let extra = 0;
@@ -200,31 +209,28 @@ function send(msg: WorkerResponse): void {
 self.onmessage = (e: MessageEvent<unknown>) => {
   const msg = e.data;
   if (!msg || typeof msg !== 'object' || !('type' in msg)) {
-    send({ type: 'error', message: 'malformed worker message', stack: null });
+    send({ type: 'error', message: 'malformed worker message' });
     return;
   }
 
   const req = msg as WorkerRequest;
   try {
-    if (req.type === 'load') {
-      load(req.engine, req.code);
+    if (req.type === 'build') {
+      build(req.engine, req.code);
       send({
-        type: 'loaded',
+        type: 'built',
         tapes: snapshotTapes(),
         alphabets: snapshotAlphabets(),
         halted,
-        stepsApplied,
-        nextCommands: pendingCommand ? commandsFromYield(pendingCommand) : null,
       });
       return;
     }
 
     if (req.type === 'step') {
-      if (!machine) throw new Error('not loaded');
+      if (!machine) throw new Error('not built');
       const { commands, nextCommands } = step();
       send({
         type: 'stepped',
-        tapes: snapshotTapes(),
         halted,
         commands,
         nextCommands,
@@ -234,12 +240,11 @@ self.onmessage = (e: MessageEvent<unknown>) => {
     }
 
     if (req.type === 'run') {
-      if (!machine) throw new Error('not loaded');
+      if (!machine) throw new Error('not built');
       const { commands, truncated, startStep } = runToEnd(req.maxSteps ?? MAX_STEPS);
       send({
         type: 'ran',
         tapes: snapshotTapes(),
-        halted,
         truncated,
         commands,
         startStep,
@@ -250,10 +255,14 @@ self.onmessage = (e: MessageEvent<unknown>) => {
 
     throw new Error(`unknown message type: ${(req as { type: string }).type}`);
   } catch (err) {
+    // Carry the current tape state when present — a step/run that errors
+    // mid-flight has typically already applied N steps; sending the partial
+    // state lets the main-thread mirror jump to it instead of stranding the
+    // user on the loaded tape.
     send({
       type: 'error',
       message: err instanceof Error ? err.message : String(err),
-      stack: err instanceof Error ? (err.stack ?? null) : null,
+      tapes: tapes.length > 0 ? snapshotTapes() : undefined,
     });
   }
 };

--- a/src/lib/syntaxLinter.ts
+++ b/src/lib/syntaxLinter.ts
@@ -4,7 +4,7 @@ import { syntaxTree } from '@codemirror/language';
 /**
  * Editor preflight using the Lezer JS parser already loaded by
  * @codemirror/lang-javascript. Catches obvious syntax errors (unclosed braces,
- * missing parens, etc.) before the user clicks Load. Does NOT catch semantic
+ * missing parens, etc.) before the user clicks Build. Does NOT catch semantic
  * issues like `let const = 1` — for that you'd need a real type checker.
  */
 export const syntaxLinter = linter((view) => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,43 +15,60 @@ export type Command = {
   symbol: string | null;
 };
 
+/**
+ * Per-tape alphabets — outer length = tape count, inner = symbols where
+ * index 0 is the blank. Both levels are `readonly` because alphabets are
+ * immutable inputs from the worker, never mutated UI-side.
+ */
+export type Alphabets = readonly (readonly string[])[];
+
+/**
+ * `symbols` is the tape's full backing array (or a viewport the producer
+ * already centered — same shape, different length). `position` is the head
+ * index into `symbols`. The blank symbol is sourced separately from the
+ * matching alphabet (`alphabets[i][0]`) — snapshots aren't self-describing,
+ * but it removes per-snapshot duplication of the alphabet's blank.
+ *
+ * Two producers:
+ * - `machineWorker.ts` on `built` / `ran` / `error`: full tape from user code (no
+ *   trim — the main-thread mirror needs every cell so the user can navigate
+ *   beyond the initial window without blanks where original symbols should
+ *   appear).
+ * - `MachineView.svelte#mirrorSnapshots` after each step: viewport-shaped
+ *   (length `VIEWPORT_WIDTH`, head at the center index). `Tape.svelte`'s
+ *   position-aware indexing handles either uniformly.
+ */
 export type TapeSnapshot = {
   symbols: string[];
   position: number;
-  blank: string;
 };
-
-/** Hard cap on `run`-mode steps before the worker truncates. */
-export const MAX_STEPS = 100_000;
-
-/** Hard cap on a single worker request's wall-clock time. */
-export const WORKER_TIMEOUT_MS = 5_000;
-
-/** UI-side cap on tape count (palette has 5 caret colors). */
-export const MAX_TAPES = 5;
 
 /* ───── worker request / response ───── */
 
 export type WorkerRequest =
-  | { type: 'load'; engine: Engine; code: string }
+  | { type: 'build'; engine: Engine; code: string }
   | { type: 'step' }
   | { type: 'run'; maxSteps?: number };
 
 /* Multi-tape: every shape is per-tape arrays. N=1 for single-tape machines,
  * N=K for K-tape machines (TapeBlock.fromTapes([...K])). */
 
-export type LoadedResponse = {
-  type: 'loaded';
+export type BuiltResponse = {
+  type: 'built';
   tapes: TapeSnapshot[];
   alphabets: string[][];
   halted: boolean;
-  stepsApplied: number;
-  nextCommands: Command[] | null;
 };
 
+/**
+ * `stepped` deliberately omits `tapes` — the main-thread `mirrorMachine`
+ * applies the same `commands` and is the source of truth for tape rendering
+ * (deterministic given identical commands). Initial tape comes from `built`,
+ * post-run tape from `ran`, and a partial tape from `error` if a step / run
+ * threw mid-flight.
+ */
 export type SteppedResponse = {
   type: 'stepped';
-  tapes: TapeSnapshot[];
   halted: boolean;
   commands: Command[] | null;
   nextCommands: Command[] | null;
@@ -61,7 +78,6 @@ export type SteppedResponse = {
 export type RanResponse = {
   type: 'ran';
   tapes: TapeSnapshot[];
-  halted: boolean;
   truncated: boolean;
   commands: Command[][];
   startStep: number;
@@ -71,11 +87,18 @@ export type RanResponse = {
 export type ErrorResponse = {
   type: 'error';
   message: string;
-  stack: string | null;
+  /**
+   * Partial tape state at the moment of failure. Sent when the worker errored
+   * mid-step / mid-run (e.g. no edge in the state graph for the current
+   * symbol) so the main thread can mirror the state where execution stuck —
+   * otherwise the user would see only the loaded tape and lose every step
+   * the worker actually applied before the throw.
+   */
+  tapes?: TapeSnapshot[];
 };
 
 export type WorkerResponse =
-  | LoadedResponse
+  | BuiltResponse
   | SteppedResponse
   | RanResponse
   | ErrorResponse;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,


### PR DESCRIPTION
## Summary

Three intertwined themes:

- **Mirror-machine becomes the source of truth** for tape rendering during stepping. The worker's `stepped` response no longer carries `tapes` — applying a `Command` to a `Tape` is deterministic, so the main-thread mirror replays them. Worker still ships full tape state on `built` (initial), `ran` (final), and `error` (partial state at point of failure, surfaced through a typed `WorkerError`). `Tape.svelte` reads `turing.Tape.viewport` directly via a new `setFromTape(tape, …)` API; `TapeSnapshot` no longer carries `blank` or any UI shape.
- **Component split**: extracted `TapesStack.svelte` (multi-tape stack + head-thread connector) and `Toolbar.svelte` (Build/Step/Run/Stop + with-pause + examples menu) out of the orchestrator, dropping it from 1037 → 761 lines. Renamed `MachineTab.svelte` → `MachineView.svelte` (the file is the active-tab body, not a tab itself).
- **UX overhaul**: Build button (was Load), Stop button next to Run during RUNNING_STEP/AUTO, Step/Run stay enabled in HALTED (reload-from-code), code-changed warning fires once per session, log gets `<hr>` separators per Build/Step/Run, per-tape grouped sections, paper-style command shorthand `(<sym>/<L|R|S>)`, past-tense verbs (kept/wrote/moved/stayed), and the user picks the literal blank glyph (no UI substitution; CSS sugar `.cell.blank` / `.cp-btn.blank` for the visual hint). Bundled examples switched to `'␣'` as the actual blank.

## Worker contract changes

- `load`/`loaded` → `build`/`built` (matches the Build button). `runner.load()` → `runner.build()`.
- `BuiltResponse.{stepsApplied, nextCommands}`, `RanResponse.halted`, `ErrorResponse.stack` dropped (dead).
- `ErrorResponse.tapes?` added (partial state on mid-run failure).

## Naming / consistency

- `cmds`/`cmd` → `commands`/`command`; `mv` → `movement`; `arr`/`cb` → `array`/`callbacks`; `entries` → `logEntries`; `applyTimer`/`flashTimer` → `*TimeoutId`; `describeOne` → `describeAppliedCommand`; `stepEntry`+`appliedEntry` → `commandsEntry(commands, application, colors?)`; `setFromSnapshot` → `setFromTape`; `win` → `viewport`.
- Custom callback props (`onApply`/`onReset`/`onClear`/`onClick`) all camelCase.
- New `Alphabets` type alias for the per-tape readonly nested array.

## CSS / tooling

- Native CSS nesting throughout.
- ES2023 target (for `Array.prototype.with` in `ControlPanel`).
- Favicon + title use first-tape blue (`--accent`); dead `--head-dim` removed; redundant `var()` fallbacks removed.

## Upstream bug filed

[`mellonis/turing-machine-js#95`](https://github.com/mellonis/turing-machine-js/issues/95) — `Tape` constructor accepts `viewportWidth` but doesn't `normalise()`. Workaround: set `viewportWidth` via the setter after construction. Code in `MachineView.svelte#_buildMirrorMachine` carries a `WORKAROUND for …` comment so it can be reverted when the upstream fix lands. CLAUDE.md adds a convention for this pattern.

## Documentation

- `CLAUDE.md` rewritten: architecture tree, MachineView overview, Tape/multi-tape sections, conventions (no UI substitution, CSS nesting, upstream-workaround pattern), caps.
- `README.md` architecture tree synced.

## Closes

- Closes #4

## Test plan

- [x] `npm run check` — 0 errors / 0 warnings / 0 problems
- [ ] Manual smoke: Build (Turing replace-b) → tape shows 23 cells with dimmed blanks
- [ ] Manual smoke: Step / Run / Run-with-pause / Stop / Take Control
- [ ] Manual smoke: Multi-tape (Copy 2 tapes) — head-thread renders, both tapes update
- [ ] Manual smoke: Post engine
- [ ] Manual smoke: Code with intentional state-graph error → tape mirrors partial state, error log appears
- [ ] Manual smoke: localStorage with stale `' '` blank example → user resets via reset button → demo proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)