### PR TITLE
Add save/load named user code snippets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,18 +37,19 @@ src/
     ├── autoStep.ts          paused-auto-step controller + parseInterval
     ├── completions.ts       CodeMirror autocomplete: machine namespace + locals
     ├── syntaxLinter.ts      Lezer-based syntax-error markers
-    ├── persist.ts           localStorage helpers per engine
+    ├── persist.ts           localStorage helpers per engine — code, example, snippets (UUID-keyed)
     ├── defaultCode.ts       starter Turing / Post snippets
     ├── format.ts            describeAppliedCommand / formatTape / commandsEntry / tapesEntry
     └── icons.ts             Tabler icon namespace (?raw imports)
 ```
 
-**`App.svelte`** picks the active engine from `?machine=` and renders one `<MachineView engine={...}>` keyed by engine — switching engines unmounts and remounts the tab (kills CodeMirror undo, cheap CPU).
+**`App.svelte`** picks the active engine from the URL pathname (`/turing`, `/post`) and renders one `<MachineView engine={...}>` keyed by engine — switching engines unmounts and remounts the tab (kills CodeMirror undo, cheap CPU). Legacy `?machine=<engine>` URLs are rewritten to the path form on first load. SPA-fallback routing is required (nginx `try_files $uri $uri/ /index.html;` in `vps/nginx/sites/demo.machines.mellonis.ru`; Vite default in dev).
 
 **`MachineView.svelte`** is the orchestrator (UI is split into `TapesStack`, `Toolbar`, `ControlPanel`, `Editor`, `Log`). It owns:
 
 - `executionMode` (`$state<ExecutionMode>`) — see state machine below
 - `logEntries`, `alphabets`, `lastSnapshots`, `halted`, `code`, `withPause`, `intervalText` — all `$state` (multi-tape: `alphabets`/`lastSnapshots` are per-tape arrays)
+- `selectedExampleId`, `snippets`, `loadedSnippetId` — all `$state`. `loadedSnippetId` is the UUID of the currently loaded user snippet (or `null` for a bundled example); drives `sourceCode`, `dirty`, and `resetVisible` ($derived). See the *Snippets* section below.
 - `pendingOp: 'load' | 'run' | null` and `stepInFlight: boolean` — concurrency guards
 - `panelEnabled` / `applyVisible` / `takeControlVisible` / `loadDisabled` / `stepDisabled` / `runDisabled` / `tapeCount` — all `$derived` (single source of truth for UI state)
 - `mirrorMachine` / `mirrorTapeBlock` — a real `TuringMachine` instance on the main thread that mirrors the worker's tape state. Built by `_buildMirrorMachine` after each `reloadWorker`; advanced one step at a time by `_runMirrorStep` (uses an `ifOtherSymbol` one-step `State` so the upstream library's transitions drive the visualization, not bespoke UI code). `renderFromMirror` hands each `mirrorTapeBlock.tapes[i]` to the matching `<Tape>` via `TapesStack.setFromTape(i, tape, …)`.
@@ -110,7 +111,7 @@ The component owns no tape state of its own beyond the fixed-size `viewport: $st
 
 The head ▲ marker below each bottom belt is a **CSS-border triangle** (not a Unicode glyph) so its visible edges exactly match its box and `left:50%; translateX(-50%)` aligns pixel-perfect with the head-thread line. `.viewport` (CSS class on the outer wrapper, not the JS variable) carries `background: var(--bg)` to mask the head-thread behind the stack across the whole tape row — without that, the 4px inter-cell gap passes through the head column during slide animations and exposes the line.
 
-**Bundled examples use `'␣'` (U+2423 OPEN BOX) as the literal blank symbol in their alphabets.** Convention: pick a visible glyph for blank if you want to see blank cells out of the box; the demo no longer normalizes blanks to a special UI character.
+**Bundled Turing examples use `' '` (space) as the blank symbol** — matching the Post machine's fixed blank — so both tabs feel consistent. Blank cells render dimmed (`.cell.blank` CSS) regardless of which character is chosen as blank.
 
 ## Multi-tape stack and head-thread connector
 
@@ -125,7 +126,7 @@ A `.head-thread` div sits behind the stack as the first child of `.tapes-stack` 
 
 ## Conventions
 
