### PR TITLE
Closes #3 — Add light/dark/system theme support

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     />
     <meta name="author" content="Ruslan Gilmullin" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <script src="/theme-init.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^4.0.0",
         "@tsconfig/svelte": "^5.0.4",
+        "@types/node": "^24.12.2",
         "eslint": "^9.0.0",
         "eslint-plugin-svelte": "^2.46.0",
         "svelte": "^5.0.0",
@@ -1276,6 +1277,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -3132,6 +3143,13 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "@tsconfig/svelte": "^5.0.4",
+    "@types/node": "^24.12.2",
     "eslint": "^9.0.0",
     "eslint-plugin-svelte": "^2.46.0",
     "svelte": "^5.0.0",

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -2,7 +2,22 @@
    so it runs before the SPA bundle and before first paint, preventing a
    flash between the default-rendered theme and the saved/preferred one.
    Lives in public/ rather than inline because the production CSP is
-   `script-src 'self' 'unsafe-eval'` (no 'unsafe-inline'). */
+   `script-src 'self' 'unsafe-eval'` (no 'unsafe-inline').
+
+   Two things happen here:
+
+   1. Set <html data-theme>. CSS in app.css branches on this attribute and
+      flips token values for the light theme.
+
+   2. Paint <html> with the resolved theme's bg + fg via inline style.
+      Production has its CSS link in <head> (render-blocking), so step 1
+      alone is enough there. But `npm run dev` injects CSS via the JS
+      module at runtime — between paint and that injection the body
+      renders with browser-default white, then snaps to the dark theme
+      once styles arrive. The inline style on documentElement covers that
+      gap; once the real CSS loads, its rules on `html, body` override
+      the inline value with the same tokens. Keep these literals in sync
+      with the matching tokens in app.css. */
 (function () {
   try {
     var saved = localStorage.getItem('machines-demo:theme');
@@ -15,7 +30,15 @@
     var resolved = saved === 'dark' || saved === 'light'
       ? saved
       : (prefersLight ? 'light' : 'dark');
-    document.documentElement.setAttribute('data-theme', resolved);
+    var root = document.documentElement;
+    root.setAttribute('data-theme', resolved);
+    if (resolved === 'light') {
+      root.style.backgroundColor = '#ffffff';
+      root.style.color = '#1a1b1e';
+    } else {
+      root.style.backgroundColor = '#1a1b1e';
+      root.style.color = '#e6e6e6';
+    }
   } catch (_e) {
     /* localStorage may throw in private modes / sandboxed contexts —
        fall back to default (dark) by leaving the attribute unset. */

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -1,0 +1,23 @@
+/* Sync, pre-paint theme bootstrap. Loaded as a classic <script> in <head>
+   so it runs before the SPA bundle and before first paint, preventing a
+   flash between the default-rendered theme and the saved/preferred one.
+   Lives in public/ rather than inline because the production CSP is
+   `script-src 'self' 'unsafe-eval'` (no 'unsafe-inline'). */
+(function () {
+  try {
+    var saved = localStorage.getItem('machines-demo:theme');
+    var prefersLight = window.matchMedia
+      && window.matchMedia('(prefers-color-scheme: light)').matches;
+    /* Saved choice is one of 'system' | 'dark' | 'light'. 'system' (and any
+       missing/legacy value) resolves through prefers-color-scheme. The DOM
+       attribute always carries a concrete 'dark' | 'light' so CSS selectors
+       match without a system-aware fallback path. */
+    var resolved = saved === 'dark' || saved === 'light'
+      ? saved
+      : (prefersLight ? 'light' : 'dark');
+    document.documentElement.setAttribute('data-theme', resolved);
+  } catch (_e) {
+    /* localStorage may throw in private modes / sandboxed contexts —
+       fall back to default (dark) by leaving the attribute unset. */
+  }
+})();

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { turingVersion, postVersion } from 'virtual:lib-versions';
+  import { turingVersion, postVersion, appVersion } from 'virtual:lib-versions';
   import MachineView from './components/MachineView.svelte';
   import { icons } from './lib/icons.ts';
+  import { theme } from './lib/theme.svelte.ts';
   import { ENGINES, type Engine } from './lib/types.ts';
 
   function readEngineFromUrl(): Engine {
@@ -36,6 +37,16 @@
     }
     history.pushState(null, '', url);
   }
+
+  const themeIcon = $derived(
+    theme.current === 'system'
+      ? icons.deviceDesktop
+      : theme.current === 'light' ? icons.sun : icons.moon,
+  );
+  const themeNext = $derived(
+    theme.current === 'system' ? 'light' : theme.current === 'light' ? 'dark' : 'system',
+  );
+  const themeLabel = $derived(`Theme: ${theme.current} — click to switch to ${themeNext}`);
 </script>
 
 <header>
@@ -56,6 +67,26 @@
       Post
     </button>
   </nav>
+  <button
+    type="button"
+    class="theme-toggle"
+    onclick={() => theme.cycle()}
+    title={themeLabel}
+    aria-label={themeLabel}
+  >
+    {@html themeIcon}
+  </button>
+</header>
+
+<main>
+  {#key activeEngine}
+    <MachineView engine={activeEngine} />
+  {/key}
+</main>
+
+<footer>
+  <span class="app-version" title="machines-demo version">v{appVersion}</span>
+  <span class="sep" aria-hidden="true">·</span>
   <span class="lib-versions">
     <a
       href="https://www.npmjs.com/package/@turing-machine-js/machine"
@@ -81,13 +112,7 @@
   >
     {@html icons.github}
   </a>
-</header>
-
-<main>
-  {#key activeEngine}
-    <MachineView engine={activeEngine} />
-  {/key}
-</main>
+</footer>
 
 <style>
   header {
@@ -139,30 +164,11 @@
     }
   }
 
-  .lib-versions {
+  /* Theme toggle sits at the right end of the header — pushed there by
+     `margin-left: auto` since the lib-versions chunk that previously held
+     that role moved to the footer. */
+  .theme-toggle {
     margin-left: auto;
-    font-size: 12px;
-    color: var(--muted);
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-
-    a {
-      color: inherit;
-      text-decoration: none;
-      transition: color var(--anim-button-hover-ms) ease;
-
-      &:hover {
-        color: var(--fg);
-      }
-    }
-
-    .sep {
-      opacity: 0.6;
-    }
-  }
-
-  .repo-link {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -170,11 +176,15 @@
     height: 28px;
     border-radius: 6px;
     color: var(--muted);
-    text-decoration: none;
+    background: transparent;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font: inherit;
     transition: background-color var(--anim-button-hover-ms) ease, color var(--anim-button-hover-ms) ease;
 
     &:hover {
-      background: rgba(255, 255, 255, 0.06);
+      background: var(--hover-bg);
       color: var(--fg);
     }
 
@@ -192,6 +202,62 @@
 
     @media (max-width: 768px) {
       overflow: auto;
+    }
+  }
+
+  /* Bottom-right meta strip: app + lib versions + GitHub link. Compact and
+     low-emphasis; mirrors the header's muted treatment. */
+  footer {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    font-size: 11px;
+    color: var(--muted);
+    border-top: 1px solid var(--cell-border);
+
+    a {
+      color: inherit;
+      text-decoration: none;
+      transition: color var(--anim-button-hover-ms) ease;
+
+      &:hover {
+        color: var(--fg);
+      }
+    }
+
+    .sep {
+      opacity: 0.6;
+    }
+  }
+
+  .lib-versions {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .repo-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    margin-left: 4px;
+    border-radius: 4px;
+    color: var(--muted);
+    transition: background-color var(--anim-button-hover-ms) ease, color var(--anim-button-hover-ms) ease;
+
+    &:hover {
+      background: var(--hover-bg);
+      color: var(--fg);
+    }
+
+    :global(svg) {
+      width: 14px;
+      height: 14px;
+      display: block;
     }
   }
 </style>

--- a/src/app.css
+++ b/src/app.css
@@ -20,8 +20,16 @@
 
   /* editor / log surface — matches the CodeMirror oneDark background so the
      left-side log and right-side editor read as the same kind of read-only
-     dark surface. */
+     dark surface. Light-theme override below targets CodeMirror's default
+     (no oneDark) light bg so the pairing holds in both themes. */
   --editor-bg: #282c34;
+
+  /* semantic surface tints — overlay-on-surface hover, subtle dividers,
+     drop shadows. Defined as tokens so light/dark themes can flip the
+     base color while components stay theme-agnostic. */
+  --hover-bg: rgba(255, 255, 255, 0.06);
+  --divider: rgba(255, 255, 255, 0.05);
+  --shadow: rgba(0, 0, 0, 0.35);
 
   /* animation timings */
   --anim-belt-slide-ms: 400ms;
@@ -32,6 +40,59 @@
 
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   color-scheme: dark;
+}
+
+/* Light theme. Applied either by the FOUC-safe init script setting
+   `<html data-theme="light">` (explicit user choice or first-load OS
+   preference), or by the system-preference fallback below for the rare
+   case the init script didn't run. */
+:root[data-theme='light'] {
+  --bg: #ffffff;
+  --fg: #1a1b1e;
+  --muted: #5a5d63;
+  --accent: #2563eb;
+  --cell-bg: #f5f5f7;
+  --cell-border: #d0d0d4;
+  --head: #d97706;
+  --error: #dc2626;
+  --warn: #b45309;
+  --ok: #16a34a;
+
+  --surface-bg: rgba(0, 0, 0, 0.04);
+  --editor-bg: #ffffff;
+
+  --hover-bg: rgba(0, 0, 0, 0.06);
+  --divider: rgba(0, 0, 0, 0.06);
+  --shadow: rgba(0, 0, 0, 0.12);
+
+  color-scheme: light;
+}
+
+/* CSS-only fallback: if the init script didn't set an attribute (e.g. it
+   failed to load), still respect the OS preference. The init script is
+   the primary path — it handles the saved-choice case. */
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) {
+    --bg: #ffffff;
+    --fg: #1a1b1e;
+    --muted: #5a5d63;
+    --accent: #2563eb;
+    --cell-bg: #f5f5f7;
+    --cell-border: #d0d0d4;
+    --head: #d97706;
+    --error: #dc2626;
+    --warn: #b45309;
+    --ok: #16a34a;
+
+    --surface-bg: rgba(0, 0, 0, 0.04);
+    --editor-bg: #ffffff;
+
+    --hover-bg: rgba(0, 0, 0, 0.06);
+    --divider: rgba(0, 0, 0, 0.06);
+    --shadow: rgba(0, 0, 0, 0.12);
+
+    color-scheme: light;
+  }
 }
 
 *,

--- a/src/components/ControlPanel.svelte
+++ b/src/components/ControlPanel.svelte
@@ -203,7 +203,7 @@
     padding: 4px 0;
 
     & + & {
-      border-top: 1px solid rgba(255, 255, 255, 0.05);
+      border-top: 1px solid var(--divider);
     }
   }
 
