### PR TITLE
Closes #17 — Sandbox: block network/timer/concurrency globals in worker user code

### DIFF
--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -49,6 +49,50 @@ type MachineYield = {
   nextSymbols: string[];
 };
 
+/* ───── sandbox: ban ambient capabilities user code shouldn't reach ─────
+ *
+ * The engine is synchronous and the worker boundary already isolates the
+ * main thread, so network/timer/concurrency APIs have no legitimate use in
+ * user code. Two layers, both best-effort:
+ *
+ *   1. Parameter shadow inside `build()` — bare references like `fetch(...)`
+ *      resolve to the function parameter (a stub that throws an informative
+ *      error) instead of the worker global.
+ *   2. `globalThis` redefine, applied once at worker startup — catches
+ *      `globalThis.fetch` / `self.fetch` and similar.
+ *
+ * Bypass paths exist in pure JS: `(new Function('return this'))()` (the
+ * Function constructor evaluates in global scope, escaping the parameter
+ * shadow), and `(0, eval)('globalThis')`. `Promise` stays available — the
+ * engine is synchronous so `await` is a no-op for stepping anyway, but
+ * blocking it would make most JS unwriteable. For airtight isolation see
+ * issue #18 (ShadowRealm).
+ */
+
+const SANDBOX_BLOCKED_GLOBALS = [
+  'fetch', 'XMLHttpRequest', 'WebSocket', 'EventSource',
+  'BroadcastChannel', 'MessageChannel',
+  'setTimeout', 'setInterval', 'clearTimeout', 'clearInterval',
+  'queueMicrotask', 'requestIdleCallback', 'cancelIdleCallback',
+  'Worker', 'importScripts',
+] as const;
+
+const sandboxStub = (name: string) => () => {
+  throw new Error(`${name} is not available in this sandbox`);
+};
+
+for (const name of SANDBOX_BLOCKED_GLOBALS) {
+  try {
+    Object.defineProperty(globalThis, name, {
+      get: sandboxStub(name),
+      configurable: true,
+    });
+  } catch {
+    // Some hosts may have non-configurable globals; the parameter shadow
+    // in `build()` is the primary defense and still applies.
+  }
+}
+
 /* ───── runtime state ───── */
 
 let machine: AnyMachine | null = null;
@@ -111,8 +155,11 @@ function build(engine: Engine, code: string): void {
   const imports: Record<string, unknown> =
     engine === 'post' ? { ...post } : { ...turing };
 
-  const userFn = new Function('imports', code) as (i: Record<string, unknown>) => unknown;
-  const result = userFn(imports);
+  const userFn = new Function('imports', ...SANDBOX_BLOCKED_GLOBALS, code) as (
+    i: Record<string, unknown>,
+    ...stubs: unknown[]
+  ) => unknown;
+  const result = userFn(imports, ...SANDBOX_BLOCKED_GLOBALS.map(sandboxStub));
 
   if (!result || typeof result !== 'object') {
     throw new Error('user code must return { machine, initialState?, tape? }');


### PR DESCRIPTION
## Summary

User code in the Web Worker now resolves `fetch`, `setTimeout`, etc. to a stub that throws `${name} is not available in this sandbox` — instead of either the worker global (silent async behavior the synchronous engine never observes) or `undefined` (cryptic "undefined is not a function" stacks).

Two best-effort layers in `src/lib/machineWorker.ts`:

1. **Parameter shadow** inside `build()` — `new Function` takes the banned names as parameters, so bare references like `fetch(...)` in user code resolve to the throwing stub instead of the worker global.
2. **`globalThis` redefine**, run once at worker startup — catches `globalThis.fetch` / `self.fetch` paths.

Bypass paths exist in pure JS (`Function('return this')()`, indirect `eval`); documented inline pointing to #18 for the airtight ShadowRealm path. `Promise` stays available — blocking it would make most JS unwriteable and the engine is synchronous regardless.

Banned set: `fetch`, `XMLHttpRequest`, `WebSocket`, `EventSource`, `BroadcastChannel`, `MessageChannel`, `setTimeout`, `setInterval`, `clearTimeout`, `clearInterval`, `queueMicrotask`, `requestIdleCallback`, `cancelIdleCallback`, `Worker`, `importScripts`.

Closes #17.

## Test plan

- [x] `npm run check` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean (worker bundle 33 kB)
- [ ] Browser smoke test: paste `fetch('https://example.com')` into the editor, click Build, expect `Error: fetch is not available in this sandbox` in the log
- [ ] Browser regression: bundled examples (Turing + Post default snippets) still build and step