-- **localStorage** keys `machines-demo:code:turing` / `machines-demo:code:post` persist editor contents (via `lib/persist.ts`, errors swallowed).
+- **localStorage** keys follow `machines-demo:<engine>:<key>` hierarchy (non-engine key `machines-demo:theme` is the only exception): `code` persists editor contents, `example` the selected bundled example id, `snippets` the user snippet map (keyed by UUID → `{ title, code, savedAt }`). The currently loaded snippet's UUID is **not** stored here — it lives in the URL (`?snippet=<uuid>`) so it's bookmarkable / shareable. (Via `lib/persist.ts`, errors swallowed.)
 - **`report(text, kind?)`** in MachineView is the single log entry point — appends to `logEntries`. `reportSeparator()` pushes a `{separator: true}` entry that `Log.svelte` renders as an `<hr>`; called before each Build / first-Step / Run so distinct sessions read as visually grouped. The mobile-status `latestEntry $derived` skips separator entries.
 - **CSS nesting** is used throughout (native, no preprocessor) — Vite's CSS pipeline handles it; supported by all evergreen browsers. Keep nesting shallow (≤2 levels) to preserve specificity readability.
 - **No UI substitution of alphabet symbols.** The user picks the blank glyph in their alphabet; the UI renders the literal symbol. CSS classes (`Tape.svelte#.cell.blank`, `ControlPanel.svelte#.cp-btn.blank`) provide visual hints (dim border / opacity) so blank cells remain recognisable regardless of which character was chosen — no character is reserved for "blank visualization", so no alphabet glyph collides with one.
@@ -137,6 +138,24 @@ A `.head-thread` div sits behind the stack as the first child of `.tapes-stack` 
 - **No static literal fallbacks in `var()`.** A `var()` fallback must itself be another CSS custom property (e.g. `var(--dot, var(--head))`) — never a hardcoded color, length, or time. Literals leak out of the design system and bypass theming. Two patterns satisfy this:
   - **Globally-scoped tokens** (colors, surface vars, animation timings) — declared in `:root` in `app.css`. Optionally promoted to `@property` for type-checking and animatable customs (e.g. `@property --anim-button-hover-ms { syntax: '<time>'; inherits: true; initial-value: 120ms }`). When `@property`'s `initial-value` must mirror another token (it can't reference `var()`), document the coupling with a `/* follows --x — keep in sync when theming */` comment above the literal value.
   - **Optional, per-element customs** (e.g. `--dot` in `ControlPanel.svelte`) — either fall back to another token at the read site (`var(--dot, var(--head))`) or declare a class-level default (`.tape-dot { --dot: var(--head); background: var(--dot) }`). Pick the class-level default when the same custom is read in multiple places, the inline fallback when it's a one-off.