@@ -259,7 +259,7 @@
     &.movement {
       margin-left: auto;
       padding-left: 8px;
-      border-left: 1px solid rgba(255, 255, 255, 0.05);
+      border-left: 1px solid var(--divider);
     }
   }
 
@@ -267,7 +267,7 @@
     display: flex;
     justify-content: flex-end;
     padding-top: 6px;
-    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    border-top: 1px solid var(--divider);
   }
 
   .cp-btn {
@@ -278,7 +278,7 @@
     height: 28px;
     padding: 4px 8px;
     background: var(--cell-bg);
-    border: 1px solid rgba(255, 255, 255, 0.06);
+    border: 1px solid var(--hover-bg);
     color: var(--fg);
     border-radius: 4px;
     cursor: pointer;
@@ -291,7 +291,7 @@
       color var(--anim-button-hover-ms) ease;
 
     &:hover {
-      border-color: rgba(110, 168, 254, 0.5);
+      border-color: color-mix(in srgb, var(--accent) 50%, transparent);
       color: var(--accent);
     }
 
@@ -301,18 +301,18 @@
        even when the blank symbol is an invisible space. */
     &.blank {
       min-width: 30px;
-      border-color: color-mix(in srgb, rgba(255, 255, 255, 0.06) 40%, var(--cell-bg));
+      border-color: color-mix(in srgb, var(--hover-bg) 40%, var(--cell-bg));
       color: color-mix(in srgb, var(--fg) 40%, var(--cell-bg));
     }
 
     &.selected {
-      background: rgba(110, 168, 254, 0.2);
+      background: color-mix(in srgb, var(--accent) 20%, transparent);
       border-color: var(--accent);
       color: var(--accent);
     }
 
     &.pressed {
-      background: rgba(110, 168, 254, 0.4);
+      background: color-mix(in srgb, var(--accent) 40%, transparent);
       border-color: var(--accent);
       color: var(--accent);
       transform: scale(0.96);

--- a/src/components/ControlPanel.svelte
+++ b/src/components/ControlPanel.svelte
@@ -83,6 +83,30 @@
     { code: 'S', svg: icons.stay, label: 'stay' },
     { code: 'R', svg: icons.right, label: 'right' },
   ];
+
+  // Svelte action: tracks horizontal scroll position on the symbols row and
+  // toggles `can-scroll-left` / `can-scroll-right` classes. CSS uses these
+  // classes to drive a mask-image fade so the edges of the row hint at
+  // off-screen content only when there's actually content there to scroll
+  // to. Fires on scroll and on resize (alphabet length / panel width).
+  function scrollEdgeIndicator(node: HTMLElement) {
+    const update = () => {
+      const atLeft = node.scrollLeft <= 0;
+      const atRight = node.scrollLeft + node.clientWidth >= node.scrollWidth - 1;
+      node.classList.toggle('can-scroll-left', !atLeft);
+      node.classList.toggle('can-scroll-right', !atRight);
+    };
+    update();
+    node.addEventListener('scroll', update, { passive: true });
+    const ro = new ResizeObserver(update);
+    ro.observe(node);
+    return {
+      destroy() {
+        node.removeEventListener('scroll', update);
+        ro.disconnect();
+      },
+    };
+  }
 </script>
 
 <div
@@ -102,37 +126,39 @@
           <span class="tape-label">Tape {i + 1}</span>
         {/if}
         <div class="row symbols">
-          <button
-            type="button"
-            class="cp-btn keep"
-            class:selected={symbols[i] === null}
-            title="Keep current symbol"
-            aria-label={showTapeLabels
-              ? `Tape ${i + 1}: keep current symbol`
-              : 'Keep current symbol'}
-            onclick={() => selectSymbol(i, null)}
-          >
-            {@html icons.keep}
-          </button>
-          <!-- `sym` not `symbol` — the latter shadows the built-in TS/JS
-               `symbol` type the upstream library uses for movement primitives.
-               No UI substitution: the button shows the literal alphabet
-               symbol, including whatever the user picked for blank. -->
-          {#each alpha as sym, j (j)}
+          <div class="symbols-scroll" use:scrollEdgeIndicator>
             <button
               type="button"
-              class="cp-btn"
-              class:blank={j === 0}
-              class:selected={symbols[i] === sym}
-              title={j === 0 ? 'Write blank' : `Write ${sym}`}
+              class="cp-btn keep"
+              class:selected={symbols[i] === null}
+              title="Keep current symbol"
               aria-label={showTapeLabels
-                ? `Tape ${i + 1}: ${j === 0 ? 'write blank' : `write ${sym}`}`
-                : j === 0 ? 'Write blank' : `Write ${sym}`}
-              onclick={() => selectSymbol(i, sym)}
+                ? `Tape ${i + 1}: keep current symbol`
+                : 'Keep current symbol'}
+              onclick={() => selectSymbol(i, null)}
             >
-              {sym}
+              {@html icons.keep}
             </button>
-          {/each}
+            <!-- `sym` not `symbol` — the latter shadows the built-in TS/JS
+                 `symbol` type the upstream library uses for movement primitives.
+                 No UI substitution: the button shows the literal alphabet
+                 symbol, including whatever the user picked for blank. -->
+            {#each alpha as sym, j (j)}
+              <button
+                type="button"
+                class="cp-btn"
+                class:blank={j === 0}
+                class:selected={symbols[i] === sym}
+                title={j === 0 ? 'Write blank' : `Write ${sym}`}
+                aria-label={showTapeLabels
+                  ? `Tape ${i + 1}: ${j === 0 ? 'write blank' : `write ${sym}`}`
+                  : j === 0 ? 'Write blank' : `Write ${sym}`}
+                onclick={() => selectSymbol(i, sym)}
+              >
+                {sym}
+              </button>
+            {/each}
+          </div>
         </div>
         <div class="row movement">
           {#each MOVEMENT_BUTTONS as b (b.code)}
@@ -235,31 +261,95 @@
     flex-wrap: wrap;
 
     &.symbols {
+      /* Outer is the flex item that participates in .tape-row layout.
+         Splitting layout (outer) from overflow (inner .symbols-scroll)
+         is required: a single element doing both didn't scroll because
+         the flex algorithm derives its width from content, defeating
+         the overflow clip. */
       flex: 1;
       min-width: 0;
-
-      /* Long alphabets shouldn't wrap a second row on a narrow phone — let
-         the symbols row scroll horizontally. */
-      @media (max-width: 768px) {
-        flex-wrap: nowrap;
-        overflow-x: auto;
-        scrollbar-width: none;
-        -webkit-overflow-scrolling: touch;
-
-        &::-webkit-scrollbar {
-          display: none;
-        }
-
-        .cp-btn {
-          flex-shrink: 0;
-        }
-      }
+      display: block;
     }
 
     &.movement {
       margin-left: auto;
       padding-left: 8px;
       border-left: 1px solid var(--divider);
+    }
+  }
+
+  /* Inner scroll container for the symbols row — owns the overflow.
+     Long alphabets scroll horizontally instead of wrapping, so each
+     tape's row height stays constant and chips line up across tapes.
+
+     Edge fades: the `can-scroll-*` classes are toggled by the
+     scrollEdgeIndicator action; `mask-image` softens whichever edge
+     has off-screen content so the user sees an affordance for scroll. */
+  .symbols-scroll {
+    --edge-fade: 20px;
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 4px;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    .cp-btn {
+      flex-shrink: 0;
+    }
+
+    /* `can-scroll-*` classes are toggled at runtime by the
+       scrollEdgeIndicator action — Svelte's CSS scoper can't see
+       them in the template, hence :global(...). */
+    &:global(.can-scroll-left.can-scroll-right) {
+      -webkit-mask-image: linear-gradient(
+        to right,
+        transparent 0,
+        black var(--edge-fade),
+        black calc(100% - var(--edge-fade)),
+        transparent 100%
+      );
+      mask-image: linear-gradient(
+        to right,
+        transparent 0,
+        black var(--edge-fade),
+        black calc(100% - var(--edge-fade)),
+        transparent 100%
+      );
+    }
+
+    &:global(.can-scroll-left:not(.can-scroll-right)) {
+      -webkit-mask-image: linear-gradient(
+        to right,
+        transparent 0,
+        black var(--edge-fade),
+        black 100%
+      );
+      mask-image: linear-gradient(
+        to right,
+        transparent 0,
+        black var(--edge-fade),
+        black 100%
+      );
+    }
+
+    &:global(.can-scroll-right:not(.can-scroll-left)) {
+      -webkit-mask-image: linear-gradient(
+        to right,
+        black 0,
+        black calc(100% - var(--edge-fade)),
+        transparent 100%
+      );
+      mask-image: linear-gradient(
+        to right,
+        black 0,
+        black calc(100% - var(--edge-fade)),
+        transparent 100%
+      );
     }
   }
 

--- a/src/components/Editor.svelte
+++ b/src/components/Editor.svelte
@@ -5,6 +5,7 @@
   import { importsCompletion } from '../lib/completions.ts';
   import { syntaxLinter } from '../lib/syntaxLinter.ts';
   import { saveCode } from '../lib/persist.ts';
+  import { theme } from '../lib/theme.svelte.ts';
   import IconButton from './IconButton.svelte';
   import type { Engine } from '../lib/types.ts';
 
@@ -23,7 +24,14 @@
   });
 
   const lang = javascript();
