### PR TITLE
Bump to 1.0.0-alpha.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "machines-demo",
-  "version": "1.0.0-alpha.10",
+  "version": "1.0.0-alpha.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "machines-demo",
-      "version": "1.0.0-alpha.10",
+      "version": "1.0.0-alpha.11",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machines-demo",
   "private": true,
-  "version": "1.0.0-alpha.10",
+  "version": "1.0.0-alpha.11",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bumps version to 1.0.0-alpha.11.

Includes issues #25–#28:
- #25 Highlight active snippet in dropdown
- #26 Reset button tooltip reflects target
- #27 Snippet delete: two-click inline confirm
- #28 Snippet rename with inline confirm