### PR TITLE
Switch bundled examples to Unicode blank/mark glyphs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@codemirror/lang-javascript": "^6.2.0",
         "@codemirror/lint": "^6.8.0",
         "@codemirror/theme-one-dark": "^6.1.0",
-        "@post-machine-js/machine": "^3.0.1",
+        "@post-machine-js/machine": "^3.1.0",
         "@tabler/icons": "^3.41.1",
         "@turing-machine-js/machine": "^3.0.2",
         "codemirror": "^6.0.1",
@@ -829,9 +829,9 @@
       "license": "MIT"
     },
     "node_modules/@post-machine-js/machine": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@post-machine-js/machine/-/machine-3.0.1.tgz",
-      "integrity": "sha512-vxP5P0vnlJTWudimSUR0gwGFpugLBVe+qIgNEJxWUxAbpoVp2yQUNQTUG2Y62xBP3OpBR9nPRwZ1T44f1wFKXw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@post-machine-js/machine/-/machine-3.1.0.tgz",
+      "integrity": "sha512-zvQsaYrD/KCrDTFNp6s8GEx5BlaR7eC4Zlin56Cu3hkvmFQGqFL6pgXU94ysgwNG2aVJcv7d8yTODDW2zXmiTQ==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@codemirror/lang-javascript": "^6.2.0",
     "@codemirror/lint": "^6.8.0",
     "@codemirror/theme-one-dark": "^6.1.0",
-    "@post-machine-js/machine": "^3.0.1",
+    "@post-machine-js/machine": "^3.1.0",
     "@tabler/icons": "^3.41.1",
     "@turing-machine-js/machine": "^3.0.2",
     "codemirror": "^6.0.1",

--- a/src/lib/defaultCode.ts
+++ b/src/lib/defaultCode.ts
@@ -21,7 +21,7 @@ const {
   haltState, ifOtherSymbol, movements,
 } = imports;
 
-const alphabet = new Alphabet([' ', 'a', 'b', 'c', '*']);
+const alphabet = new Alphabet(['␣', 'a', 'b', 'c', '*']);
 const tape = new Tape({ alphabet, symbols: ['a', 'b', 'c', 'b', 'a'] });
 const tapeBlock = TapeBlock.fromTapes([tape]);
 const machine = new TuringMachine({ tapeBlock });
@@ -58,7 +58,7 @@ const {
   haltState, ifOtherSymbol, movements,
 } = imports;
 
-const alphabet = new Alphabet([' ', 'a', 'b']);
+const alphabet = new Alphabet(['␣', 'a', 'b']);
 const t0 = new Tape({ alphabet, symbols: ['a', 'b', 'a', 'b'] });
 const t1 = new Tape({ alphabet, symbols: [] });
 const tapeBlock = TapeBlock.fromTapes([t0, t1]);
@@ -79,7 +79,7 @@ const initialState = new State({
       { symbol: 'b', movement: movements.right },
     ],
   },
-  [symbol([' ', ifOtherSymbol])]: {
+  [symbol(['␣', ifOtherSymbol])]: {
     command: [
       { movement: movements.stay },
       { movement: movements.stay },
@@ -103,16 +103,19 @@ const POST_WALK_MARK = `// Task: walk right while marked; mark the first blank c
 
 const { PostMachine, Tape, check, mark, right, stop } = imports;
 
-const machine = new PostMachine({
-  10: check(20, 30),
-  20: right(10),
-  30: mark,
-  40: stop,
-});
+const machine = new PostMachine(
+  {
+    10: check(20, 30),
+    20: right(10),
+    30: mark,
+    40: stop,
+  },
+  { blankSymbol: '␣', markSymbol: '•' },
+);
 
 machine.replaceTapeWith(new Tape({
   alphabet: machine.tape.alphabet,
-  symbols: ['*', '*', ' '],
+  symbols: ['•', '•', '␣'],
 }));
 
 return { machine };


### PR DESCRIPTION
Closes #30.

## Summary

- **Turing examples** — alphabet blank changed from `' '` (space) to `'␣'` (U+2423 OPEN BOX) in both bundled snippets, including the literal `' '` in the `[symbol([' ', ifOtherSymbol])]` state key of the copy-two-tapes example.
- **Post example** — `PostMachine` constructed with `{ blankSymbol: '␣', markSymbol: '•' }` (U+2022 BULLET); tape symbols updated from `['*', '*', ' ']` to `['•', '•', '␣']`.
- **`@post-machine-js/machine`** bumped `^3.0.1` → `^3.1.0` (the constructor alphabet option landed in 3.1.0).

No changes to rendering logic — the demo's `Tape.svelte` is already glyph-agnostic (`Cell.blank` is a flag from `tape.alphabet.blankSymbol`, not a hardcoded character check). The `format.ts` `'*'` on line 16 is a log-format wildcard for "kept" (null write), independent of any alphabet symbol — no change needed there.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm run check` — 0 errors, 0 warnings.
- [ ] `npm run dev` — load both tabs, verify `␣` cells render dimmed (`.cell.blank` CSS) and `•` renders at full opacity in the Post tab. Step through the Post example and confirm `mark` writes `•` and `erase` writes `␣`. Confirm the Turing replace-b example halts correctly with blank cells shown as `␣`.