-  const extensions = $derived([...importsCompletion(engine), syntaxLinter]);
+  // Bundle oneDark only when the dark theme is active; the light theme falls
+  // back to CodeMirror's default highlighting so the editor reads as a plain
+  // light surface paired with --editor-bg.
+  const extensions = $derived(
+    theme.current === 'dark'
+      ? [oneDark, ...importsCompletion(engine), syntaxLinter]
+      : [...importsCompletion(engine), syntaxLinter],
+  );
 </script>
 
 <div class="editor">
@@ -31,7 +39,6 @@
   <CodeMirror
     bind:value={code}
     {lang}
-    theme={oneDark}
     {extensions}
   />
 </div>

--- a/src/components/Editor.svelte
+++ b/src/components/Editor.svelte
@@ -54,6 +54,16 @@
     border-radius: 6px;
     overflow: hidden;
 
+    /* svelte-codemirror-editor wraps CodeMirror in <div
+       class="codemirror-wrapper">. Without an explicit height on that
+       wrapper, .cm-editor's `height: 100%` resolves against an auto-
+       sized parent and CodeMirror's internal .cm-scroller never gets a
+       definite height — so the editor grows to its full code height
+       instead of scrolling internally. */
+    :global(.codemirror-wrapper) {
+      height: 100%;
+    }
+
     :global(.cm-editor) {
       height: 100%;
       font-size: 13px;

--- a/src/components/Editor.svelte
+++ b/src/components/Editor.svelte
@@ -24,11 +24,13 @@
   });
 
   const lang = javascript();
