### PR TITLE
Bump to 1.0.0-alpha.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "machines-demo",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "machines-demo",
-      "version": "1.0.0-alpha.6",
+      "version": "1.0.0-alpha.7",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machines-demo",
   "private": true,
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Cuts a new alpha for the deploy that ships the @turing-machine-js/machine 3.0.2 upgrade + the #95 workaround removal (PR #15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)