+
+## Snippets
+
+User-saved code lives in `localStorage` under `machines-demo:<engine>:snippets`, keyed by UUID → `{ title, code, savedAt }`. Title is user-visible (matches the save-popover input); UUID is the stable identity that survives renames and is the share key (issue #24).
+
+The currently loaded snippet's UUID lives in the URL query string (`?snippet=<uuid>`), not in localStorage. On mount, MachineView reads it; on `loadedSnippetId` change a `$effect` rewrites it via `history.replaceState` (no history entries — switching engines is the only operation that pushes). If the URL UUID isn't in `snippets`, MachineView reports `snippet not found: <uuid>` once and falls back to the `code` localStorage key. The bad param is dropped on the next state change (the `$effect` writes the canonical URL).
+
+Reset and save UIs share two derivations in MachineView:
+- `sourceCode` — the code Reset would restore: the loaded snippet's saved code, or the selected bundled example's code, or `null` when the loaded snippet was deleted (no target).
+- `dirty` = `sourceCode !== null && code !== sourceCode` — drives the accent dot on the save icon, the popover's *Save changes* button enabled state, and `resetVisible` (alias of `dirty`). When the editor matches its source — or `sourceCode` is null — both the reset button and the dirty dot disappear, since clicking them would be a no-op.
+
+Save UX (Toolbar.svelte):
+- Click the floppy → open popover. With a snippet loaded, the popover shows *Save changes to "<title>"* (primary, accent border) plus an *or save as new* section with a name input.
+- ⌘S / Ctrl-S → silently saves the loaded snippet via `onSaveChanges`; opens the popover when nothing is loaded.
+- ⌘⇧S / Ctrl-Shift-S → always opens the popover (Save As).
+- The keydown listener `preventDefault`s to suppress the browser's *Save Page* dialog and is a no-op when the popover is already open (so Enter inside the input keeps its meaning).
+
+`saveSnippet` matches by `title` to preserve the UUID on overwrite, returning `{ id, snippet }` so MachineView can sync `snippets` reactively without re-reading localStorage.
 
 ## Editor
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,10 +6,14 @@
   import { theme } from './lib/theme.svelte.ts';
   import { ENGINES, type Engine } from './lib/types.ts';
 
+  // Engine lives in the URL path (`/turing`, `/post`). The first path segment
+  // is the engine; anything else (`/`, `/foo`) normalises to the default
+  // engine. Requires SPA-fallback routing on the server (nginx
+  // `try_files $uri $uri/ /index.html;` for prod; Vite's default in dev).
   function readEngineFromUrl(): Engine {
     try {
-      const v = new URL(window.location.href).searchParams.get('machine');
-      return (ENGINES as readonly string[]).includes(v ?? '') ? (v as Engine) : 'turing';
+      const seg = window.location.pathname.replace(/^\/+/, '').split('/')[0];
+      return (ENGINES as readonly string[]).includes(seg) ? (seg as Engine) : 'turing';
     } catch {
       return 'turing';
     }
@@ -18,6 +22,27 @@
   let activeEngine = $state<Engine>('turing');
 
   onMount(() => {
+    // Backwards-compat: legacy `?machine=<engine>` → `/<engine>`. Rewrite the
+    // URL once on mount so old bookmarks/links don't silently lose context.
+    const url = new URL(window.location.href);
+    const legacy = url.searchParams.get('machine');
+    if (legacy !== null) {
+      url.searchParams.delete('machine');
+      if ((ENGINES as readonly string[]).includes(legacy)) {
+        url.pathname = '/' + legacy;
+      }
+      history.replaceState(null, '', url);
+    }
+
+    // Normalise unknown/root paths to `/<default-engine>` so the URL always
+    // reflects the active engine (no silent fallback discrepancy).
+    const seg = window.location.pathname.replace(/^\/+/, '').split('/')[0];
+    if (!(ENGINES as readonly string[]).includes(seg)) {
+      const normalised = new URL(window.location.href);
+      normalised.pathname = '/turing';
+      history.replaceState(null, '', normalised);
+    }
+
     activeEngine = readEngineFromUrl();
     const onPopState = () => {
       activeEngine = readEngineFromUrl();
@@ -29,13 +54,9 @@
   function selectEngine(engine: Engine): void {
     if (engine === activeEngine) return;
     activeEngine = engine;
-    const url = new URL(window.location.href);
-    if (engine === 'turing') {
-      url.searchParams.delete('machine');
-    } else {
-      url.searchParams.set('machine', engine);
-    }
-    history.pushState(null, '', url);
+    // Drop existing query params: they are engine-scoped (e.g. `?snippet=`)
+    // and don't carry over to the other engine's namespace.
+    history.pushState(null, '', '/' + engine);
   }
 
   const themeIcon = $derived(

--- a/src/components/Editor.svelte
+++ b/src/components/Editor.svelte
@@ -13,9 +13,10 @@
     engine: Engine;
     code: string;
     onReset: () => void;
+    resetVisible?: boolean;
   };
 
-  let { engine, code = $bindable(), onReset }: Props = $props();
+  let { engine, code = $bindable(), onReset, resetVisible = true }: Props = $props();
 
   // Persist code to localStorage on every change. saveCode swallows quota /
   // private-mode errors internally.
@@ -37,7 +38,9 @@
 </script>
 
 <div class="editor">
-  <IconButton icon="resetCode" title="Reset code to selected example" onClick={onReset} />
+  {#if resetVisible}
+    <IconButton icon="resetCode" title="Reset code to selected example" onClick={onReset} />
+  {/if}
   <CodeMirror
     bind:value={code}
     {lang}

--- a/src/components/Log.svelte
+++ b/src/components/Log.svelte
@@ -19,7 +19,9 @@
 </script>
 
 <div class="log-panel">
-  <IconButton icon="eraser" title="Clear log" onClick={onClear} />
+  {#if entries.length > 0}
+    <IconButton icon="eraser" title="Clear log" onClick={onClear} />
+  {/if}
   <div class="content" bind:this={scrollEl}>
     {#each entries as entry, i (i)}
       {#if entry.separator}

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -18,7 +18,15 @@
     findExample,
     type Example,
   } from '../lib/defaultCode.ts';
-  import { loadCode, loadExampleId, saveExampleId } from '../lib/persist.ts';
+  import {
+    loadCode,
+    loadExampleId,
+    saveExampleId,
+    loadSnippets,
+    saveSnippet,
+    deleteSnippet,
+    type Snippets,
+  } from '../lib/persist.ts';
   import { icons } from '../lib/icons.ts';
 
   type Props = { engine: Engine };
@@ -70,9 +78,26 @@
     return (persistedId && findExample(engine, persistedId)) || defaultExample(engine);
   });
   let selectedExampleId = $state<string>(initialExample.id);
-  let code = $state<string>(
-    untrack(() => loadCode(engine) ?? initialExample.code),
-  );
+  const initialSnippets = untrack(() => loadSnippets(engine));
+  let snippets = $state<Snippets>(initialSnippets);
+  // Active snippet is read from the URL (`?snippet=<uuid>`) — bookmarkable,
+  // shareable, and the future-#24 share key. When the URL points at a snippet
+  // that exists locally, its code becomes the editor's code; otherwise we fall
+  // back to localStorage and report the bad UUID once on mount.
+  const initial = untrack(() => {
+    const raw = new URL(window.location.href).searchParams.get('snippet');
+    const urlId = raw !== null && raw !== '' ? raw : null;
+    if (urlId !== null && urlId in initialSnippets) {
+      return { loadedSnippetId: urlId, code: initialSnippets[urlId].code, badUrlId: null as string | null };
+    }
+    return {
+      loadedSnippetId: null as string | null,
+      code: loadCode(engine) ?? initialExample.code,
+      badUrlId: urlId,
+    };
+  });
+  let loadedSnippetId = $state<string | null>(initial.loadedSnippetId);
+  let code = $state<string>(initial.code);
 
   const selectedExample = $derived(
     findExample(engine, selectedExampleId) ?? defaultExample(engine),
@@ -116,6 +141,16 @@
     executionMode !== 'MANUAL' && executionMode !== 'RUNNING_CONTINUOUS',
   );
   const beltTransitionsOn = $derived(executionMode !== 'RUNNING_CONTINUOUS');
+
+  // The code Reset would restore to: the loaded snippet's saved code, or the
+  // selected bundled example's code, or null when the loaded snippet was
+  // deleted (no target — Reset is hidden in that branch).
+  const sourceCode = $derived.by(() => {
+    if (loadedSnippetId !== null) return snippets[loadedSnippetId]?.code ?? null;
+    return selectedExample.code;
+  });
+  const dirty = $derived(sourceCode !== null && code !== sourceCode);
+  const resetVisible = $derived(dirty);
 
   const loadDisabled = $derived(pendingOp !== null);
   // Step/Run stay enabled in HALTED — they reload-from-code on entry, which
@@ -433,18 +468,63 @@
   }
 
   function resetCodeToSelected(): void {
+    if (loadedSnippetId !== null) {
+      const snippet = snippets[loadedSnippetId];
+      if (snippet) code = snippet.code;
+      return;
+    }
     code = selectedExample.code;
   }
 
   function pickExample(ex: Example): void {
     selectedExampleId = ex.id;
     code = ex.code;
+    loadedSnippetId = null;
+  }
+
+  function onSaveSnippet(title: string): void {
+    const { id, snippet } = saveSnippet(engine, title, code);
+    snippets = { ...snippets, [id]: snippet };
+    loadedSnippetId = id;
+  }
+
+  function onSaveChanges(): void {
+    if (loadedSnippetId === null) return;
+    const existing = snippets[loadedSnippetId];
+    if (!existing) return;
+    const { id, snippet } = saveSnippet(engine, existing.title, code);
+    snippets = { ...snippets, [id]: snippet };
+    report(`saved "${existing.title}"`, 'ok');
+  }
+
+  function onLoadSnippet(id: string): void {
+    const snippet = snippets[id];
+    if (snippet) {
+      code = snippet.code;
+      loadedSnippetId = id;
+    }
+  }
+
+  function onDeleteSnippet(id: string): void {
+    deleteSnippet(engine, id);
+    const { [id]: _, ...rest } = snippets;
+    snippets = rest;
+    // Keep loadedSnippetId set so `resetVisible` hides the reset button when
+    // the snippet is gone — otherwise reset would silently jump to the
+    // bundled example.
   }
 
   // Persist the selected example id (separate from the editor code) so the
   // reset button keeps targeting the chosen source across reloads.
   $effect(() => {
     saveExampleId(engine, selectedExampleId);
+  });
+
+  $effect(() => {
+    const url = new URL(window.location.href);
+    if (loadedSnippetId !== null) url.searchParams.set('snippet', loadedSnippetId);
+    else url.searchParams.delete('snippet');
+    history.replaceState(null, '', url);
   });
 
   /* ───── effects ─────
@@ -508,6 +588,7 @@
   /* ───── lifecycle ───── */
 
   onMount(() => {
+    if (initial.badUrlId !== null) report(`snippet not found: ${initial.badUrlId}`, 'error');
     void doLoad();
   });
 
@@ -558,6 +639,13 @@
       onRun={doRun}
       onStop={stopMachine}
       onPickExample={pickExample}
+      {snippets}
+      {loadedSnippetId}
+      {dirty}
+      {onSaveSnippet}
+      {onSaveChanges}
+      {onLoadSnippet}
+      {onDeleteSnippet}
     />
     <div
       class="status"
@@ -570,7 +658,7 @@
     {#await editorPromise}
       <div class="editor-loading">Loading editor…</div>
     {:then Editor}
-      <Editor {engine} bind:code onReset={resetCodeToSelected} />
+      <Editor {engine} bind:code onReset={resetCodeToSelected} {resetVisible} />
     {:catch err}
       <div class="editor-error">Failed to load editor: {err.message}</div>
     {/await}

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { icons } from '../lib/icons.ts';
   import type { Example } from '../lib/defaultCode.ts';
+  import type { Snippets } from '../lib/persist.ts';
 
   // Execution-mode strings the toolbar cares about. Kept loose (string union
   // matching MachineView's ExecutionMode) so we don't duplicate the type.
@@ -19,11 +20,18 @@
     selectedExampleId: string;
     withPause: boolean;
     intervalText: string;
+    snippets: Snippets;
+    loadedSnippetId: string | null;
+    dirty: boolean;
     onBuild: () => void;
     onStep: () => void;
     onRun: () => void;
     onStop: () => void;
     onPickExample: (ex: Example) => void;
+    onSaveSnippet: (title: string) => void;
+    onSaveChanges: () => void;
+    onLoadSnippet: (id: string) => void;
+    onDeleteSnippet: (id: string) => void;
   };
 
   let {
@@ -36,11 +44,18 @@
     selectedExampleId,
     withPause = $bindable(),
     intervalText = $bindable(),
+    snippets,
+    loadedSnippetId,
+    dirty,
     onBuild,
     onStep,
     onRun,
     onStop,
     onPickExample,
+    onSaveSnippet,
+    onSaveChanges,
+    onLoadSnippet,
+    onDeleteSnippet,
   }: Props = $props();
 
   // Examples dropdown — fully owned here so the outside-click and Escape
@@ -69,6 +84,87 @@
       document.removeEventListener('keydown', onKey);
     };
   });
+
+  let saveOpen = $state(false);
+  let saveName = $state('');
+  let pendingOverwrite = $state(false);
+  let saveMenuEl: HTMLDivElement | undefined;
+  let nameInputEl = $state<HTMLInputElement | undefined>(undefined);
+
+  const loadedSnippet = $derived(
+    loadedSnippetId !== null ? snippets[loadedSnippetId] ?? null : null,
+  );
+  const trimmedName = $derived(saveName.trim());
+  const snippetTitles = $derived(new Set(Object.values(snippets).map((s) => s.title)));
+  const saveNameExists = $derived(trimmedName !== '' && snippetTitles.has(trimmedName));
+  const saveEnabled = $derived(trimmedName !== '');
+
+  $effect(() => {
+    if (!saveOpen) return;
+    const onPointer = (e: MouseEvent): void => {
+      if (!saveMenuEl?.contains(e.target as Node)) closeSavePopover();
+    };
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') closeSavePopover();
+    };
+    document.addEventListener('mousedown', onPointer);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onPointer);
+      document.removeEventListener('keydown', onKey);
+    };
+  });
+
+  $effect(() => {
+    if (saveOpen && nameInputEl) nameInputEl.focus();
+  });
+
+  $effect(() => {
+    if (!saveOpen) return;
+    void trimmedName;
+    pendingOverwrite = false;
+  });
+
+  function closeSavePopover(): void {
+    saveOpen = false;
+    saveName = '';
+    pendingOverwrite = false;
+  }
+
+  // ⌘S / ⌘⇧S — preventDefault is what stops the browser's Save Page dialog.
+  $effect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.key !== 's' && e.key !== 'S') return;
+      e.preventDefault();
+      if (saveOpen) return; // popover has its own Enter binding
+      if (e.shiftKey) {
+        saveName = '';
+        saveOpen = true;
+      } else if (loadedSnippet !== null) {
+        onSaveChanges();
+      } else {
+        saveName = '';
+        saveOpen = true;
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  });
+
+  function doSave(): void {
+    if (!saveEnabled) return;
+    if (saveNameExists && !pendingOverwrite) {
+      pendingOverwrite = true;
+      return;
+    }
+    onSaveSnippet(trimmedName);
+    closeSavePopover();
+  }
+
+  const sortedSnippets = $derived(
+    Object.entries(snippets).sort((a, b) => b[1].savedAt - a[1].savedAt),
+  );
 
   // with-pause / interval are configuration for the *next* Run; meaningless
   // mid-run, so hide them in the running modes (they'd just be inert chrome).