-  // Bundle oneDark only when the dark theme is active; the light theme falls
-  // back to CodeMirror's default highlighting so the editor reads as a plain
-  // light surface paired with --editor-bg.
+  // Bundle oneDark only when the *resolved* theme is dark; the light theme
+  // falls back to CodeMirror's default highlighting paired with --editor-bg.
+  // Use `resolved`, not `current`: `current` may be 'system', and a 'system'
+  // choice on a dark OS would otherwise drop oneDark while the rest of the
+  // page renders dark.
   const extensions = $derived(
-    theme.current === 'dark'
+    theme.resolved === 'dark'
       ? [oneDark, ...importsCompletion(engine), syntaxLinter]
       : [...importsCompletion(engine), syntaxLinter],
   );

--- a/src/components/IconButton.svelte
+++ b/src/components/IconButton.svelte
@@ -43,7 +43,7 @@
     justify-content: center;
 
     &:hover {
-      background: rgba(255, 255, 255, 0.06);
+      background: var(--hover-bg);
       color: var(--fg);
     }
 

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -20,7 +20,6 @@
   } from '../lib/defaultCode.ts';
   import { loadCode, loadExampleId, saveExampleId } from '../lib/persist.ts';
   import { icons } from '../lib/icons.ts';
-  import pkg from '../../package.json';
 
   type Props = { engine: Engine };
   let { engine }: Props = $props();
