### PR TITLE
Highlight active snippet in dropdown

### DIFF
--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -211,6 +211,7 @@
               <button
                 type="button"
                 role="menuitem"
+                class:selected={id === loadedSnippetId}
                 onclick={() => { onLoadSnippet(id); examplesOpen = false; }}
               >{snippet.title}</button>
               <button


### PR DESCRIPTION
Closes #25

Adds `class:selected={id === loadedSnippetId}` to the snippet load button in the examples dropdown, mirroring the `.selected` treatment already used for bundled examples.