### PR TITLE
Snippet rename with inline confirm

### DIFF
--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -25,6 +25,7 @@
     loadSnippets,
     saveSnippet,
     deleteSnippet,
+    renameSnippet,
     type Snippets,
   } from '../lib/persist.ts';
   import { icons } from '../lib/icons.ts';
@@ -519,6 +520,14 @@
     // bundled example.
   }
 
+  function onRenameSnippet(id: string, newTitle: string): void {
+    const updated = renameSnippet(engine, id, newTitle);
+    if (!updated) return;
+    // On collision renameSnippet deletes the conflicting entry; rebuild the
+    // full map from localStorage so we don't have to replicate the logic here.
+    snippets = { ...loadSnippets(engine) };
+  }
+
   // Persist the selected example id (separate from the editor code) so the
   // reset button keeps targeting the chosen source across reloads.
   $effect(() => {
@@ -651,6 +660,7 @@
       {onSaveChanges}
       {onLoadSnippet}
       {onDeleteSnippet}
+      {onRenameSnippet}
     />
     <div
       class="status"

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -32,6 +32,7 @@
     onSaveChanges: () => void;
     onLoadSnippet: (id: string) => void;
     onDeleteSnippet: (id: string) => void;
+    onRenameSnippet: (id: string, newTitle: string) => void;
   };
 
   let {
@@ -56,6 +57,7 @@
     onSaveChanges,
     onLoadSnippet,
     onDeleteSnippet,
+    onRenameSnippet,
   }: Props = $props();
 
   // Examples dropdown — fully owned here so the outside-click and Escape
@@ -168,6 +170,52 @@
 
   let deletePendingId = $state<string | null>(null);
 
+  let renameId = $state<string | null>(null);
+  let renameDraft = $state('');
+  let renameOverwrite = $state(false);
+  let renameInputEl = $state<HTMLInputElement | undefined>(undefined);
+
+  const snippetTitlesExcludingRename = $derived(
+    renameId !== null
+      ? new Set(Object.entries(snippets).filter(([k]) => k !== renameId).map(([, s]) => s.title))
+      : snippetTitles,
+  );
+  const renameTrimmed = $derived(renameDraft.trim());
+  const renameConflicts = $derived(
+    renameTrimmed !== '' && snippetTitlesExcludingRename.has(renameTrimmed),
+  );
+
+  $effect(() => {
+    if (renameId !== null && renameInputEl) renameInputEl.focus();
+  });
+
+  $effect(() => {
+    void renameTrimmed;
+    renameOverwrite = false;
+  });
+
+  function openRename(id: string): void {
+    renameId = id;
+    renameDraft = snippets[id]?.title ?? '';
+    renameOverwrite = false;
+  }
+
+  function cancelRename(): void {
+    renameId = null;
+    renameDraft = '';
+    renameOverwrite = false;
+  }
+
+  function commitRename(): void {
+    if (!renameId || renameTrimmed === '') return;
+    if (renameConflicts && !renameOverwrite) {
+      renameOverwrite = true;
+      return;
+    }
+    onRenameSnippet(renameId, renameTrimmed);
+    cancelRename();
+  }
+
   // with-pause / interval are configuration for the *next* Run; meaningless
   // mid-run, so hide them in the running modes (they'd just be inert chrome).
   const configVisible = $derived(
@@ -198,7 +246,7 @@
             <button
               type="button"
               role="menuitem"
-              class:selected={ex.id === selectedExampleId}
+              class:selected={ex.id === selectedExampleId && loadedSnippetId === null}
               onclick={() => pick(ex)}
             >
               {ex.title}
@@ -226,6 +274,49 @@
                   title="Cancel"
                   onclick={(e) => { e.stopPropagation(); deletePendingId = null; }}
                 >Cancel</button>
+              {:else if renameId === id}
+                {#if renameOverwrite}
+                  <span class="rename-conflict-label">Overwrite "{renameTrimmed}"?</span>
+                  <button
+                    type="button"
+                    class="rename-confirm-yes"
+                    onclick={(e) => { e.stopPropagation(); commitRename(); }}
+                  >Yes</button>
+                  <button
+                    type="button"
+                    class="rename-confirm-no"
+                    onclick={(e) => { e.stopPropagation(); renameOverwrite = false; }}
+                  >No</button>
+                {:else}
+                  <input
+                    type="text"
+                    class="rename-input"
+                    class:conflict={renameConflicts}
+                    bind:this={renameInputEl}
+                    bind:value={renameDraft}
+                    maxlength="80"
+                    onclick={(e) => e.stopPropagation()}
+                    onkeydown={(e) => {
+                      if (e.key === 'Enter') { e.stopPropagation(); commitRename(); }
+                      if (e.key === 'Escape') { e.stopPropagation(); cancelRename(); }
+                    }}
+                  />
+                  <button
+                    type="button"
+                    class="rename-ok-btn"
+                    disabled={renameTrimmed === ''}
+                    aria-label="Confirm rename"
+                    title="Confirm rename"
+                    onclick={(e) => { e.stopPropagation(); commitRename(); }}
+                  >{@html icons.apply}</button>
+                  <button
+                    type="button"
+                    class="delete-btn"
+                    aria-label="Cancel rename"
+                    title="Cancel"
+                    onclick={(e) => { e.stopPropagation(); cancelRename(); }}
+                  >{@html icons.xSmall}</button>
+                {/if}
               {:else}
                 <button
                   type="button"
@@ -233,6 +324,13 @@
                   class:selected={id === loadedSnippetId}
                   onclick={() => { onLoadSnippet(id); examplesOpen = false; }}
                 >{snippet.title}</button>
+                <button
+                  type="button"
+                  class="rename-btn"
+                  aria-label="Rename snippet {snippet.title}"
+                  title="Rename"
+                  onclick={(e) => { e.stopPropagation(); openRename(id); }}
+                >{@html icons.pencil}</button>
                 <button
                   type="button"
                   class="delete-btn"
@@ -493,6 +591,9 @@
 
     .delete-btn {
       flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       width: 28px;
       padding: 4px;
       background: transparent;
@@ -512,6 +613,115 @@
         width: 14px;
         height: 14px;
       }
+    }
+
+    .rename-btn {
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      padding: 4px;
+      background: transparent;
+      border: none;
+      color: var(--muted);
+      border-radius: 4px;
+      cursor: pointer;
+      opacity: 0;
+
+      :global(svg) {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    &:hover .rename-btn {
+      opacity: 0.6;
+
+      &:hover {
+        color: var(--accent);
+        background: color-mix(in srgb, var(--accent) 12%, transparent);
+        opacity: 1;
+      }
+    }
+
+    .rename-input {
+      flex: 1;
+      min-width: 0;
+      background: var(--cell-bg);
+      border: 1px solid var(--cell-border);
+      color: var(--fg);
+      padding: 3px 6px;
+      font: inherit;
+      font-size: 13px;
+      border-radius: 4px;
+
+      &:focus {
+        outline: none;
+        border-color: var(--accent);
+      }
+
+      &.conflict {
+        border-color: var(--error);
+      }
+    }
+
+    .rename-ok-btn {
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      padding: 4px;
+      background: transparent;
+      border: none;
+      color: var(--accent);
+      border-radius: 4px;
+      cursor: pointer;
+
+      &:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--accent) 12%, transparent);
+      }
+
+      &:disabled {
+        opacity: 0.3;
+        cursor: not-allowed;
+      }
+
+      :global(svg) {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    .rename-conflict-label {
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-size: 12px;
+      color: var(--muted);
+      padding: 0 4px;
+    }
+
+    .rename-confirm-yes {
+      flex-shrink: 0;
+      font-size: 12px;
+      padding: 3px 8px;
+      border-color: color-mix(in srgb, var(--ok) 50%, transparent);
+      color: var(--ok);
+
+      &:hover {
+        border-color: var(--ok) !important;
+        color: var(--ok) !important;
+      }
+    }
+
+    .rename-confirm-no {
+      flex-shrink: 0;
+      font-size: 12px;
+      padding: 3px 8px;
     }
 
     .delete-confirm-label {

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -8,6 +8,7 @@ import keep from '@tabler/icons/outline/keyframe-align-vertical.svg?raw';
 import left from '@tabler/icons/outline/arrow-narrow-left.svg?raw';
 import moon from '@tabler/icons/outline/moon.svg?raw';
 import pause from '@tabler/icons/outline/player-pause.svg?raw';
+import pencil from '@tabler/icons/outline/pencil.svg?raw';
 import resetCode from '@tabler/icons/outline/arrow-back-up.svg?raw';
 import right from '@tabler/icons/outline/arrow-narrow-right.svg?raw';
 import run from '@tabler/icons/outline/player-play.svg?raw';
@@ -30,6 +31,7 @@ export const icons = {
   left,
   moon,
   pause,
+  pencil,
   resetCode,
   right,
   run,

--- a/src/lib/persist.ts
+++ b/src/lib/persist.ts
@@ -99,3 +99,29 @@ export function deleteSnippet(engine: Engine, id: string): void {
     /* ignore */
   }
 }
+
+// Renames a snippet's title, preserving its UUID and code.
+// If another snippet already has newTitle, that snippet is deleted and the
+// renamed snippet takes its place (current snippet's UUID survives).
+// Returns the updated snippet, or null if `id` is not found.
+export function renameSnippet(
+  engine: Engine,
+  id: string,
+  newTitle: string,
+): Snippet | null {
+  try {
+    const current = loadSnippets(engine);
+    const snippet = current[id];
+    if (!snippet) return null;
+    if (snippet.title === newTitle) return snippet;
+    const conflictId = Object.entries(current).find(
+      ([k, s]) => k !== id && s.title === newTitle,
+    )?.[0];
+    if (conflictId !== undefined) delete current[conflictId];
+    current[id] = { ...snippet, title: newTitle, savedAt: Date.now() };
+    localStorage.setItem(engineKey(engine, 'snippets'), JSON.stringify(current));
+    return current[id];
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #28

- `persist.ts`: adds `renameSnippet(engine, id, newTitle)` — preserves UUID and code; on title collision deletes the conflicting snippet
- `MachineView.svelte`: adds `onRenameSnippet` handler (reloads snippets from localStorage after a collision to stay in sync)
- `Toolbar.svelte`: pencil button on each snippet row opens an inline input; Enter/blur commits, Escape cancels; collision triggers a two-click overwrite confirm (matching the save-popover pattern)
- Bonus: example highlight is suppressed when a snippet is loaded (the example is no longer the active source)