### PR TITLE
Closes #7 - Show bundled library versions in header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "machines-demo",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "machines-demo",
-      "version": "1.0.0-alpha.3",
+      "version": "1.0.0-alpha.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machines-demo",
   "private": true,
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { turingVersion, postVersion } from 'virtual:lib-versions';
   import MachineView from './components/MachineView.svelte';
   import { icons } from './lib/icons.ts';
   import { ENGINES, type Engine } from './lib/types.ts';
@@ -55,6 +56,21 @@
       Post
     </button>
   </nav>
+  <span class="lib-versions">
+    <a
+      href="https://www.npmjs.com/package/@turing-machine-js/machine"
+      target="_blank"
+      rel="noopener"
+      title="@turing-machine-js/machine on npm"
+    >turing v{turingVersion}</a>
+    <span class="sep" aria-hidden="true">·</span>
+    <a
+      href="https://www.npmjs.com/package/@post-machine-js/machine"
+      target="_blank"
+      rel="noopener"
+      title="@post-machine-js/machine on npm"
+    >post v{postVersion}</a>
+  </span>
   <a
     class="repo-link"
     href="https://github.com/mellonis/machines-demo"
@@ -123,8 +139,30 @@
     }
   }
 
-  .repo-link {
+  .lib-versions {
     margin-left: auto;
+    font-size: 12px;
+    color: var(--muted);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+
+    a {
+      color: inherit;
+      text-decoration: none;
+      transition: color var(--anim-button-hover-ms) ease;
+
+      &:hover {
+        color: var(--fg);
+      }
+    }
+
+    .sep {
+      opacity: 0.6;
+    }
+  }
+
+  .repo-link {
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,3 +5,8 @@ declare module '*.svg?raw' {
   const content: string;
   export default content;
 }
+
+declare module 'virtual:lib-versions' {
+  export const turingVersion: string;
+  export const postVersion: string;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,27 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { readFileSync } from 'node:fs';
+
+const pkgVersion = (pkg: string): string =>
+  JSON.parse(readFileSync(`./node_modules/${pkg}/package.json`, 'utf-8')).version;
+
+const VIRTUAL_ID = 'virtual:lib-versions';
+
+const libVersions = (): Plugin => ({
+  name: 'lib-versions',
+  resolveId(id) {
+    if (id === VIRTUAL_ID) return `\0${VIRTUAL_ID}`;
+  },
+  load(id) {
+    if (id !== `\0${VIRTUAL_ID}`) return;
+    const turing = pkgVersion('@turing-machine-js/machine');
+    const post = pkgVersion('@post-machine-js/machine');
+    return `export const turingVersion = ${JSON.stringify(turing)};
+export const postVersion = ${JSON.stringify(post)};
+`;
+  },
+});
 
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [svelte(), libVersions()],
 });


### PR DESCRIPTION
## Summary
- Display the resolved versions of `@turing-machine-js/machine` and `@post-machine-js/machine` as a small dim line in the app header (linked to npm).
- Versions are read from each package's installed `package.json` and exposed via a tiny Vite virtual module so they bake in for both `dev` and `build`. (A plain `define` did not substitute inside compiled `.svelte` files at dev time.)
- Bumps the demo's own version to `1.0.0-alpha.4`.

This is the minimum scope of #7. The version-picker extension is left open.

## Test plan
- [x] `npm run check`
- [x] `npm run lint`
- [x] `npm run build` — bundle contains both `turing v3.0.1` / `post v3.0.1`
- [x] dev server resolves `virtual:lib-versions` correctly
- [ ] visual check on desktop + 768px breakpoint (deferred to reviewer — author could not open Chrome to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)