@@ -37,7 +36,6 @@
     '#c084fc', // purple
     '#ffd166', // amber
   ];
-  const APP_VERSION = pkg.version;
 
   type ExecutionMode =
     | 'DEMO'
@@ -576,7 +574,6 @@
     {:catch err}
       <div class="editor-error">Failed to load editor: {err.message}</div>
     {/await}
-    <div class="version">v{APP_VERSION}</div>
   </div>
 </section>
 
@@ -675,14 +672,6 @@
       flex-shrink: 0;
       opacity: 0.85;
     }
-  }
-
-  .version {
-    font-family: ui-monospace, 'SF Mono', Consolas, monospace;
-    font-size: 11px;
-    color: var(--muted);
-    text-align: right;
-    padding-top: 4px;
   }
 
   .editor-loading,

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -650,8 +650,8 @@
     height: 30px;
     padding: 4px 12px;
     background: transparent;
-    border: 1px solid rgba(95, 208, 104, 0.28);
-    color: rgba(95, 208, 104, 0.7);
+    border: 1px solid color-mix(in srgb, var(--ok) 28%, transparent);
+    color: color-mix(in srgb, var(--ok) 70%, transparent);
     border-radius: 6px;
     cursor: pointer;
     font: inherit;
@@ -663,7 +663,7 @@
       color var(--anim-button-hover-ms) ease;
 
     &:hover {
-      background: rgba(95, 208, 104, 0.14);
+      background: color-mix(in srgb, var(--ok) 14%, transparent);
       border-color: var(--ok);
       color: var(--ok);
     }

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -192,8 +192,8 @@
   }
 
   .stop-btn {
-    border-color: rgba(255, 107, 107, 0.4);
-    color: rgba(255, 107, 107, 0.8);
+    border-color: color-mix(in srgb, var(--error) 40%, transparent);
+    color: color-mix(in srgb, var(--error) 80%, transparent);
 
     &:hover {
       border-color: var(--error) !important;
@@ -226,7 +226,7 @@
     background: var(--cell-bg);
     border: 1px solid var(--surface-border);
     border-radius: 6px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+    box-shadow: 0 8px 24px var(--shadow);
 
     li {
       list-style: none;
@@ -246,13 +246,13 @@
       cursor: pointer;
 
       &:hover {
-        background: rgba(110, 168, 254, 0.14);
+        background: color-mix(in srgb, var(--accent) 14%, transparent);
         color: var(--accent);
       }
 
       &.selected {
         color: var(--accent);
-        background: rgba(110, 168, 254, 0.18);
+        background: color-mix(in srgb, var(--accent) 18%, transparent);
       }
     }
   }

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -1,10 +1,12 @@
 import apply from '@tabler/icons/outline/corner-down-left.svg?raw';
 import build from '@tabler/icons/outline/hammer.svg?raw';
+import deviceDesktop from '@tabler/icons/outline/device-desktop.svg?raw';
 import eraser from '@tabler/icons/outline/eraser.svg?raw';
 import examples from '@tabler/icons/outline/file-code.svg?raw';
 import github from '@tabler/icons/outline/brand-github.svg?raw';
 import keep from '@tabler/icons/outline/keyframe-align-vertical.svg?raw';
 import left from '@tabler/icons/outline/arrow-narrow-left.svg?raw';
+import moon from '@tabler/icons/outline/moon.svg?raw';
 import pause from '@tabler/icons/outline/player-pause.svg?raw';
 import resetCode from '@tabler/icons/outline/arrow-back-up.svg?raw';
 import right from '@tabler/icons/outline/arrow-narrow-right.svg?raw';
@@ -12,16 +14,19 @@ import run from '@tabler/icons/outline/player-play.svg?raw';
 import stay from '@tabler/icons/outline/keyframe-align-horizontal.svg?raw';
 import step from '@tabler/icons/outline/player-skip-forward.svg?raw';
 import stop from '@tabler/icons/outline/player-stop.svg?raw';
+import sun from '@tabler/icons/outline/sun.svg?raw';
 import takeControl from '@tabler/icons/outline/device-gamepad-2.svg?raw';
 
 export const icons = {
   apply,
   build,
+  deviceDesktop,
   eraser,
   examples,
   github,
   keep,
   left,
+  moon,
   pause,
   resetCode,
   right,
@@ -29,6 +34,7 @@ export const icons = {
   stay,
   step,
   stop,
+  sun,
   takeControl,
 } as const;
 

--- a/src/lib/persist.ts
+++ b/src/lib/persist.ts
@@ -2,6 +2,26 @@ import type { Engine } from './types.ts';
 
 const CODE_KEY_PREFIX = 'machines-demo:code:';
 const EXAMPLE_KEY_PREFIX = 'machines-demo:example:';
+const THEME_KEY = 'machines-demo:theme';
+
+export type Theme = 'system' | 'dark' | 'light';
+
+export function loadTheme(): Theme | null {
+  try {
+    const v = localStorage.getItem(THEME_KEY);
+    return v === 'dark' || v === 'light' || v === 'system' ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveTheme(theme: Theme): void {
+  try {
+    localStorage.setItem(THEME_KEY, theme);
+  } catch {
+    /* ignore */
+  }
+}
 
 export function loadCode(engine: Engine): string | null {
   try {

--- a/src/lib/theme.svelte.ts
+++ b/src/lib/theme.svelte.ts
@@ -1,0 +1,62 @@
+import { loadTheme, saveTheme, type Theme } from './persist.ts';
+
+export type ResolvedTheme = 'dark' | 'light';
+
+const SYSTEM_QUERY = '(prefers-color-scheme: light)';
+
+function systemPrefersLight(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia(SYSTEM_QUERY).matches;
+}
+
+function resolve(choice: Theme): ResolvedTheme {
+  if (choice === 'dark' || choice === 'light') return choice;
+  return systemPrefersLight() ? 'light' : 'dark';
+}
+
+function applyToDom(resolved: ResolvedTheme): void {
+  document.documentElement.setAttribute('data-theme', resolved);
+}
+
+// User's choice — saved value, defaulting to 'system'. The DOM attribute is
+// the *resolved* theme (always 'dark' | 'light' so CSS selectors match
+// without a system-aware fallback path).
+class ThemeStore {
+  current = $state<Theme>(loadTheme() ?? 'system');
+  resolved = $state<ResolvedTheme>(resolve(loadTheme() ?? 'system'));
+
+  constructor() {
+    // While 'system' is active, follow OS appearance changes live so the
+    // page flips with the OS without requiring a reload.
+    const mq = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia(SYSTEM_QUERY)
+      : null;
+    mq?.addEventListener?.('change', () => {
+      if (this.current !== 'system') return;
+      const next: ResolvedTheme = mq.matches ? 'light' : 'dark';
+      this.resolved = next;
+      applyToDom(next);
+    });
+  }
+
+  set(next: Theme): void {
+    if (this.current === next) return;
+    this.current = next;
+    const resolved = resolve(next);
+    this.resolved = resolved;
+    applyToDom(resolved);
+    saveTheme(next);
+  }
+
+  /* Cycle order: system → light → dark → system. The icon shown reflects the
+     current choice (device-desktop / sun / moon), so each click advances by
+     one and the user can read what they're switching from. */
+  cycle(): void {
+    const order: Theme[] = ['system', 'light', 'dark'];
+    const i = order.indexOf(this.current);
+    this.set(order[(i + 1) % order.length]);
+  }
+}
+
+export const theme = new ThemeStore();

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -9,4 +9,5 @@ declare module '*.svg?raw' {
 declare module 'virtual:lib-versions' {
   export const turingVersion: string;
   export const postVersion: string;
+  export const appVersion: string;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,9 @@ const pkgVersion = (pkg: string): string =>
 
 const VIRTUAL_ID = 'virtual:lib-versions';
 
+const appVersion = (): string =>
+  JSON.parse(readFileSync('./package.json', 'utf-8')).version;
+
 const libVersions = (): Plugin => ({
   name: 'lib-versions',
   resolveId(id) {
@@ -16,8 +19,10 @@ const libVersions = (): Plugin => ({
     if (id !== `\0${VIRTUAL_ID}`) return;
     const turing = pkgVersion('@turing-machine-js/machine');
     const post = pkgVersion('@post-machine-js/machine');
+    const app = appVersion();
     return `export const turingVersion = ${JSON.stringify(turing)};
 export const postVersion = ${JSON.stringify(post)};
+export const appVersion = ${JSON.stringify(app)};
 `;
   },
 });


### PR DESCRIPTION
## Summary

- New `:root[data-theme=\"light\"]` token block plus a `prefers-color-scheme` CSS fallback. Adds semantic `--hover-bg`, `--divider`, `--shadow` tokens to replace the dark-only `rgba(255,255,255,0.0X)` literals scattered across components, and converts accent/error/ok alpha tints to `color-mix(... var(--token), transparent)` so they follow the active accent rather than baking dark-mode RGB.
- Three-state theme cycle: **system → light → dark**. `theme.svelte.ts` keeps the user's *choice* (system/light/dark) while the DOM `data-theme` attribute always carries the *resolved* theme (dark/light), so CSS selectors match without a system-aware fallback path. While `system` is active, a `matchMedia` listener flips the page live with the OS.
- FOUC-safe pre-paint init: `public/theme-init.js` runs as a classic `<script>` in `<head>`. External (not inline) because the production CSP is `script-src 'self' 'unsafe-eval'` — same-origin under `'self'`.
- `Editor.svelte` includes `oneDark` only when the *resolved* theme is dark; light theme falls back to CodeMirror's default highlighting paired with `--editor-bg: #fff`.
- Header now hosts only title + tabs + theme toggle. App version, lib versions, and the GitHub link moved to a new bottom-right footer; app version comes from `package.json` via the existing `virtual:lib-versions` plugin.

## Notes for reviewer

- **Light-theme visual verification is deferred.** The agent that wrote this couldn't click in the browser to flip themes (computer-use treats browsers as read-only). Build, type-check, and lint pass; please eyeball both themes locally before merging — particularly the editor (no oneDark) and the tape stack.
- **CARET_COLORS unchanged.** The 5-entry palette in `MachineView.svelte:34-38` (`#ffd166` amber, `#5fd068` green, …) may have low contrast on the light `--cell-bg: #f5f5f7`. Worth checking visually; if contrast looks off, a per-theme palette is a small follow-up.
- **Out of scope:** the multi-tape control panel can have rows clipped on narrow viewports — pre-existing layout issue, unrelated to theming. Worth a separate issue.
- **Cycle order** (`system → light → dark`) — happy to flip to `light → dark → system` if you'd prefer a more conventional order.

## Test plan

- [ ] Visit on a dark-OS machine: page renders dark, toggle cycles system → light → dark → system; OS-flip propagates while in `system`.
- [ ] Visit on a light-OS machine: same cycle, starts light.
- [ ] Refresh after each pick: theme persists.
- [ ] No FOUC on initial load (saved=light, etc.).
- [ ] Editor (CodeMirror) is readable in both themes.
- [ ] Tape, control panel, log, toolbar all readable in both themes.
- [ ] `npm run check && npm run lint && npm run build` all green.

minor English: in the issue body \"All UI components are readable\" — fine; in this PR I deliberately phrased the FOUC point as \"no FOUC on initial load\" rather than the issue's \"no flash of unstyled content\" because I'm guarding both — the saved choice and the OS preference.