@@ -107,9 +203,82 @@
             </button>
           </li>
         {/each}
+        {#if sortedSnippets.length > 0}
+          <li role="separator" class="divider"></li>
+          <li role="none" class="section-label">My snippets</li>
+          {#each sortedSnippets as [id, snippet] (id)}
+            <li role="none" class="snippet-row">
+              <button
+                type="button"
+                role="menuitem"
+                onclick={() => { onLoadSnippet(id); examplesOpen = false; }}
+              >{snippet.title}</button>
+              <button
+                type="button"
+                class="delete-btn"
+                aria-label="Delete snippet {snippet.title}"
+                title="Delete"
+                onclick={(e) => { e.stopPropagation(); onDeleteSnippet(id); }}
+              >{@html icons.xSmall}</button>
+            </li>
+          {/each}
+        {/if}
       </ul>
     {/if}
   </div>
+
+  <div class="save-menu" bind:this={saveMenuEl}>
+    <button
+      type="button"
+      class="icon-only"
+      class:dirty
+      aria-label="Save snippet"
+      aria-haspopup="dialog"
+      aria-expanded={saveOpen}
+      title="Save snippet (⌘S)"
+      onclick={() => { if (saveOpen) closeSavePopover(); else { saveName = ''; saveOpen = true; } }}
+    >
+      {@html icons.saveFloppy}
+    </button>
+    {#if saveOpen}
+      <div class="save-popover" role="dialog" aria-label="Save snippet">
+        {#if loadedSnippet !== null}
+          <button
+            type="button"
+            class="save-changes"
+            disabled={!dirty}
+            onclick={() => { onSaveChanges(); closeSavePopover(); }}
+          >
+            Save changes to "{loadedSnippet.title}"
+          </button>
+          <div class="popover-section-label">or save as new</div>
+        {/if}
+        <input
+          type="text"
+          bind:this={nameInputEl}
+          bind:value={saveName}
+          placeholder="Snippet name"
+          maxlength="80"
+          onkeydown={(e) => {
+            if (e.key === 'Enter') doSave();
+            if (e.key === 'Escape') closeSavePopover();
+          }}
+        />
+        {#if pendingOverwrite}
+          <div class="overwrite-confirm">
+            <span>Overwrite "{trimmedName}"?</span>
+            <button type="button" class="confirm-yes" onclick={doSave}>Yes</button>
+            <button type="button" onclick={() => (pendingOverwrite = false)}>No</button>
+          </div>
+        {:else}
+          <button type="button" disabled={!saveEnabled} onclick={doSave}>
+            {loadedSnippet !== null ? 'Save as new' : 'Save'}
+          </button>
+        {/if}
+      </div>
+    {/if}
+  </div>
+
   <button type="button" disabled={loadDisabled} onclick={onBuild}>
     {@html icons.build}<span class="btn-label">Build</span>
   </button>
@@ -208,8 +377,24 @@
     display: inline-flex;
   }
 
-  .toolbar .examples-menu .icon-only {
+  .toolbar .examples-menu .icon-only,
+  .toolbar .save-menu .icon-only {
     padding: 6px 8px;
+  }
+
+  .toolbar .save-menu .icon-only.dirty {
+    position: relative;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--accent);
+    }
   }
 
   .dropdown {
@@ -254,6 +439,161 @@
         color: var(--accent);
         background: color-mix(in srgb, var(--accent) 18%, transparent);
       }
+    }
+  }
+
+  .divider {
+    height: 1px;
+    background: var(--divider);
+    margin: 4px 6px;
+    padding: 0;
+  }
+
+  .section-label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted);
+    padding: 4px 10px 2px;
+  }
+
+  .snippet-row {
+    display: flex;
+    align-items: center;
+
+    button:first-child {
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .delete-btn {
+      flex-shrink: 0;
+      width: 28px;
+      padding: 4px;
+      background: transparent;
+      border: none;
+      color: var(--muted);
+      border-radius: 4px;
+      cursor: pointer;
+      opacity: 0.6;
+
+      &:hover {
+        color: var(--error);
+        background: color-mix(in srgb, var(--error) 12%, transparent);
+        opacity: 1;
+      }
+
+      :global(svg) {
+        width: 14px;
+        height: 14px;
+      }
+    }
+  }
+
+  .save-menu {
+    position: relative;
+    display: inline-flex;
+  }
+
+  .save-popover {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: 20;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px;
+    min-width: 220px;
+    background: var(--cell-bg);
+    border: 1px solid var(--surface-border);
+    border-radius: 6px;
+    box-shadow: 0 8px 24px var(--shadow);
+
+    input[type='text'] {
+      background: var(--cell-bg);
+      border: 1px solid var(--cell-border);
+      color: var(--fg);
+      padding: 5px 8px;
+      font: inherit;
+      font-size: 13px;
+      border-radius: 4px;
+      width: 100%;
+      box-sizing: border-box;
+
+      &:focus {
+        outline: none;
+        border-color: var(--accent);
+      }
+    }
+
+    > button {
+      align-self: flex-end;
+      padding: 5px 14px;
+      font-size: 13px;
+    }
+
+    .save-changes {
+      align-self: stretch;
+      text-align: left;
+      border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+      color: var(--accent);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      &:hover:not(:disabled) {
+        border-color: var(--accent) !important;
+        background: color-mix(in srgb, var(--accent) 10%, transparent);
+      }
+    }
+
+    .popover-section-label {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--muted);
+      padding: 4px 0 0;
+      border-top: 1px solid var(--divider);
+      margin-top: 2px;
+    }
+  }
+
+  .overwrite-confirm {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+
+    span {
+      flex: 1;
+      font-size: 12px;
+      color: var(--muted);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .confirm-yes {
+      border-color: color-mix(in srgb, var(--ok) 50%, transparent);
+      color: var(--ok);
+      font-size: 12px;
+      padding: 3px 10px;
+
+      &:hover {
+        border-color: var(--ok) !important;
+        color: var(--ok) !important;
+      }
+    }
+
+    button:not(.confirm-yes) {
+      font-size: 12px;
+      padding: 3px 10px;
     }
   }
 

--- a/src/lib/defaultCode.ts
+++ b/src/lib/defaultCode.ts
@@ -21,7 +21,7 @@ const {
   haltState, ifOtherSymbol, movements,
 } = imports;
 
-const alphabet = new Alphabet(['␣', 'a', 'b', 'c', '*']);
+const alphabet = new Alphabet([' ', 'a', 'b', 'c', '*']);
 const tape = new Tape({ alphabet, symbols: ['a', 'b', 'c', 'b', 'a'] });
 const tapeBlock = TapeBlock.fromTapes([tape]);
 const machine = new TuringMachine({ tapeBlock });
@@ -55,10 +55,10 @@ const TURING_COPY_TWO_TAPES = `// Task: copy tape 0 ('abab') onto blank tape 1, 
 
 const {
   Alphabet, State, Tape, TapeBlock, TuringMachine,
-  haltState, movements,
+  haltState, ifOtherSymbol, movements,
 } = imports;
 
-const alphabet = new Alphabet(['␣', 'a', 'b']);
+const alphabet = new Alphabet([' ', 'a', 'b']);
 const t0 = new Tape({ alphabet, symbols: ['a', 'b', 'a', 'b'] });
 const t1 = new Tape({ alphabet, symbols: [] });
 const tapeBlock = TapeBlock.fromTapes([t0, t1]);
@@ -67,19 +67,19 @@ const machine = new TuringMachine({ tapeBlock });
 const { symbol } = tapeBlock;
 
 const initialState = new State({
-  [symbol(['a', '␣'])]: {
+  [symbol(['a', ifOtherSymbol])]: {
     command: [
       { symbol: 'a', movement: movements.right },
       { symbol: 'a', movement: movements.right },
     ],
   },
-  [symbol(['b', '␣'])]: {
+  [symbol(['b', ifOtherSymbol])]: {
     command: [
       { symbol: 'b', movement: movements.right },
       { symbol: 'b', movement: movements.right },
     ],
   },
-  [symbol(['␣', '␣'])]: {
+  [symbol([' ', ifOtherSymbol])]: {
     command: [
       { movement: movements.stay },
       { movement: movements.stay },

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -11,11 +11,13 @@ import pause from '@tabler/icons/outline/player-pause.svg?raw';
 import resetCode from '@tabler/icons/outline/arrow-back-up.svg?raw';
 import right from '@tabler/icons/outline/arrow-narrow-right.svg?raw';
 import run from '@tabler/icons/outline/player-play.svg?raw';
+import saveFloppy from '@tabler/icons/outline/device-floppy.svg?raw';
 import stay from '@tabler/icons/outline/keyframe-align-horizontal.svg?raw';
 import step from '@tabler/icons/outline/player-skip-forward.svg?raw';
 import stop from '@tabler/icons/outline/player-stop.svg?raw';
 import sun from '@tabler/icons/outline/sun.svg?raw';
 import takeControl from '@tabler/icons/outline/device-gamepad-2.svg?raw';
+import xSmall from '@tabler/icons/outline/x.svg?raw';
 
 export const icons = {
   apply,
@@ -31,11 +33,13 @@ export const icons = {
   resetCode,
   right,
   run,
+  saveFloppy,
   stay,
   step,
   stop,
   sun,
   takeControl,
+  xSmall,
 } as const;
 
 export type IconName = keyof typeof icons;

--- a/src/lib/persist.ts
+++ b/src/lib/persist.ts
@@ -1,8 +1,14 @@
 import type { Engine } from './types.ts';
 
-const CODE_KEY_PREFIX = 'machines-demo:code:';
-const EXAMPLE_KEY_PREFIX = 'machines-demo:example:';
 const THEME_KEY = 'machines-demo:theme';
+
+function engineKey(engine: Engine, suffix: string): string {
+  return `machines-demo:${engine}:${suffix}`;
+}
+
+export type Snippet = { title: string; code: string; savedAt: number };
+// Keyed by UUID — the UUID is the stable identity; title is user-visible name.
+export type Snippets = Record<string, Snippet>;
 
 export type Theme = 'system' | 'dark' | 'light';
 
@@ -25,7 +31,7 @@ export function saveTheme(theme: Theme): void {
 
 export function loadCode(engine: Engine): string | null {
   try {
-    return localStorage.getItem(CODE_KEY_PREFIX + engine);
+    return localStorage.getItem(engineKey(engine, 'code'));
   } catch {
     return null;
   }
@@ -33,7 +39,7 @@ export function loadCode(engine: Engine): string | null {
 
 export function saveCode(engine: Engine, code: string): void {
   try {
-    localStorage.setItem(CODE_KEY_PREFIX + engine, code);
+    localStorage.setItem(engineKey(engine, 'code'), code);
   } catch {
     /* quota or private mode — ignore */
   }
@@ -41,7 +47,7 @@ export function saveCode(engine: Engine, code: string): void {
 
 export function loadExampleId(engine: Engine): string | null {
   try {
-    return localStorage.getItem(EXAMPLE_KEY_PREFIX + engine);
+    return localStorage.getItem(engineKey(engine, 'example'));
   } catch {
     return null;
   }
@@ -49,7 +55,46 @@ export function loadExampleId(engine: Engine): string | null {
 
 export function saveExampleId(engine: Engine, id: string): void {
   try {
-    localStorage.setItem(EXAMPLE_KEY_PREFIX + engine, id);
+    localStorage.setItem(engineKey(engine, 'example'), id);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function loadSnippets(engine: Engine): Snippets {
+  try {
+    const v = localStorage.getItem(engineKey(engine, 'snippets'));
+    return v ? (JSON.parse(v) as Snippets) : {};
+  } catch {
+    return {};
+  }
+}
+
+// Returns { id, snippet } so the caller can sync reactive state without
+// duplicating the object. Preserves the UUID on overwrite (matched by title).
+export function saveSnippet(
+  engine: Engine,
+  title: string,
+  code: string,
+): { id: string; snippet: Snippet } {
+  const current = loadSnippets(engine);
+  const existingId = Object.entries(current).find(([, s]) => s.title === title)?.[0];
+  const id = existingId ?? crypto.randomUUID();
+  const snippet: Snippet = { title, code, savedAt: Date.now() };
+  try {
+    current[id] = snippet;
+    localStorage.setItem(engineKey(engine, 'snippets'), JSON.stringify(current));
+  } catch {
+    /* quota or private mode — ignore */
+  }
+  return { id, snippet };
+}
+
+export function deleteSnippet(engine: Engine, id: string): void {
+  try {
+    const current = loadSnippets(engine);
+    delete current[id];
+    localStorage.setItem(engineKey(engine, 'snippets'), JSON.stringify(current));
   } catch {
     /* ignore */
   }


### PR DESCRIPTION
Closes #8.

## Summary

- **Save/load user snippets** — floppy icon opens a popover with explicit "Save changes to <title>" (loaded snippet, primary) + "Save as new" (name input). Overwrite confirmation when the name collides. ⌘S saves silently when a snippet is loaded; ⌘⇧S always opens the popover (Save As).
- **Snippets list** in the examples dropdown ("My snippets" section), sorted newest-first, each with an inline delete button.
- **Dirty indicator** — small accent dot on the save icon when the editor diverges from the loaded source (snippet or example). Reset button hides when not dirty (clicking would be a no-op).
- **Active snippet in URL** — `?snippet=<uuid>` survives reload, is bookmarkable, and is the share key for #24. Invalid UUIDs report once and self-clean. Replaces the `…:active-snippet` localStorage key (gone).
- **Engine in URL path** — `/turing`, `/post`. Legacy `?machine=<engine>` rewrites on mount. Requires nginx `try_files $uri $uri/ /index.html;` (in the vps repo, deploys alongside).
- **Snippet shape** — `{ title, code, savedAt }` keyed by UUID; UUID is the stable identity preserved on overwrite (matched by title). All per-engine localStorage keys hierarchically structured: `machines-demo:<engine>:<key>` (`code`, `example`, `snippets`).
- **Bundled examples cleanup** — Turing examples use `' '` as blank for parity with the Post machine; copy-two-tapes uses `ifOtherSymbol` for the second tape (clearer intent).
- **Polish** — Clear-log button hides when log is empty (same no-op-affordance principle as Reset).

## Test plan

- [ ] Save a snippet via the popover; verify it appears in the dropdown and round-trips on reload.
- [ ] ⌘S with a loaded snippet: silently saves, log shows `saved "<title>"`, dirty dot disappears.
- [ ] ⌘⇧S always opens the popover with a blank name.
- [ ] Overwrite confirm fires when the typed name collides with another snippet.
- [ ] Reset is hidden when not dirty; visible only when the editor diverges from the loaded source.
- [ ] Open `/turing?snippet=<unknown>`: error reported, URL self-cleans.
- [ ] Open `/turing?snippet=<known>`: that snippet's code loads.
- [ ] Old `?machine=post` URL rewrites to `/post` on first load.
- [ ] Engine switch button updates the path and drops query params.

## Follow-ups (filed)

- #24 — Share snippet via URL (server-side persistence by UUID; UUID groundwork is here)
- #25 — Highlight active snippet in dropdown
- #26 — Reset button tooltip should reflect target
- #27 — Snippet delete: inline confirm or undo
- #28 — Snippet rename