### PR TITLE
Bump to 1.0.0-alpha.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "machines-demo",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "machines-demo",
-      "version": "1.0.0-alpha.7",
+      "version": "1.0.0-alpha.8",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machines-demo",
   "private": true,
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Releases #17 (sandbox: block network/timer/concurrency globals in worker user code).