### PR TITLE
Bump engines to v4 (#39)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "@codemirror/lang-javascript": "^6.2.0",
         "@codemirror/lint": "^6.8.0",
         "@codemirror/theme-one-dark": "^6.1.0",
-        "@post-machine-js/machine": "^3.1.0",
+        "@post-machine-js/machine": "^4.0.0",
         "@tabler/icons": "^3.41.1",
-        "@turing-machine-js/machine": "^3.0.2",
+        "@turing-machine-js/machine": "^4.0.0",
         "codemirror": "^6.0.1",
         "svelte-codemirror-editor": "^2.1.0"
       },
@@ -829,15 +829,15 @@
       "license": "MIT"
     },
     "node_modules/@post-machine-js/machine": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@post-machine-js/machine/-/machine-3.1.0.tgz",
-      "integrity": "sha512-zvQsaYrD/KCrDTFNp6s8GEx5BlaR7eC4Zlin56Cu3hkvmFQGqFL6pgXU94ysgwNG2aVJcv7d8yTODDW2zXmiTQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@post-machine-js/machine/-/machine-4.0.0.tgz",
+      "integrity": "sha512-BjG70ywFaPYRRAuaMBth8RKPQvYLZvMnDdYfoUMPRMNbwSffQsyC/rkrxTaX5/p3z1MPp3YtimySwci/VDjbDg==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^3.0.1"
+        "@turing-machine-js/machine": "^4.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1257,9 +1257,9 @@
       "license": "MIT"
     },
     "node_modules/@turing-machine-js/machine": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-3.0.2.tgz",
-      "integrity": "sha512-f45nKgieeEdkxY8I8/RTKeNyaJQAztiMZhGYCC6fJQ7mnTs8lhVs12HH7Rh/3UhgnOqQk8sCxUkWvpFG1P6Kqg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-4.0.0.tgz",
+      "integrity": "sha512-gSdhz1/0b0ZeFwyn+rLQgWwehveu/HsXO6rLossenrRwaVIY3ej32wUqS5bZTNqYTManAWSfyZ1ASYBYxQbYcg==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "@codemirror/lang-javascript": "^6.2.0",
     "@codemirror/lint": "^6.8.0",
     "@codemirror/theme-one-dark": "^6.1.0",
-    "@post-machine-js/machine": "^3.1.0",
+    "@post-machine-js/machine": "^4.0.0",
     "@tabler/icons": "^3.41.1",
-    "@turing-machine-js/machine": "^3.0.2",
+    "@turing-machine-js/machine": "^4.0.0",
     "codemirror": "^6.0.1",
     "svelte-codemirror-editor": "^2.1.0"
   },


### PR DESCRIPTION
## Summary

- `@turing-machine-js/machine`: `^3.0.2` → `^4.0.0`
- `@post-machine-js/machine`: `^3.1.0` → `^4.0.0`
- `package-lock.json` refreshed

Bundled examples don't use any v4-only feature yet, so this is dep-only. `npm run check`, `npm run build`, `npm run lint` are clean locally.

The demo's worker still uses the sync `runStepByStep` path. The one unawaited v4 `run()` call site (`MachineView.svelte:258`) is currently correct — `run()` body runs synchronously when no `onDebugBreak` is provided — and is tracked for cleanup in #40.

Closes #39.

## Test plan

- [ ] Smoke-test on both tabs in `npm run dev`: Build / Step / Run / Take Control across all bundled examples; confirm no regressions