### PR TITLE
Reset button tooltip reflects target

### DIFF
--- a/src/components/Editor.svelte
+++ b/src/components/Editor.svelte
@@ -14,9 +14,10 @@
     code: string;
     onReset: () => void;
     resetVisible?: boolean;
+    resetTitle?: string;
   };
 
-  let { engine, code = $bindable(), onReset, resetVisible = true }: Props = $props();
+  let { engine, code = $bindable(), onReset, resetVisible = true, resetTitle = 'Reset code to selected example' }: Props = $props();
 
   // Persist code to localStorage on every change. saveCode swallows quota /
   // private-mode errors internally.
@@ -39,7 +40,7 @@
 
 <div class="editor">
   {#if resetVisible}
-    <IconButton icon="resetCode" title="Reset code to selected example" onClick={onReset} />
+    <IconButton icon="resetCode" title={resetTitle} onClick={onReset} />
   {/if}
   <CodeMirror
     bind:value={code}

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -151,6 +151,11 @@
   });
   const dirty = $derived(sourceCode !== null && code !== sourceCode);
   const resetVisible = $derived(dirty);
+  const resetTitle = $derived(
+    loadedSnippetId !== null && loadedSnippetId in snippets
+      ? `Reset to "${snippets[loadedSnippetId].title}"`
+      : 'Reset to selected example',
+  );
 
   const loadDisabled = $derived(pendingOp !== null);
   // Step/Run stay enabled in HALTED — they reload-from-code on entry, which
@@ -658,7 +663,7 @@
     {#await editorPromise}
       <div class="editor-loading">Loading editor…</div>
     {:then Editor}
-      <Editor {engine} bind:code onReset={resetCodeToSelected} {resetVisible} />
+      <Editor {engine} bind:code onReset={resetCodeToSelected} {resetVisible} {resetTitle} />
     {:catch err}
       <div class="editor-error">Failed to load editor: {err.message}</div>
     {/await}


### PR DESCRIPTION
Closes #26

`Editor.svelte` now accepts a `resetTitle` prop (defaults to the original static string). `MachineView.svelte` derives the correct label — snippet name when a snippet is loaded, otherwise "Reset to selected example" — and passes it down.