### PR TITLE
Worker: add run() mode with onDebugBreak hook (#40)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,20 +58,33 @@ src/
 
 ## Execution modes
 
-`ExecutionMode = 'DEMO' | 'MANUAL' | 'RUNNING_STEP' | 'RUNNING_AUTO' | 'RUNNING_CONTINUOUS' | 'HALTED'`
+`ExecutionMode = 'DEMO' | 'MANUAL' | 'RUNNING_STEP' | 'RUNNING_AUTO' | 'RUNNING_CONTINUOUS' | 'RUNNING_PAUSED_AT_BREAK' | 'HALTED'`
 
 | Mode | Panel | Apply visible | Take control | Belt behavior |
 |---|---|---|---|---|
 | `DEMO` | disabled mirror | yes (flashes) | yes | timer-driven random commands generated per tick from each tape's alphabet (40% keep, otherwise uniform). Loads `selectedExample.code` (canonical), not the editor's `code`. Auto-stops on first user-clicked Build (`demoEnabled = false`). |
 | `MANUAL` | enabled | yes | hidden | user-driven via Apply (writes to `mirrorMachine` via the same `ifOtherSymbol` one-step path used by Step) |
-| `RUNNING_STEP` | disabled mirror | hidden | yes | one slide per Step click; also serves as the **paused** state for `RUNNING_AUTO` |
-| `RUNNING_AUTO` | disabled mirror | hidden | yes | timer-driven worker steps; Step button shows pause icon + "Pause" label; click → `RUNNING_STEP` |
+| `RUNNING_STEP` | disabled mirror | hidden | yes | legacy step path — **only** entered as the paused state for `RUNNING_AUTO`. Cold-start Step now goes through run-mode → `RUNNING_PAUSED_AT_BREAK` instead. |
+| `RUNNING_AUTO` | disabled mirror | hidden | yes | timer-driven worker steps via `runner.step()`; Step button shows pause icon + "Pause" label; click → `RUNNING_STEP`. Doesn't pause at debug breakpoints (no `onDebugBreak` plumbing on this path; tracked in #43). |
 | `RUNNING_CONTINUOUS` | neutral cmd shown | hidden | hidden | snap-to-final, transitions off; per-step commands batch-logged after the worker returns |
+| `RUNNING_PAUSED_AT_BREAK` | disabled mirror | hidden | hidden | worker is paused inside `machine.run({ ... })` at an `onDebugBreak` fire (user-authored or Step-armed). Run button labels "Continue"; Step sends `resume(step: true)`; Stop terminates the worker. |
 | `HALTED` | disabled mirror | hidden | yes | frozen at final state. Build/Step/Run remain enabled — Step/Run reload-from-code on entry (the same path as MANUAL/DEMO), effectively restarting the machine without an explicit Build click. |
 
-Take control is the only entry into `MANUAL`. Once the user takes control, demo never restarts. From `MANUAL` (or `DEMO`/`HALTED`), Step and Run both call `reloadWorker(code)` first — the user's manual `Apply`s and code edits are reconciled by always rebuilding the worker + `mirrorMachine` from the current editor `code`.
+Take control is the only entry into `MANUAL`. Once the user takes control, demo never restarts. From `MANUAL` (or `DEMO`/`HALTED`), Step and Run both call `reloadWorker(code)` first — the user's manual `Apply`s and code edits are reconciled by always rebuilding the worker + `mirrorMachine` from the current editor `code`. **Cold-start Step then enters run-mode via `runner.run({ step: true, debug, onPaused })`** — the worker arms `initialState.debug.after = true` so iter 1's after-fire is the step boundary, then transitions to `RUNNING_PAUSED_AT_BREAK`.
 
-A `Stop` button is shown next to Run while `RUNNING_STEP` / `RUNNING_AUTO` (`stopVisible`); clicking it sets `executionMode = 'HALTED'` and reports `'stopped'`. The auto-step `$effect` cleans itself up when mode leaves `RUNNING_AUTO`.
+A `Stop` button is shown next to Run while `RUNNING_STEP` / `RUNNING_AUTO` / `RUNNING_PAUSED_AT_BREAK` (`stopVisible`); clicking it sets `executionMode = 'HALTED'` and reports `'stopped'`. From `RUNNING_PAUSED_AT_BREAK` it also terminates the worker (the `runner.run()` Promise rejects; `failHalted` is suppressed via `stopRequested`). The auto-step `$effect` cleans itself up when mode leaves `RUNNING_AUTO`.
+
+## Debugger UX (debug mode + breakpoints)
+
+A `debug` checkbox in the Toolbar controls whether user-authored `state.debug` / `haltState.debug` breakpoints pause execution. State `debugMode` is owned by `MachineView.svelte`, persisted to `localStorage` under `machines-demo:<engine>:debugMode`. Mid-run toggle works via `runner.setDebug(on)` — a `$effect` watches `debugMode` and pushes the change to the worker, which flips an internal `debugEnabled` flag without restarting.
+
+Step (cold-start and from break) always uses run-mode and arms `state.debug.after = true` on the relevant state to fire one boundary pause:
+- **Cold-start**: arms `initialState.debug.after = true` before invoking `machine.run(...)` (preserves any user-authored `state.debug.before`).
+- **From `RUNNING_PAUSED_AT_BREAK`**: `resume(step: true)` arms `m.state.debug.after` (when paused at before) or `m.nextState.debug.after` (when paused at after). `pendingRestore` undoes the mutation before the user observes the next break.
+
+`PausedResponse.stepInduced` distinguishes worker-armed Step boundaries from user-authored breakpoints. The worker computes it by reading `m.state.debug[when]` AFTER `pendingRestore` runs (so it reflects the user's authored value, not our arm). `MachineView#onPausedHandler` logs full `paused at state X before/after applying command for symbols: [...]` only when `debugMode && !stepInduced`; otherwise generic `paused`.
+
+**Engine quirks at halt** (filed upstream as [`turing-machine-js#108`](https://github.com/mellonis/turing-machine-js/issues/108)): the halting iter's `after`-fire never fires (the engine's `prevYield`-deferred after pattern needs an iter K+1 that doesn't exist when iter K transitions to halt); `haltState.debug.after` is silently ignored (no halt-pause anchor). `haltState.debug.before` IS honored — fires on the iter that transitions to halt, OR'd into that iter's `beforeMatch`.
 
 ## Worker contract
 
@@ -81,7 +94,11 @@ All shapes are TS discriminated unions in `src/lib/types.ts`. Single canonical `
 |---|---|
 | `{ type: 'build', engine, code }` | `{ type: 'built', tapes, alphabets, halted }` |
 | `{ type: 'step' }` | `{ type: 'stepped', halted, commands, nextCommands, stepsApplied }` |
-| `{ type: 'run', maxSteps? }` | `{ type: 'ran', tapes, truncated, commands, startStep, stepsApplied }` |
+| `{ type: 'run', maxSteps?, debug?, step? }` | `{ type: 'ran', tapes, truncated, commands, startStep, stepsApplied }` (or interleaved `paused`s, see below) |
+| `{ type: 'resume', step? }` | `paused` (next break) or `ran` (halt) |
+| `{ type: 'setDebug', on }` | (no response — fire-and-forget; flips worker-side `debugEnabled` flag) |
+
+`paused` interleaves with `ran`/`error` on the run channel: `{ type: 'paused', tapes, commands, stepsApplied, state, currentSymbols, debugBreak, stepInduced }`. The runner's `run({ onPaused })` Promise stays pending across paused/resume cycles; only `ran` / `error` complete it. Per-segment timer suspends on `paused`, restarts on `resume`-send, killed on `ran` / `error`.
 
 On any failure: `{ type: 'error', message, tapes? }`. When the worker errors mid-step / mid-run (typical case: no edge in the state graph for the current symbol), the response also carries the partial tape state. The runner wraps `error` responses in a `WorkerError` (custom class with a `tapes` field); `MachineView.svelte#failHalted` rebuilds the mirror and updates `lastSnapshots` from those tapes — without this, the user would see only the loaded tape and lose every step the worker actually applied before throwing.
 
@@ -96,7 +113,7 @@ The main thread converts each `TapeSnapshot` to a `turing.Tape` once via `_build
 **Caps** (all in `lib/caps.ts`):
 - `MAX_TAPES = 5` — multi-tape limit; the worker rejects loads with more tapes than the caret palette can color.
 - `MAX_STEPS = 100_000` — `run`-mode hard cap; if `runToEnd` reaches it before the machine halts, the response sets `truncated: true`. Same backstop as `WORKER_TIMEOUT_MS` but counts steps instead of wall-clock time, so a tight loop that never yields still terminates eventually.
-- `WORKER_TIMEOUT_MS = 5_000` — wall-clock cap on a single worker request. The `MachineRunner` schedules a `setTimeout` and kills the worker (terminate + respawn next request) if the round-trip exceeds it.
+- `WORKER_TIMEOUT_MS = 5_000` — wall-clock cap on a single worker request **segment**. For `build` / `step` / `run`-without-pause it's a round-trip cap. For `run` with paused/resume cycles it's per-segment: timer suspends on each `paused` (user is inspecting; no clock), restarts on `resume`-send, killed on `ran`/`error`. The `MachineRunner` schedules a `setTimeout` and kills the worker (terminate + respawn next request) if any segment exceeds it.
 - `VIEWPORT_WIDTH = 23` — see Tape section below.
 
 Tape derivation in `machineWorker.ts` prefers `tapeBlock.tapes` so a user adapting the single-tape default snippet to multi-tape doesn't silently see only tape 0.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Step (cold-start and from break) always uses run-mode and arms `state.debug.afte
 - **Cold-start**: arms `initialState.debug.after = true` before invoking `machine.run(...)` (preserves any user-authored `state.debug.before`).
 - **From `RUNNING_PAUSED_AT_BREAK`**: `resume(step: true)` arms `m.state.debug.after` (when paused at before) or `m.nextState.debug.after` (when paused at after). `pendingRestore` undoes the mutation before the user observes the next break.
 
-`PausedResponse.stepInduced` distinguishes worker-armed Step boundaries from user-authored breakpoints. The worker computes it by reading `m.state.debug[when]` AFTER `pendingRestore` runs (so it reflects the user's authored value, not our arm). `MachineView#onPausedHandler` logs full `paused at state X before/after applying command for symbols: [...]` only when `debugMode && !stepInduced`; otherwise generic `paused`.
+`MachineView#onPausedHandler` always logs `paused at state X <when> applying command for symbols: [...]`. Reads as "we made a step, look at the result": `.after`-arming means iter K just ran when we pause, and the log surfaces iter K's state + just-executed symbols. The `debug` toggle gates whether user-authored breaks fire, not how pauses are logged.
 
 **Engine quirks at halt** (filed upstream as [`turing-machine-js#108`](https://github.com/mellonis/turing-machine-js/issues/108)): the halting iter's `after`-fire never fires (the engine's `prevYield`-deferred after pattern needs an iter K+1 that doesn't exist when iter K transitions to halt); `haltState.debug.after` is silently ignored (no halt-pause anchor). `haltState.debug.before` IS honored — fires on the iter that transitions to halt, OR'd into that iter's `beforeMatch`.
 
@@ -98,7 +98,7 @@ All shapes are TS discriminated unions in `src/lib/types.ts`. Single canonical `
 | `{ type: 'resume', step? }` | `paused` (next break) or `ran` (halt) |
 | `{ type: 'setDebug', on }` | (no response — fire-and-forget; flips worker-side `debugEnabled` flag) |
 
-`paused` interleaves with `ran`/`error` on the run channel: `{ type: 'paused', tapes, commands, stepsApplied, state, currentSymbols, debugBreak, stepInduced }`. The runner's `run({ onPaused })` Promise stays pending across paused/resume cycles; only `ran` / `error` complete it. Per-segment timer suspends on `paused`, restarts on `resume`-send, killed on `ran` / `error`.
+`paused` interleaves with `ran`/`error` on the run channel: `{ type: 'paused', tapes, commands, stepsApplied, state, currentSymbols, debugBreak }`. The runner's `run({ onPaused })` Promise stays pending across paused/resume cycles; only `ran` / `error` complete it. Per-segment timer suspends on `paused`, restarts on `resume`-send, killed on `ran` / `error`.
 
 On any failure: `{ type: 'error', message, tapes? }`. When the worker errors mid-step / mid-run (typical case: no edge in the state graph for the current symbol), the response also carries the partial tape state. The runner wraps `error` responses in a `WorkerError` (custom class with a `tapes` field); `MachineView.svelte#failHalted` rebuilds the mirror and updates `lastSnapshots` from those tapes — without this, the user would see only the loaded tape and lose every step the worker actually applied before throwing.
 

--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ User code and the engine live inside a Web Worker. The main thread holds the UI 
 
                       ↕  postMessage
 
-        requests:   build / step / run / resume
+        requests:   build / step / run / resume / setDebug
         responses:  built / stepped / ran / paused / error
 ```
 
-**Crosses the boundary:** `TapeSnapshot[]` (on `built` / `ran` / `error` / `paused`), per-step `Command[]` (movement + written symbol), tape alphabets, plus break metadata (state name, current symbols, `debugBreak` flags) on `paused` — plain data only.
+**Crosses the boundary:** `TapeSnapshot[]` (on `built` / `ran` / `error` / `paused`), per-step `Command[]` (movement + written symbol), tape alphabets, plus break metadata (state name, current symbols, `debugBreak` flags, `stepInduced` flag distinguishing user breakpoints from worker-armed Step boundaries) on `paused` — plain data only.
 
 **Never crosses:** the user's code, the `TuringMachine` / `State` / `Reference` instances it constructs, and the upstream library singletons (`haltState`, `ifOtherSymbol`, the `movements` Symbols). Identity-checked sentinels wouldn't survive `structuredClone`, and keeping user code worker-side is what justifies `'unsafe-eval'` in CSP — the worker is the actual security boundary.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ User code and the engine live inside a Web Worker. The main thread holds the UI 
         responses:  built / stepped / ran / paused / error
 ```
 
-**Crosses the boundary:** `TapeSnapshot[]` (on `built` / `ran` / `error` / `paused`), per-step `Command[]` (movement + written symbol), tape alphabets, plus break metadata (state name, current symbols, `debugBreak` flags, `stepInduced` flag distinguishing user breakpoints from worker-armed Step boundaries) on `paused` — plain data only.
+**Crosses the boundary:** `TapeSnapshot[]` (on `built` / `ran` / `error` / `paused`), per-step `Command[]` (movement + written symbol), tape alphabets, plus break metadata (state name, current symbols, `debugBreak` flags) on `paused` — plain data only.
 
 **Never crosses:** the user's code, the `TuringMachine` / `State` / `Reference` instances it constructs, and the upstream library singletons (`haltState`, `ifOtherSymbol`, the `movements` Symbols). Identity-checked sentinels wouldn't survive `structuredClone`, and keeping user code worker-side is what justifies `'unsafe-eval'` in CSP — the worker is the actual security boundary.
 

--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ User code and the engine live inside a Web Worker. The main thread holds the UI 
 
                       ↕  postMessage
 
-        requests:   build / step / run
-        responses:  built / stepped / ran / error
+        requests:   build / step / run / resume
+        responses:  built / stepped / ran / paused / error
 ```
 
-**Crosses the boundary:** `TapeSnapshot[]` (on `built` / `ran` / `error`), per-step `Command[]` (movement + written symbol), tape alphabets — plain data only.
+**Crosses the boundary:** `TapeSnapshot[]` (on `built` / `ran` / `error` / `paused`), per-step `Command[]` (movement + written symbol), tape alphabets, plus break metadata (state name, current symbols, `debugBreak` flags) on `paused` — plain data only.
 
 **Never crosses:** the user's code, the `TuringMachine` / `State` / `Reference` instances it constructs, and the upstream library singletons (`haltState`, `ifOtherSymbol`, the `movements` Symbols). Identity-checked sentinels wouldn't survive `structuredClone`, and keeping user code worker-side is what justifies `'unsafe-eval'` in CSP — the worker is the actual security boundary.
 

--- a/docs/superpowers/plans/2026-05-08-worker-run-mode.md
+++ b/docs/superpowers/plans/2026-05-08-worker-run-mode.md
@@ -1141,15 +1141,11 @@ function onPausedHandler(paused: import('../lib/types.ts').PausedResponse): void
   lastSnapshots = paused.tapes;
   _buildMirrorMachine(paused.tapes, alphabets);
   setAllFromMirror();
-  // Format the break log entry.
-  const phase =
-    paused.debugBreak.before && paused.debugBreak.after
-      ? 'before+after'
-      : paused.debugBreak.before
-        ? 'before'
-        : 'after';
+  // Format the break log entry. Engine's run() dispatches onDebugBreak
+  // separately for before/after — exactly one is true at the wire.
+  const kind = paused.debugBreak.before ? 'before' : 'after';
   const symbols = paused.currentSymbols.join(' ');
-  report(`paused at ${paused.state || '(unnamed)'} [${phase}]: ${symbols}`, 'ok');
+  report(`paused at ${paused.state || '(unnamed)'} [${kind}]: ${symbols}`, 'ok');
   executionMode = 'RUNNING_PAUSED_AT_BREAK';
 }
 ```

--- a/docs/superpowers/plans/2026-05-08-worker-run-mode.md
+++ b/docs/superpowers/plans/2026-05-08-worker-run-mode.md
@@ -659,12 +659,14 @@ export class MachineRunner {
       this.runPending.onPaused?.(data);
       return;
     }
-    // ran / error complete the run; stepped / built complete a simple request.
+    // ran completes the run.
     if (data.type === 'ran') {
       const p = this.runPending;
       this.runPending = null;
       if (!p) return;
-      this.stopRunTimer();
+      // Clear timer via captured local — stopRunTimer() guards on
+      // !this.runPending and would no-op here.
+      if (p.timeoutId) clearTimeout(p.timeoutId);
       p.resolveRan(data);
       return;
     }
@@ -673,7 +675,7 @@ export class MachineRunner {
       if (this.runPending) {
         const p = this.runPending;
         this.runPending = null;
-        this.stopRunTimer();
+        if (p.timeoutId) clearTimeout(p.timeoutId);
         p.reject(err);
         return;
       }

--- a/docs/superpowers/plans/2026-05-08-worker-run-mode.md
+++ b/docs/superpowers/plans/2026-05-08-worker-run-mode.md
@@ -1,0 +1,1387 @@
+# Worker run() mode with onDebugBreak — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire v4's `onDebugBreak` into the demo's Run flow end-to-end, so user code that sets `state.debug` / `haltState.debug` pauses execution at break points with Continue / Step / Stop affordances. Track #40.
+
+**Architecture:** Extend the worker's existing `run` request with an optional `debug` flag and break-pause support. Add `resume` request and `paused` response. New main-thread mode `RUNNING_PAUSED_AT_BREAK` with Continue/Step/Stop. A "Debug mode" checkbox in the Toolbar gates whether breaks pause; Step from break uses a `nextState.debug = { before: true }` one-shot trick (deferred via `onStep` for `after`-breaks). Worker gains a phase state machine (defense in depth).
+
+**Tech Stack:** TypeScript, Svelte 5 (runes), Web Worker, `@turing-machine-js/machine` v4, Vite. No test framework — verification is `npm run check` + `npm run build` + `npm run lint` + manual smoke testing.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-worker-run-mode-design.md`
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `src/lib/types.ts` | Extend `WorkerRequest` (`run.debug?`, new `resume`); add `PausedResponse`; add to `WorkerResponse` union |
+| `src/lib/persist.ts` | Add `loadDebugMode` / `saveDebugMode` |
+| `src/lib/machineWorker.ts` | Phase machine; `await machine.run({...})` replacing `runToEnd`; `paused` posting; `resume` handler; `pendingStepNext` flag for after-break step trick |
+| `src/lib/machineRunner.ts` | Async run lifecycle: `onPaused` callback in `run()` opts, `resume(step?)` API, per-segment timer (suspend on `paused`, resume on `resume`-send) |
+| `src/lib/defaultCode.ts` | One-line "don't run the machine" comment in all 3 snippets |
+| `src/components/Toolbar.svelte` | Add "Debug mode" checkbox + `debugMode` prop |
+| `src/components/MachineView.svelte` | New `RUNNING_PAUSED_AT_BREAK` mode; debugMode state + persist; paused handler with log replay; Continue/Step/Stop wiring; take-control log entry; `_runMirrorStep` async + `await` (line 258 fix) |
+| `README.md` | "Architecture: two lands" — add `paused` / `resume` to wire shapes |
+
+---
+
+## Verification model
+
+This codebase has no automated tests. Each task that changes code finishes with:
+
+1. `npm run check` — `svelte-check` + `tsc --noEmit`. Must be 0 errors / 0 warnings.
+2. `npm run lint` — ESLint flat config. Must exit 0.
+3. `npm run build` — production build. Must succeed.
+
+A final smoke-test task (Task 13) walks both engines through every UX path.
+
+---
+
+## Task 1: Extend worker boundary types
+
+**Files:**
+- Modify: `src/lib/types.ts`
+
+- [ ] **Step 1: Extend `WorkerRequest` and add `PausedResponse`**
+
+In `src/lib/types.ts`, update the `WorkerRequest` union and add a new response type. Replace lines 48-51 (the `WorkerRequest` union) with:
+
+```ts
+export type WorkerRequest =
+  | { type: 'build'; engine: Engine; code: string }
+  | { type: 'step' }
+  | { type: 'run'; maxSteps?: number; debug?: boolean }
+  | { type: 'resume'; step?: boolean };
+```
+
+Add this `PausedResponse` shape immediately after `RanResponse` (around line 86, before `ErrorResponse`):
+
+```ts
+/**
+ * Sent by the worker when `machine.run({ debug: true, ... })` hit a break
+ * point (state.debug or haltState.debug). The main thread responds with a
+ * `resume` request (optionally `step: true`) to continue, or terminates the
+ * worker via the runner to stop. The worker's `run()` Promise stays pending
+ * across paused/resume cycles; only `ran` / `error` complete it.
+ */
+export type PausedResponse = {
+  type: 'paused';
+  tapes: TapeSnapshot[];
+  /**
+   * Per-step commands buffered since the previous `paused` (or since the
+   * `run` request started). The main thread replays these in the Log so the
+   * user sees the trace leading up to the break; tape state is restored
+   * from `tapes` (snap, no animation), same path as `ran`.
+   */
+  commands: Command[][];
+  stepsApplied: number;
+  /** `m.state.name` — the user's State instance does not cross the boundary. */
+  state: string;
+  currentSymbols: string[];
+  /** At least one of `before` / `after` is `true`. Field shape mirrors the
+   * upstream `m.debugBreak` type (omitted-key = false, never `undefined`). */
+  debugBreak: { before?: true; after?: true };
+};
+```
+
+Add `PausedResponse` to the `WorkerResponse` union (line 100-104):
+
+```ts
+export type WorkerResponse =
+  | BuiltResponse
+  | SteppedResponse
+  | RanResponse
+  | PausedResponse
+  | ErrorResponse;
+```
+
+- [ ] **Step 2: Verify the type changes**
+
+Run: `npm run check`
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/types.ts
+git commit -m "Worker types: add resume/paused, run.debug flag (#40)"
+```
+
+---
+
+## Task 2: Persist debugMode
+
+**Files:**
+- Modify: `src/lib/persist.ts`
+
+- [ ] **Step 1: Add load/save for debugMode**
+
+In `src/lib/persist.ts`, add two functions after `saveExampleId` (around line 62):
+
+```ts
+export function loadDebugMode(engine: Engine): boolean {
+  try {
+    return localStorage.getItem(engineKey(engine, 'debugMode')) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function saveDebugMode(engine: Engine, on: boolean): void {
+  try {
+    localStorage.setItem(engineKey(engine, 'debugMode'), on ? 'true' : 'false');
+  } catch {
+    /* quota or private mode — ignore */
+  }
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `npm run check && npm run lint`
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/persist.ts
+git commit -m "Persist debugMode per engine (#40)"
+```
+
+---
+
+## Task 3: Worker — phase state machine and async run skeleton
+
+**Files:**
+- Modify: `src/lib/machineWorker.ts`
+
+This is the largest single task. It does the structural rewrite without yet implementing the Step trick (Task 4).
+
+- [ ] **Step 1: Replace the worker's runtime state and request loop**
+
+Open `src/lib/machineWorker.ts`. Replace the runtime-state block (lines 96-114, "runtime state" through `function reset()`) with:
+
+```ts
+/* ───── runtime state ───── */
+
+type WorkerPhase =
+  | { kind: 'idle' }
+  | { kind: 'built'; halted: boolean }
+  | { kind: 'running' }
+  | { kind: 'paused' };
+
+let phase: WorkerPhase = { kind: 'idle' };
+let machine: AnyMachine | null = null;
+let initialState: unknown = null;
+let tapes: AnyTape[] = [];
+let generator: Generator<MachineYield, void, void> | null = null;
+let stepsApplied = 0;
+let pendingCommand: MachineYield | null = null;
+
+// Holds the resolver of the Promise awaited inside onDebugBreak. Set when
+// the worker is paused at a break; cleared on `resume`. Concurrent `run`
+// requests are rejected by the phase machine before they reach this slot.
+let resumeResolve: ((action: { step: boolean }) => void) | null = null;
+
+// Per-run buffer of commands captured by onStep. Drained on `paused` (sent
+// in the response) and on `ran` (sent in the response).
+let runCommandBuffer: Command[][] = [];
+let runStartStep = 0;
+
+function reset(): void {
+  phase = { kind: 'idle' };
+  machine = null;
+  initialState = null;
+  tapes = [];
+  generator = null;
+  stepsApplied = 0;
+  pendingCommand = null;
+  resumeResolve = null;
+  runCommandBuffer = [];
+  runStartStep = 0;
+}
+
+function expectPhase(...allowed: WorkerPhase['kind'][]): void {
+  if (!allowed.includes(phase.kind)) {
+    throw new Error(
+      `worker phase ${phase.kind}, expected ${allowed.join('|')}`,
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Update `build()` to set the phase**
+
+In the same file, modify `build()` (around line 153). After the existing `generator = machine.runStepByStep(...)` block (the `if (first.done)` check around line 207-212), set the phase:
+
+```ts
+  generator = machine.runStepByStep({ initialState });
+  const first = generator.next();
+  if (first.done) {
+    phase = { kind: 'built', halted: true };
+    pendingCommand = null;
+  } else {
+    phase = { kind: 'built', halted: false };
+    pendingCommand = first.value;
+  }
+}
+```
+
+(Replace the `halted = true; pendingCommand = null;` and `halted = false; ...` legacy lines — `halted` is no longer a separate field; phase carries it.)
+
+- [ ] **Step 3: Update `step()` to use phase**
+
+Replace `function step()` (around line 215-230) with:
+
+```ts
+function step(): { commands: Command[] | null; nextCommands: Command[] | null; halted: boolean } {
+  expectPhase('built');
+  const built = phase as Extract<WorkerPhase, { kind: 'built' }>;
+  if (built.halted || !pendingCommand || !generator) {
+    return { commands: null, nextCommands: null, halted: true };
+  }
+  const commands = commandsFromYield(pendingCommand);
+  const r = generator.next();
+  stepsApplied += 1;
+  let halted: boolean;
+  if (r.done) {
+    halted = true;
+    pendingCommand = null;
+  } else {
+    halted = false;
+    pendingCommand = r.value;
+  }
+  phase = { kind: 'built', halted };
+  const nextCommands = pendingCommand ? commandsFromYield(pendingCommand) : null;
+  return { commands, nextCommands, halted };
+}
+```
+
+- [ ] **Step 4: Replace `runToEnd` with async `run`**
+
+Delete `runToEnd` (around line 232-250) and replace with:
+
+```ts
+async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boolean; startStep: number }> {
+  expectPhase('built');
+  const built = phase as Extract<WorkerPhase, { kind: 'built' }>;
+  if (built.halted || !machine) throw new Error('cannot run: halted or not built');
+
+  // Initial-yield handling: build() always primes pendingCommand. We discard
+  // the engine's runStepByStep generator and start a fresh `run()` from the
+  // current initial state — the engine handles its own iteration internally.
+  generator = null;
+  pendingCommand = null;
+
+  runStartStep = stepsApplied;
+  runCommandBuffer = [];
+  phase = { kind: 'running' };
+
+  let truncated = false;
+
+  try {
+    await machine.run({
+      initialState,
+      stepsLimit: maxSteps,
+      onStep: (m: MachineYield) => {
+        runCommandBuffer.push(commandsFromYield(m));
+        stepsApplied += 1;
+      },
+      onDebugBreak: debug
+        ? async (m: DebugBreakPayload) => {
+            // Send the buffered run-segment so far, then wait for resume.
+            const commandsBatch = runCommandBuffer;
+            runCommandBuffer = [];
+            phase = { kind: 'paused' };
+            send({
+              type: 'paused',
+              tapes: snapshotTapes(),
+              commands: commandsBatch,
+              stepsApplied,
+              state: m.state.name ?? '',
+              currentSymbols: [...m.currentSymbols],
+              debugBreak: { ...m.debugBreak } as { before?: true; after?: true },
+            });
+            await new Promise<void>((resolve) => {
+              resumeResolve = (_action) => {
+                resumeResolve = null;
+                resolve();
+              };
+            });
+            phase = { kind: 'running' };
+          }
+        : undefined,
+    });
+  } catch (err) {
+    // The engine throws when its stepsLimit counter is reached. Check the
+    // counter at catch time — more reliable than a flag set in onStep
+    // (engine may throw before the flag-setting iteration's onStep runs).
+    if (stepsApplied - runStartStep >= maxSteps) {
+      truncated = true;
+      // fall through, send `ran` with truncated: true
+    } else {
+      // Reset phase before rethrow so the catch in onmessage sees a known
+      // state. tapes still hold partial state (existing error path).
+      phase = { kind: 'built', halted: false };
+      throw err;
+    }
+  }
+
+  phase = { kind: 'built', halted: true };
+  return { truncated, startStep: runStartStep };
+}
+```
+
+You'll need to add a `MachineYield`-compatible type for `onStep`/`onDebugBreak` payloads. Above the `runtime state` block, add:
+
+```ts
+// onDebugBreak payload subset we read. Engine's full type carries more.
+type DebugBreakPayload = {
+  state: { name?: string };
+  currentSymbols: string[];
+  nextState: { debug: { before?: true; after?: true } | null };
+  debugBreak?: { before?: true; after?: true };
+};
+```
+
+(The `MachineYield` already exists in this file; it's the engine's per-step yield. We're treating onStep as receiving a `MachineYield`-like object.)
+
+- [ ] **Step 5: Wire `run` and `resume` into the request handler**
+
+Replace the request-handling block (around line 256-315, the `self.onmessage` body) with:
+
+```ts
+function send(msg: WorkerResponse): void {
+  self.postMessage(msg);
+}
+
+self.onmessage = (e: MessageEvent<unknown>) => {
+  const msg = e.data;
+  if (!msg || typeof msg !== 'object' || !('type' in msg)) {
+    send({ type: 'error', message: 'malformed worker message' });
+    return;
+  }
+
+  const req = msg as WorkerRequest;
+  void handleRequest(req);
+};
+
+async function handleRequest(req: WorkerRequest): Promise<void> {
+  try {
+    if (req.type === 'build') {
+      build(req.engine, req.code);
+      const built = phase as Extract<WorkerPhase, { kind: 'built' }>;
+      send({
+        type: 'built',
+        tapes: snapshotTapes(),
+        alphabets: snapshotAlphabets(),
+        halted: built.halted,
+      });
+      return;
+    }
+
+    if (req.type === 'step') {
+      const { commands, nextCommands, halted } = step();
+      send({
+        type: 'stepped',
+        halted,
+        commands,
+        nextCommands,
+        stepsApplied,
+      });
+      return;
+    }
+
+    if (req.type === 'run') {
+      const { truncated, startStep } = await run(req.maxSteps ?? MAX_STEPS, req.debug ?? false);
+      send({
+        type: 'ran',
+        tapes: snapshotTapes(),
+        truncated,
+        commands: runCommandBuffer,
+        startStep,
+        stepsApplied,
+      });
+      runCommandBuffer = [];
+      return;
+    }
+
+    if (req.type === 'resume') {
+      expectPhase('paused');
+      const r = resumeResolve;
+      if (!r) throw new Error('resume: no pending Promise');
+      r({ step: req.step ?? false });
+      return;
+    }
+
+    throw new Error(`unknown message type: ${(req as { type: string }).type}`);
+  } catch (err) {
+    send({
+      type: 'error',
+      message: err instanceof Error ? err.message : String(err),
+      tapes: tapes.length > 0 ? snapshotTapes() : undefined,
+    });
+  }
+}
+```
+
+- [ ] **Step 6: Verify**
+
+Run: `npm run check`
+Expected: 0 errors, 0 warnings. If `MachineYield` typing complains for `onStep`, cast at the call site (`m as MachineYield`).
+
+Run: `npm run build`
+Expected: succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/machineWorker.ts
+git commit -m "Worker: phase machine + async run with onDebugBreak (#40)"
+```
+
+---
+
+## Task 4: Worker — Step from break (`nextState.debug` trick)
+
+**Files:**
+- Modify: `src/lib/machineWorker.ts`
+
+Adds the deferred-onStep coordination so Step from `RUNNING_PAUSED_AT_BREAK` advances exactly one iteration.
+
+- [ ] **Step 1: Add step-trick state and onStep deferral**
+
+In `src/lib/machineWorker.ts`, add two module-level slots near `resumeResolve`:
+
+```ts
+let pendingStepNext = false;
+let pendingRestore: (() => void) | null = null;
+```
+
+Reset both in `reset()`:
+
+```ts
+function reset(): void {
+  // ... existing resets ...
+  pendingStepNext = false;
+  pendingRestore = null;
+}
+```
+
+- [ ] **Step 2: Wire onStep to apply the deferred trick**
+
+Inside `run()`, replace the `onStep` callback in the `machine.run({...})` call with:
+
+```ts
+onStep: (m: MachineYield & { nextState?: { debug: { before?: true } | null } }) => {
+  if (pendingStepNext && m.nextState) {
+    const ns = m.nextState as { debug: { before?: true } | null };
+    const original = ns.debug;
+    ns.debug = { before: true };
+    pendingRestore = () => { ns.debug = original; };
+    pendingStepNext = false;
+  }
+  runCommandBuffer.push(commandsFromYield(m));
+  stepsApplied += 1;
+},
+```
+
+- [ ] **Step 3: Wire onDebugBreak to consume `step` action and arm the trick**
+
+Inside `run()`, replace the existing `onDebugBreak` callback with:
+
+```ts
+onDebugBreak: debug
+  ? async (m: DebugBreakPayload) => {
+      // Restore the synthesized one-shot before the user observes the break.
+      if (pendingRestore) {
+        pendingRestore();
+        pendingRestore = null;
+      }
+      const commandsBatch = runCommandBuffer;
+      runCommandBuffer = [];
+      phase = { kind: 'paused' };
+      send({
+        type: 'paused',
+        tapes: snapshotTapes(),
+        commands: commandsBatch,
+        stepsApplied,
+        state: m.state.name ?? '',
+        currentSymbols: [...m.currentSymbols],
+        debugBreak: { ...m.debugBreak } as { before?: true; after?: true },
+      });
+      const action = await new Promise<{ step: boolean }>((resolve) => {
+        resumeResolve = (a) => {
+          resumeResolve = null;
+          resolve(a);
+        };
+      });
+      phase = { kind: 'running' };
+      if (action.step) {
+        if (m.debugBreak?.before) {
+          // m IS the current iteration — arm directly.
+          // onStep deferral path: when an `after` break fires, the engine
+          // substitutes m to prevYield in onDebugBreak, so the un-substituted
+          // machineState reaches us only via the next onStep call. If
+          // turing-machine-js#107 lands (escape hatch for un-substituted
+          // snapshot), this branch and pendingStepNext can collapse.
+          const ns = m.nextState as { debug: { before?: true } | null };
+          const original = ns.debug;
+          ns.debug = { before: true };
+          pendingRestore = () => { ns.debug = original; };
+        } else {
+          pendingStepNext = true;
+        }
+      }
+    }
+  : undefined,
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `npm run check && npm run lint && npm run build`
+Expected: all clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/machineWorker.ts
+git commit -m "Worker: Step from break via nextState.debug trick (#40)"
+```
+
+---
+
+## Task 5: Runner — async run lifecycle, onPaused callback, resume API
+
+**Files:**
+- Modify: `src/lib/machineRunner.ts`
+
+- [ ] **Step 1: Update imports and add Pending shape for runs**
+
+In `src/lib/machineRunner.ts`, replace the imports block with:
+
+```ts
+import MachineWorker from './machineWorker.ts?worker';
+import { MAX_STEPS, WORKER_TIMEOUT_MS } from './caps.ts';
+import {
+  type BuiltResponse,
+  type Engine,
+  type PausedResponse,
+  type RanResponse,
+  type SteppedResponse,
+  type TapeSnapshot,
+  type WorkerRequest,
+  type WorkerResponse,
+} from './types.ts';
+```
+
+- [ ] **Step 2: Replace single-pending model with run-aware tracking**
+
+Replace the `Pending` type and the `MachineRunner` class body (everything from line 29 to end of file) with:
+
+```ts
+type SimplePending = {
+  resolve: (data: WorkerResponse) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+type RunPending = {
+  resolveRan: (data: RanResponse) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout> | null;
+  onPaused: ((data: PausedResponse) => void) | null;
+};
+
+export class MachineRunner {
+  readonly engine: Engine;
+  private worker: Worker | null = null;
+  private simplePending: SimplePending | null = null;
+  private runPending: RunPending | null = null;
+
+  constructor(engine: Engine) {
+    this.engine = engine;
+  }
+
+  private rejectAll(err: Error): void {
+    if (this.simplePending) {
+      clearTimeout(this.simplePending.timer);
+      this.simplePending.reject(err);
+      this.simplePending = null;
+    }
+    if (this.runPending) {
+      if (this.runPending.timer) clearTimeout(this.runPending.timer);
+      this.runPending.reject(err);
+      this.runPending = null;
+    }
+  }
+
+  private spawnWorker(): void {
+    this.rejectAll(new Error('superseded by new worker'));
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+    }
+    this.worker = new MachineWorker();
+    this.worker.onmessage = (e: MessageEvent<WorkerResponse>) => this.onMessage(e.data);
+    this.worker.onerror = (e) => this.onWorkerError(e);
+  }
+
+  private startRunTimer(): void {
+    if (!this.runPending) return;
+    if (this.runPending.timer) clearTimeout(this.runPending.timer);
+    this.runPending.timer = setTimeout(() => {
+      const p = this.runPending;
+      this.runPending = null;
+      if (this.worker) {
+        this.worker.terminate();
+        this.worker = null;
+      }
+      p?.reject(new Error(`timeout after ${WORKER_TIMEOUT_MS}ms — worker terminated (likely infinite loop)`));
+    }, WORKER_TIMEOUT_MS);
+  }
+
+  private stopRunTimer(): void {
+    if (!this.runPending) return;
+    if (this.runPending.timer) {
+      clearTimeout(this.runPending.timer);
+      this.runPending.timer = null;
+    }
+  }
+
+  private onMessage(data: WorkerResponse): void {
+    // `paused` is the only response that doesn't complete a Promise.
+    if (data.type === 'paused') {
+      if (!this.runPending) return;
+      this.stopRunTimer();
+      this.runPending.onPaused?.(data);
+      return;
+    }
+    // ran / error complete the run; stepped / built complete a simple request.
+    if (data.type === 'ran') {
+      const p = this.runPending;
+      this.runPending = null;
+      if (!p) return;
+      this.stopRunTimer();
+      p.resolveRan(data);
+      return;
+    }
+    if (data.type === 'error') {
+      const err = new WorkerError(data.message, data.tapes ?? null);
+      if (this.runPending) {
+        const p = this.runPending;
+        this.runPending = null;
+        this.stopRunTimer();
+        p.reject(err);
+        return;
+      }
+      if (this.simplePending) {
+        const p = this.simplePending;
+        this.simplePending = null;
+        clearTimeout(p.timer);
+        p.reject(err);
+        return;
+      }
+      return;
+    }
+    // built / stepped
+    if (this.simplePending) {
+      const p = this.simplePending;
+      this.simplePending = null;
+      clearTimeout(p.timer);
+      p.resolve(data);
+    }
+  }
+
+  private onWorkerError(e: ErrorEvent): void {
+    this.rejectAll(new Error(`worker error: ${e.message ?? 'unknown'}`));
+  }
+
+  private sendSimple(msg: WorkerRequest): Promise<WorkerResponse> {
+    if (!this.worker) throw new Error('worker not spawned — call build() first');
+    if (this.simplePending || this.runPending) throw new Error('previous request still pending');
+
+    return new Promise<WorkerResponse>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.simplePending = null;
+        if (this.worker) {
+          this.worker.terminate();
+          this.worker = null;
+        }
+        reject(new Error(`timeout after ${WORKER_TIMEOUT_MS}ms — worker terminated (likely infinite loop)`));
+      }, WORKER_TIMEOUT_MS);
+      this.simplePending = { resolve, reject, timer };
+      this.worker!.postMessage(msg);
+    });
+  }
+
+  async build(code: string): Promise<BuiltResponse> {
+    this.spawnWorker();
+    const r = await this.sendSimple({ type: 'build', engine: this.engine, code });
+    if (r.type !== 'built') throw new Error(`unexpected response: ${r.type}`);
+    return r;
+  }
+
+  async step(): Promise<SteppedResponse> {
+    const r = await this.sendSimple({ type: 'step' });
+    if (r.type !== 'stepped') throw new Error(`unexpected response: ${r.type}`);
+    return r;
+  }
+
+  /**
+   * Async run with optional break-pause support. Returns when the worker
+   * sends `ran` (halt or stepsLimit). If `debug` is true and a break fires,
+   * `onPaused` is called; the consumer must call `resume()` to continue.
+   * The Promise stays pending across paused/resume cycles.
+   */
+  run(opts: {
+    maxSteps?: number;
+    debug?: boolean;
+    onPaused?: (data: PausedResponse) => void;
+  } = {}): Promise<RanResponse> {
+    if (!this.worker) throw new Error('worker not spawned — call build() first');
+    if (this.simplePending || this.runPending) throw new Error('previous request still pending');
+
+    return new Promise<RanResponse>((resolveRan, reject) => {
+      this.runPending = {
+        resolveRan,
+        reject,
+        timer: null,
+        onPaused: opts.onPaused ?? null,
+      };
+      this.startRunTimer();
+      this.worker!.postMessage({
+        type: 'run',
+        maxSteps: opts.maxSteps ?? MAX_STEPS,
+        debug: opts.debug ?? false,
+      });
+    });
+  }
+
+  /** Send a `resume` to a paused worker. Reactivates the round-trip timer. */
+  resume(step: boolean = false): void {
+    if (!this.runPending) throw new Error('resume: no pending run');
+    if (!this.worker) throw new Error('resume: worker terminated');
+    this.startRunTimer();
+    this.worker.postMessage({ type: 'resume', step });
+  }
+
+  terminate(): void {
+    this.rejectAll(new Error('runner terminated'));
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+    }
+  }
+}
+```
+
+(Keep the `WorkerError` class above — it's unchanged.)
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run check && npm run lint && npm run build`
+Expected: all clean. The runner has no consumers using the old `run()` signature aside from `MachineView.svelte` (Task 8 updates it).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/machineRunner.ts
+git commit -m "Runner: async run with onPaused callback + resume API (#40)"
+```
+
+---
+
+## Task 6: Add "Debug mode" checkbox to Toolbar
+
+**Files:**
+- Modify: `src/components/Toolbar.svelte`
+
+- [ ] **Step 1: Find the existing `with pause` checkbox markup**
+
+Run: `grep -n "withPause\|with pause" src/components/Toolbar.svelte | head -10`
+
+Note the line numbers — the checkbox markup will be a `<label class="checkbox">` block with `bind:checked={withPause}`.
+
+- [ ] **Step 2: Add `debugMode` prop and matching checkbox**
+
+In the `<script>` block of `src/components/Toolbar.svelte`, find the `Props` type and the `let { ... }: Props = $props()` destructure. Add `debugMode` (boolean, bindable) alongside `withPause`. Example:
+
+```ts
+type Props = {
+  // ... existing props ...
+  withPause: boolean;
+  debugMode: boolean;
+  // ... existing props ...
+};
+
+let {
+  // ... existing destructures ...
+  withPause = $bindable(),
+  debugMode = $bindable(),
+  // ... existing destructures ...
+}: Props = $props();
+```
+
+In the markup, immediately after the `with pause` checkbox `<label>`, add:
+
+```svelte
+<label class="checkbox" title="When on, breaks set via state.debug pause execution at a Continue/Step prompt.">
+  <input type="checkbox" bind:checked={debugMode} />
+  debug
+</label>
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run check`
+Expected: 0 errors. Note that `MachineView.svelte` will not yet be passing `debugMode` — the prop default in `$bindable()` covers that until Task 8 wires it.
+
+Run: `npm run lint`
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Toolbar.svelte
+git commit -m "Toolbar: add 'debug' checkbox (#40)"
+```
+
+---
+
+## Task 7: MachineView — `debugMode` state + `RUNNING_PAUSED_AT_BREAK` mode
+
+**Files:**
+- Modify: `src/components/MachineView.svelte`
+
+- [ ] **Step 1: Add `RUNNING_PAUSED_AT_BREAK` to the mode union**
+
+In `src/components/MachineView.svelte`, replace the `ExecutionMode` type (around line 49-55) with:
+
+```ts
+type ExecutionMode =
+  | 'DEMO'
+  | 'MANUAL'
+  | 'RUNNING_STEP'
+  | 'RUNNING_AUTO'
+  | 'RUNNING_CONTINUOUS'
+  | 'RUNNING_PAUSED_AT_BREAK'
+  | 'HALTED';
+```
+
+- [ ] **Step 2: Add `debugMode` state with persistence**
+
+Add the import for the new persist helpers — find the `from './persist.ts'` block (around lines 21-30) and extend it:
+
+```ts
+import {
+  loadCode,
+  loadExampleId,
+  saveExampleId,
+  loadSnippets,
+  saveSnippet,
+  deleteSnippet,
+  renameSnippet,
+  loadDebugMode,
+  saveDebugMode,
+  type Snippets,
+} from '../lib/persist.ts';
+```
+
+After the existing `let withPause = $state(false);` line (around line 71), add:
+
+```ts
+let debugMode = $state<boolean>(untrack(() => loadDebugMode(engine)));
+
+$effect(() => {
+  saveDebugMode(engine, debugMode);
+});
+```
+
+- [ ] **Step 3: Update derived flags to include `RUNNING_PAUSED_AT_BREAK`**
+
+Find the `takeControlVisible` derivation (around line 141-143) and update it to hide Take Control while paused at break:
+
+```ts
+const takeControlVisible = $derived(
+  executionMode !== 'MANUAL' &&
+  executionMode !== 'RUNNING_CONTINUOUS' &&
+  executionMode !== 'RUNNING_PAUSED_AT_BREAK',
+);
+```
+
+Find `beltTransitionsOn` (line 144) and update so transitions are also off while paused at break (snap-style mirror reload):
+
+```ts
+const beltTransitionsOn = $derived(
+  executionMode !== 'RUNNING_CONTINUOUS' &&
+  executionMode !== 'RUNNING_PAUSED_AT_BREAK',
+);
+```
+
+Find `runDisabled` (line 172-178) and update so a run from `RUNNING_PAUSED_AT_BREAK` is allowed (it routes to Continue, see Task 9):
+
+```ts
+const runDisabled = $derived(
+  pendingOp !== null ||
+    !workerLive ||
+    executionMode === 'RUNNING_AUTO' ||
+    executionMode === 'RUNNING_CONTINUOUS' ||
+    (withPause && !intervalIsValid),
+);
+// (No `RUNNING_PAUSED_AT_BREAK` here — Run becomes Continue while paused.)
+```
+
+Find `stepDisabled` (line 164-168) and ensure Step is enabled while paused at break:
+
+```ts
+const stepDisabled = $derived(
+  pendingOp !== null ||
+    !workerLive ||
+    executionMode === 'RUNNING_CONTINUOUS',
+);
+// (`RUNNING_PAUSED_AT_BREAK` — Step is enabled and sends resume {step: true}.)
+```
+
+Add a derivation for the run-button shape (label + handler dispatch in Task 9):
+
+```ts
+const isPaused = $derived(executionMode === 'RUNNING_PAUSED_AT_BREAK');
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `npm run check && npm run lint`
+Expected: 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/MachineView.svelte
+git commit -m "MachineView: RUNNING_PAUSED_AT_BREAK mode + debugMode state (#40)"
+```
+
+---
+
+## Task 8: MachineView — wire Toolbar `debugMode` + line 258 await fix
+
+**Files:**
+- Modify: `src/components/MachineView.svelte`
+
+- [ ] **Step 1: Pass `debugMode` to Toolbar**
+
+Find the `<Toolbar ...>` instantiation in the markup (around line 641-674). Add `bind:debugMode` alongside `bind:withPause`. Example:
+
+```svelte
+<Toolbar
+  ...
+  bind:withPause
+  bind:debugMode
+  ...
+/>
+```
+
+- [ ] **Step 2: Make `_runMirrorStep` async + await `mirrorMachine.run`**
+
+Replace `_runMirrorStep` (around line 244-259) with:
+
+```ts
+async function _runMirrorStep(commands: Command[]): Promise<void> {
+  if (!mirrorMachine || !mirrorTapeBlock) return;
+  const oneStep = new turing.State({
+    [turing.ifOtherSymbol]: {
+      command: commands.map((command) => ({
+        symbol: command.symbol !== null ? command.symbol : turing.symbolCommands.keep,
+        movement:
+          command.movement === 'L' ? turing.movements.left
+          : command.movement === 'R' ? turing.movements.right
+          : turing.movements.stay,
+      })),
+      nextState: turing.haltState,
+    },
+  });
+  await mirrorMachine.run({ initialState: oneStep });
+}
+```
+
+Replace `renderFromMirror` (around line 275-284) to await the mirror step:
+
+```ts
+async function renderFromMirror(commands: Command[], animate: boolean): Promise<void> {
+  if (!mirrorTapeBlock) return;
+  await _runMirrorStep(commands);
+  mirrorTapeBlock.tapes.forEach((tape, i) => {
+    const command = commands[i];
+    const delta = (command?.movement === 'L' ? -1 : command?.movement === 'R' ? 1 : 0) as -1 | 0 | 1;
+    const wrote = command != null && command.symbol !== null;
+    tapesStackRef?.setFromTape(i, tape, delta, animate, wrote);
+  });
+}
+```
+
+Find every caller of `renderFromMirror` and add `await` (or `void` if intentionally fire-and-forget). Likely call sites:
+- `doStep()` around line 400
+- `onApply()` around line 472 (`renderFromMirror(commands, true);`)
+- The demo loop and auto-step `$effect`s
+
+For each, change to `await renderFromMirror(...)` if inside an async function, otherwise wrap in `void (async () => { await renderFromMirror(...); })()`.
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run check`
+Expected: 0 errors. If TS complains about a non-async caller missing `await`, either make the caller async or use the `void`-wrapped pattern.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/MachineView.svelte
+git commit -m "MachineView: wire debugMode prop + await mirrorMachine.run (#40)"
+```
+
+---
+
+## Task 9: MachineView — paused handler, Continue/Step, log entry
+
+**Files:**
+- Modify: `src/components/MachineView.svelte`
+
+This task wires the runner's `onPaused` callback into the UI and adds Continue/Step button dispatch.
+
+- [ ] **Step 1: Add `onPausedHandler` and update `doRun`**
+
+In `src/components/MachineView.svelte`, find `doRun()` (around line 408). Replace the `runner.run()` call site. The full updated `doRun()` body, replacing the `if (withPause) { ... }` branch and the post-reload `runner.run()` block:
+
+```ts
+async function doRun(): Promise<void> {
+  // RUNNING_PAUSED_AT_BREAK → treat Run click as Continue.
+  if (executionMode === 'RUNNING_PAUSED_AT_BREAK') {
+    runner.resume(false);
+    executionMode = 'RUNNING_CONTINUOUS';
+    return;
+  }
+
+  if (withPause) {
+    // Resume auto-stepping from current RUNNING_STEP position without reload.
+    if (executionMode !== 'RUNNING_STEP') {
+      reportSeparator();
+      report('loading…');
+      const ok = await reloadWorker();
+      if (!ok) {
+        executionMode = userTookControl ? 'MANUAL' : 'DEMO';
+        return;
+      }
+    }
+    executionMode = 'RUNNING_AUTO';
+    codeChangedWarned = false;
+    report(`auto-stepping every ${intervalMs}ms`);
+    return;
+  }
+
+  reportSeparator();
+  report('loading…');
+  const ok = await reloadWorker();
+  if (!ok) {
+    executionMode = userTookControl ? 'MANUAL' : 'DEMO';
+    return;
+  }
+  reflectNeutral();
+  executionMode = 'RUNNING_CONTINUOUS';
+  report('running…');
+  pendingOp = 'run';
+  try {
+    const res = await runner.run({
+      maxSteps: undefined,
+      debug: debugMode,
+      onPaused: (paused) => onPausedHandler(paused),
+    });
+    lastSnapshots = res.tapes;
+    _buildMirrorMachine(res.tapes, alphabets);
+    setAllFromMirror();
+    halted = true;
+    reflectNeutral();
+    if (res.commands.length > 0) {
+      appendBatch(
+        res.commands.map((commands, i) =>
+          commandsEntry(commands, { stepNumber: res.startStep + i + 1 }, CARET_COLORS),
+        ),
+      );
+    }
+    if (res.truncated) {
+      report(`truncated at ${res.stepsApplied} steps (limit hit)`, 'warn');
+    } else {
+      report(`halted after ${res.stepsApplied} step(s)`, 'ok');
+    }
+    executionMode = 'HALTED';
+  } catch (err) {
+    failHalted(err);
+  } finally {
+    pendingOp = null;
+  }
+}
+```
+
+- [ ] **Step 2: Add `onPausedHandler`**
+
+Add a new function above `doRun` (or anywhere within the script block):
+
+```ts
+function onPausedHandler(paused: import('../lib/types.ts').PausedResponse): void {
+  // Replay buffered per-step commands so the trace leading to the break is visible.
+  if (paused.commands.length > 0) {
+    const startStep = paused.stepsApplied - paused.commands.length;
+    appendBatch(
+      paused.commands.map((commands, i) =>
+        commandsEntry(commands, { stepNumber: startStep + i + 1 }, CARET_COLORS),
+      ),
+    );
+  }
+  // Snap mirror to break-time tapes (no animation).
+  lastSnapshots = paused.tapes;
+  _buildMirrorMachine(paused.tapes, alphabets);
+  setAllFromMirror();
+  // Format the break log entry.
+  const phase =
+    paused.debugBreak.before && paused.debugBreak.after
+      ? 'before+after'
+      : paused.debugBreak.before
+        ? 'before'
+        : 'after';
+  const symbols = paused.currentSymbols.join(' ');
+  report(`paused at ${paused.state || '(unnamed)'} [${phase}]: ${symbols}`, 'ok');
+  executionMode = 'RUNNING_PAUSED_AT_BREAK';
+}
+```
+
+- [ ] **Step 3: Update Step button to send `resume { step: true }` when paused**
+
+Find `doStep()` (around line 354). Add a branch at the top:
+
+```ts
+async function doStep(): Promise<void> {
+  // RUNNING_PAUSED_AT_BREAK → Step click means "advance one iteration in the
+  // run, then re-pause". Send resume with step flag; worker will arm the
+  // nextState.debug trick.
+  if (executionMode === 'RUNNING_PAUSED_AT_BREAK') {
+    runner.resume(true);
+    // Phase will be set by the next `paused` (or `ran` if the synthesized
+    // step happens to land on halt).
+    return;
+  }
+
+  // ... existing body unchanged ...
+}
+```
+
+- [ ] **Step 4: Update Stop button to terminate worker on paused-at-break**
+
+Find `stopMachine()` (around line 316). Replace with:
+
+```ts
+function stopMachine(): void {
+  if (executionMode === 'RUNNING_PAUSED_AT_BREAK') {
+    // Pending run Promise will reject when we terminate; failHalted in the
+    // caller's catch sets the rest. We pre-empt the message here.
+    runner.terminate();
+    workerLive = false;
+  }
+  executionMode = 'HALTED';
+  report('stopped', 'warn');
+}
+```
+
+- [ ] **Step 5: Verify**
+
+Run: `npm run check && npm run lint && npm run build`
+Expected: 0 errors. If TS complains about `import('../lib/types.ts').PausedResponse` — change to a top-level import:
+
+```ts
+import { type Alphabets, type Command, type Engine, type PausedResponse, type TapeSnapshot } from '../lib/types.ts';
+```
+
+(Update the existing `from '../lib/types.ts'` import line.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/MachineView.svelte
+git commit -m "MachineView: paused-at-break handler + Continue/Step (#40)"
+```
+
+---
+
+## Task 10: MachineView — log Take Control
+
+**Files:**
+- Modify: `src/components/MachineView.svelte`
+
+- [ ] **Step 1: Add `report` call in `takeControl()`**
+
+Find `takeControl()` (around line 465). Add a report line at the start:
+
+```ts
+function takeControl(): void {
+  report('user took control', 'ok');
+  userTookControl = true;
+  executionMode = 'MANUAL';
+  reflectNeutral();
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `npm run check`
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/MachineView.svelte
+git commit -m "MachineView: log 'user took control' (#40)"
+```
+
+---
+
+## Task 11: Default snippets — "don't run the machine" comment
+
+**Files:**
+- Modify: `src/lib/defaultCode.ts`
+
+- [ ] **Step 1: Update all 3 snippet headers**
+
+In `src/lib/defaultCode.ts`, find each snippet's header comment block. For each (TURING_REPLACE_B around line 9-22, TURING_COPY_TWO_TAPES around line 45-59, POST_WALK_MARK around line 94-103), append a line to the comment block before the closing `*/`:
+
+For `TURING_REPLACE_B`, change:
+```
+ * Return: { machine, initialState, tape }
+ */
+```
+
+to:
+```
+ * Return: { machine, initialState, tape }
+ *
+ * Note: the demo runs the machine; do not call .run() or .runStepByStep() yourself.
+ */
+```
+
+Apply the same line addition (with appropriate Return-shape preservation) to `TURING_COPY_TWO_TAPES` (`Return: { machine, initialState }`) and `POST_WALK_MARK` (`Return: { machine }`).
+
+- [ ] **Step 2: Verify**
+
+Run: `npm run check && npm run lint && npm run build`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/defaultCode.ts
+git commit -m "Default snippets: don't run the machine yourself (#40)"
+```
+
+---
+
+## Task 12: README — wire shape update
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update the wire-shape lines in the Architecture section**
+
+In `README.md`, find the `requests:` and `responses:` lines inside the ASCII diagram block. Replace:
+
+```
+        requests:   build / step / run
+        responses:  built / stepped / ran / error
+```
+
+with:
+
+```
+        requests:   build / step / run / resume
+        responses:  built / stepped / ran / paused / error
+```
+
+Update the prose immediately after the diagram. Replace:
+
+> **Crosses the boundary:** `TapeSnapshot[]` (on `built` / `ran` / `error`), per-step `Command[]` (movement + written symbol), tape alphabets — plain data only.
+
+with:
+
+> **Crosses the boundary:** `TapeSnapshot[]` (on `built` / `ran` / `error` / `paused`), per-step `Command[]` (movement + written symbol), tape alphabets, plus break metadata (state name, current symbols, `debugBreak` flags) on `paused` — plain data only.
+
+- [ ] **Step 2: Verify**
+
+Run: `npm run build`
+Expected: succeeds (README isn't checked by svelte-check, but build sanity-checks).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "README: add resume/paused to the architecture diagram (#40)"
+```
+
+---
+
+## Task 13: Smoke test — manual verification
+
+**Files:** None (verification only).
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `npm run dev`
+
+Open the printed URL in a browser (typically `http://localhost:5173/turing`).
+
+- [ ] **Step 2: Smoke-test the Turing tab**
+
+For each bundled Turing example (`Replace 'b' with '*'` and `Copy tape (multi-tape)`):
+
+1. **Build / Run / no debug.** Click Build, then Run (debug unchecked). Expect halts cleanly. Log shows step entries + `halted after N step(s)`.
+2. **Step / no debug.** Click Step several times. Expect single-step entries.
+3. **With pause / no debug.** Tick "with pause", set interval to `300ms`, click Run. Expect auto-step. Click Step button (now labeled Pause) — auto-step pauses. Click Run again — resumes.
+4. **Take Control.** Click Take Control. Expect log entry: `user took control`. Use the control panel to apply a command. Expect `applied` log entry.
+5. **Build, then break test.** In the editor, modify the snippet to set `state.debug = { before: true }` on `initialState` before `return`. Tick "debug". Click Run. Expect:
+   - Log shows initial step trace (or none if first iteration breaks immediately).
+   - Log shows `paused at (unnamed) [before]: <symbol>`.
+   - Run button label changes to Continue. Step / Stop visible.
+6. **Continue.** Click Continue. Expect another `paused` (if state self-loops), or final halt.
+7. **Step from break.** While paused, click Step. Expect one more step, then re-pause.
+8. **Stop while paused.** While paused, click Stop. Expect log `stopped`, mode → HALTED.
+9. **Build during paused.** While paused, click Build. Expect new build, mode → MANUAL.
+
+- [ ] **Step 3: Smoke-test the Post tab**
+
+Switch to `/post`. For the `Walk right; mark first blank` example:
+
+1. Build / Run / no debug. Confirm halts.
+2. Modify the snippet to add `imports.haltState.debug = { before: true };` before `return`. Tick "debug". Click Run. Expect a single `paused at <state>` entry on halt-entry.
+3. Continue. Expect halt completion.
+
+- [ ] **Step 4: Sanity-check persistence**
+
+Refresh the page on each tab. Expect "debug" checkbox state to persist per tab.
+
+- [ ] **Step 5: Run final type-check + lint + build**
+
+Run: `npm run check && npm run lint && npm run build`
+Expected: 0 errors / 0 warnings; build succeeds.
+
+- [ ] **Step 6: No commit needed for smoke test (no code change).**
+
+---
+
+## Self-review checklist
+
+After all tasks complete:
+
+- [ ] `npm run check` clean
+- [ ] `npm run lint` clean
+- [ ] `npm run build` succeeds
+- [ ] All bundled examples Build/Step/Run/Take-Control as before (regression check)
+- [ ] Debug-mode unchecked → behaves exactly like pre-#40 Run
+- [ ] Debug-mode checked + `state.debug` set → break fires, Continue/Step/Stop work
+- [ ] Take Control logs entry
+- [ ] README diagram includes `paused` and `resume`

--- a/docs/superpowers/plans/2026-05-08-worker-run-mode.md
+++ b/docs/superpowers/plans/2026-05-08-worker-run-mode.md
@@ -585,13 +585,13 @@ Replace the `Pending` type and the `MachineRunner` class body (everything from l
 type SimplePending = {
   resolve: (data: WorkerResponse) => void;
   reject: (err: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
+  timeoutId: ReturnType<typeof setTimeout>;
 };
 
 type RunPending = {
   resolveRan: (data: RanResponse) => void;
   reject: (err: Error) => void;
-  timer: ReturnType<typeof setTimeout> | null;
+  timeoutId: ReturnType<typeof setTimeout> | null;
   onPaused: ((data: PausedResponse) => void) | null;
 };
 
@@ -607,12 +607,12 @@ export class MachineRunner {
 
   private rejectAll(err: Error): void {
     if (this.simplePending) {
-      clearTimeout(this.simplePending.timer);
+      clearTimeout(this.simplePending.timeoutId);
       this.simplePending.reject(err);
       this.simplePending = null;
     }
     if (this.runPending) {
-      if (this.runPending.timer) clearTimeout(this.runPending.timer);
+      if (this.runPending.timeoutId) clearTimeout(this.runPending.timeoutId);
       this.runPending.reject(err);
       this.runPending = null;
     }
@@ -631,8 +631,8 @@ export class MachineRunner {
 
   private startRunTimer(): void {
     if (!this.runPending) return;
-    if (this.runPending.timer) clearTimeout(this.runPending.timer);
-    this.runPending.timer = setTimeout(() => {
+    if (this.runPending.timeoutId) clearTimeout(this.runPending.timeoutId);
+    this.runPending.timeoutId = setTimeout(() => {
       const p = this.runPending;
       this.runPending = null;
       if (this.worker) {
@@ -645,9 +645,9 @@ export class MachineRunner {
 
   private stopRunTimer(): void {
     if (!this.runPending) return;
-    if (this.runPending.timer) {
-      clearTimeout(this.runPending.timer);
-      this.runPending.timer = null;
+    if (this.runPending.timeoutId) {
+      clearTimeout(this.runPending.timeoutId);
+      this.runPending.timeoutId = null;
     }
   }
 
@@ -680,7 +680,7 @@ export class MachineRunner {
       if (this.simplePending) {
         const p = this.simplePending;
         this.simplePending = null;
-        clearTimeout(p.timer);
+        clearTimeout(p.timeoutId);
         p.reject(err);
         return;
       }
@@ -690,7 +690,7 @@ export class MachineRunner {
     if (this.simplePending) {
       const p = this.simplePending;
       this.simplePending = null;
-      clearTimeout(p.timer);
+      clearTimeout(p.timeoutId);
       p.resolve(data);
     }
   }
@@ -704,7 +704,7 @@ export class MachineRunner {
     if (this.simplePending || this.runPending) throw new Error('previous request still pending');
 
     return new Promise<WorkerResponse>((resolve, reject) => {
-      const timer = setTimeout(() => {
+      const timeoutId = setTimeout(() => {
         this.simplePending = null;
         if (this.worker) {
           this.worker.terminate();
@@ -712,7 +712,7 @@ export class MachineRunner {
         }
         reject(new Error(`timeout after ${WORKER_TIMEOUT_MS}ms — worker terminated (likely infinite loop)`));
       }, WORKER_TIMEOUT_MS);
-      this.simplePending = { resolve, reject, timer };
+      this.simplePending = { resolve, reject, timeoutId };
       this.worker!.postMessage(msg);
     });
   }
@@ -748,7 +748,7 @@ export class MachineRunner {
       this.runPending = {
         resolveRan,
         reject,
-        timer: null,
+        timeoutId: null,
         onPaused: opts.onPaused ?? null,
       };
       this.startRunTimer();

--- a/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
+++ b/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
@@ -11,6 +11,7 @@ The worker drives execution through `runStepByStep` only (`src/lib/machineWorker
 - **Always-runWithBreaks dispatch.** The Run button always uses the new path. If user code never sets `state.debug` / `haltState.debug`, no breaks fire and behavior is identical to today's sync run. The old `run` request type is dropped — one path, no main-thread introspection of user State needed to choose.
 - **Dedicated paused-at-break mode.** A new `RUNNING_PAUSED_AT_BREAK` is introduced rather than overloading the existing `RUNNING_STEP`. The two states are conceptually different: `RUNNING_STEP` is paused between full steps and *can* single-step; `RUNNING_PAUSED_AT_BREAK` is paused inside `run()` and *cannot* (the engine's `for` loop owns the iteration).
 - **`RUNNING_AUTO` unchanged.** Auto-step uses `runStepByStep`, so breakpoints don't fire there. Documented as a known constraint in the #38 example.
+- **"Debug mode" UI gate.** A user-facing checkbox controls whether breaks pause execution at all, so `state.debug` / `haltState.debug` assignments in user code stay valid across both modes (no edit-and-comment-out churn). Demo-side emulation today (the worker's `onDebugBreak` resolves instantly when off); cross-references [turing-machine-js#106](https://github.com/mellonis/turing-machine-js/issues/106) which proposes the same gate as a `debug: boolean` parameter on upstream `run()`.
 
 ## Worker contract
 
@@ -18,9 +19,11 @@ Drop `run`. Add `runWithBreaks` and `resume`. Add `paused` response. `build` / `
 
 | Direction | Type | Payload |
 |---|---|---|
-| → | `runWithBreaks` | `{ maxSteps? }` |
+| → | `runWithBreaks` | `{ maxSteps?, debug }` |
 | → | `resume` | `{}` |
 | ← | `paused` | `{ tapes, commands, stepsApplied, state, currentSymbols, debugBreak }` |
+
+`debug: boolean` is required (no default at the wire — main thread is always explicit). When `false`, the worker's `onDebugBreak` resolves instantly without posting `paused`. When `true`, the pause/resume flow runs.
 
 Field shapes:
 
@@ -72,6 +75,21 @@ ExecutionMode = 'DEMO' | 'MANUAL' | 'RUNNING_STEP' | 'RUNNING_AUTO'
 Build from `RUNNING_PAUSED_AT_BREAK` is allowed and follows the existing pattern: terminate worker, `reloadWorker(code)`, mode → `MANUAL`. The pending Promise dies with the worker.
 
 `runDisabled` / `stepDisabled` / etc. derived flags pick up `RUNNING_PAUSED_AT_BREAK` so existing UI gating composes.
+
+## "Debug mode" UI
+
+A checkbox lives in `Toolbar.svelte` next to `with pause`. State name `debugMode`, owned by `MachineView.svelte`, persisted to `localStorage` under `machines-demo:<engine>:debugMode` (mirroring the existing `withPause` pattern). Default off.
+
+The checkbox is purely a request-payload gate: every `runWithBreaks` request includes `debug: debugMode`. The UI never disables `withPause` when `debugMode` is on (or vice versa) — they target different execution modes:
+
+| `withPause` | `debugMode` | Run button → | Breakpoints fire? |
+|---|---|---|---|
+| off | off | `RUNNING_CONTINUOUS` | no (current behavior) |
+| off | on  | `RUNNING_CONTINUOUS` | yes — pauses at breaks |
+| on  | off | `RUNNING_AUTO` | no (current behavior) |
+| on  | on  | `RUNNING_AUTO` | no — engine constraint |
+
+The bottom-right cell is the one wart: with both checked, breakpoints don't fire because `RUNNING_AUTO` uses `runStepByStep` (no `onDebugBreak`). The #38 example documents this. No UI change to flag it; the simpler matrix is worth keeping.
 
 ## Mirror behavior across breaks
 

--- a/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
+++ b/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
@@ -20,7 +20,7 @@ Extend `run` with an optional `debug` flag. Add `resume` request and `paused` re
 | Direction | Type | Payload |
 |---|---|---|
 | → | `run` | `{ maxSteps?, debug? }` |
-| → | `resume` | `{}` |
+| → | `resume` | `{ step? }` |
 | ← | `paused` | `{ tapes, commands, stepsApplied, state, currentSymbols, debugBreak }` |
 
 `debug: boolean` defaults to `false` — no surprise pauses if user code has leftover `state.debug` assignments. When `true`, the worker's `onDebugBreak` posts `paused` and awaits `resume`. When `false`, `onDebugBreak` returns immediately (pauses short-circuited at the wrapper level).
@@ -70,8 +70,8 @@ ExecutionMode = 'DEMO' | 'MANUAL' | 'RUNNING_STEP' | 'RUNNING_AUTO'
 
 | Affordance | State |
 |---|---|
-| Run button | label "Continue", icon retained, sends `resume` |
-| Step button | hidden |
+| Run button | label "Continue", icon retained, sends `resume` (no step flag) |
+| Step button | visible — sends `resume { step: true }`, advances one iteration, re-pauses |
 | Stop button | visible (terminates worker, → `HALTED`) |
 | Take Control | hidden (consistent with other RUNNING_* modes) |
 | Editor | read-only-effective (Build remains available, see below) |
@@ -80,6 +80,47 @@ ExecutionMode = 'DEMO' | 'MANUAL' | 'RUNNING_STEP' | 'RUNNING_AUTO'
 Build from `RUNNING_PAUSED_AT_BREAK` is allowed and follows the existing pattern: terminate worker, `reloadWorker(code)`, mode → `MANUAL`. The pending Promise dies with the worker.
 
 `runDisabled` / `stepDisabled` / etc. derived flags pick up `RUNNING_PAUSED_AT_BREAK` so existing UI gating composes.
+
+### Step from `RUNNING_PAUSED_AT_BREAK`
+
+Step advances exactly one engine iteration and re-pauses, by mutating `nextState.debug = { before: true }` so the next iteration breaks regardless of the user's `state.debug` config. Stash the original `debug` value; restore on entry to the synthesized break before pausing again.
+
+Two paths depending on which kind of break we're paused at:
+
+- **`before` break.** `m` is the current `machineState`; `m.nextState` is the actual next iteration's state. Apply the trick directly inside `onDebugBreak`.
+- **`after` break.** `m` is `prevYield` (the engine substitutes for context). The un-substituted `machineState` isn't reachable here. Set a `pendingStepNext` flag and defer the trick to the *next* `onStep` call, which fires with the un-substituted yield.
+
+```ts
+let pendingStepNext = false;
+let pendingRestore: (() => void) | null = null;
+
+onStep: (m) => {
+  if (pendingStepNext) {
+    const ns = m.nextState;
+    const original = ns.debug;
+    ns.debug = { before: true };
+    pendingRestore = () => { ns.debug = original; };
+    pendingStepNext = false;
+  }
+  // existing per-step buffering
+},
+onDebugBreak: async (m) => {
+  if (pendingRestore) { pendingRestore(); pendingRestore = null; }
+  // post `paused`, await `resume` (sets resumeAction = 'continue' | 'step')
+  if (resumeAction === 'step') {
+    if (m.debugBreak?.before) {
+      const ns = m.nextState;
+      const original = ns.debug;
+      ns.debug = { before: true };
+      pendingRestore = () => { ns.debug = original; };
+    } else {
+      pendingStepNext = true;
+    }
+  }
+}
+```
+
+`nextState.debug` mutation is shared across `withOverrodeHaltState` wrappers (per upstream docs); the stash-and-restore covers this — whatever the user had on the underlying state is preserved.
 
 ## "Debug mode" UI
 

--- a/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
+++ b/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
@@ -182,6 +182,10 @@ On `resume` (Continue clicked): nothing changes locally — wait for the next wo
 
 On the final `ran`: existing flow — render final tapes, batch-log buffered commands, mode → `HALTED`.
 
+## Take Control: log entry
+
+`takeControl()` (`MachineView.svelte:465`) currently transitions silently from `DEMO` / `RUNNING_*` to `MANUAL`. Add `report('user took control', 'ok')` so the mode transition is captured in the log alongside the other logged transitions (Build, Step, Run, halt, paused-at-break). One-line addition; bundled here because we're already touching the log machinery for the break-pause flow.
+
 ## Timeout
 
 Per-segment 5s budget instead of per-request:

--- a/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
+++ b/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
@@ -88,7 +88,7 @@ Step advances exactly one engine iteration and re-pauses, by mutating `nextState
 Two paths depending on which kind of break we're paused at:
 
 - **`before` break.** `m` is the current `machineState`; `m.nextState` is the actual next iteration's state. Apply the trick directly inside `onDebugBreak`.
-- **`after` break.** `m` is `prevYield` (the engine substitutes for context). The un-substituted `machineState` isn't reachable here. Set a `pendingStepNext` flag and defer the trick to the *next* `onStep` call, which fires with the un-substituted yield.
+- **`after` break.** `m` is `prevYield` (the engine substitutes for context). The un-substituted `machineState` isn't reachable here. Set a `pendingStepNext` flag and defer the trick to the *next* `onStep` call, which fires with the un-substituted yield. (Once [turing-machine-js#107](https://github.com/mellonis/turing-machine-js/issues/107) lands — escape hatch for the un-substituted snapshot — this defer can collapse back into `onDebugBreak`.)
 
 ```ts
 let pendingStepNext = false;

--- a/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
+++ b/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
@@ -182,6 +182,12 @@ On `resume` (Continue clicked): nothing changes locally — wait for the next wo
 
 On the final `ran`: existing flow — render final tapes, batch-log buffered commands, mode → `HALTED`.
 
+## Default snippets: don't run the machine
+
+User code runs synchronously inside `new Function()`. If they call `machine.run(...)` or iterate `machine.runStepByStep(...)` themselves before returning, the tape is post-execution by the time the worker snapshots it — confusing initial state, no error.
+
+No code-side defense (prototype-patching breaks the "test a different machine alongside" pattern; tape mutation is indistinguishable from legitimate setup). Document the contract instead: add one line to each bundled example header — "The demo runs the machine; don't call `.run()` or `.runStepByStep()` yourself." Three snippets in `src/lib/defaultCode.ts` (Turing single-tape, Turing multi-tape, Post).
+
 ## Take Control: log entry
 
 `takeControl()` (`MachineView.svelte:465`) currently transitions silently from `DEMO` / `RUNNING_*` to `MANUAL`. Add `report('user took control', 'ok')` so the mode transition is captured in the log alongside the other logged transitions (Build, Step, Run, halt, paused-at-break). One-line addition; bundled here because we're already touching the log machinery for the break-pause flow.

--- a/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
+++ b/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
@@ -22,7 +22,7 @@ Extend `run` with an optional `debug` flag. Add `resume` request and `paused` re
 | → | `run` | `{ maxSteps?, debug?, step? }` |
 | → | `resume` | `{ step? }` |
 | → | `setDebug` | `{ on }` |
-| ← | `paused` | `{ tapes, commands, stepsApplied, state, currentSymbols, debugBreak, stepInduced }` |
+| ← | `paused` | `{ tapes, commands, stepsApplied, state, currentSymbols, debugBreak }` |
 
 `debug: boolean` defaults to `false` — no surprise pauses if user code has leftover `state.debug` assignments. The worker's `onDebugBreak` is **always** wired and self-gates on a module-scoped `debugEnabled` flag, so a `setDebug` request from the main thread can flip behavior mid-run (the user toggling the checkbox without restarting). When `debugEnabled` is off, the hook returns immediately unless the user just clicked Step (see Step semantics below).
 
@@ -36,7 +36,6 @@ Field shapes (paused):
 - `state: string` — `m.state.name`. The user's `State` instance does not cross the boundary.
 - `currentSymbols: string[]` — the symbols under each head at break time.
 - `debugBreak: { before?: true; after?: true }` — copied from `m.debugBreak` (omitted shape = field absent, never `undefined`).
-- `stepInduced: boolean` — `true` when the pause exists only because the worker temporarily armed `state.debug[when]` for Step semantics, `false` when the user's own `state.debug` would have fired the break regardless. Computed by reading `m.state.debug[when]` AFTER `pendingRestore` runs (so we see the user's authored value, not our arm). Drives main-thread log format: full break-state info when `debug && !stepInduced`, generic `paused` otherwise.
 
 Inside the worker, `run` now calls:
 
@@ -69,7 +68,7 @@ await machine.run({
     } else {
       stepPending = false;
     }
-    send({ type: 'paused', ..., stepInduced: /* computed */ });
+    send({ type: 'paused', ... });
     await new Promise<{ step: boolean }>((resolve) => { resumeResolve = resolve });
     // on resume: if action.step, arm next pause via state.debug.after (see below)
   },
@@ -165,19 +164,15 @@ if (action.step) {
 }
 ```
 
-### `stepInduced`
+### Pause log format
 
-The user's mental model: "full break-state info should appear only when *I* authored a breakpoint". Worker-armed Step boundaries shouldn't surface state identity in the log — that would suggest the user set something they didn't.
+Reads as "we made a step, here's the result". `.after`-arming means iter K just ran when we pause; the log surfaces iter K's state and just-executed symbols:
 
-Worker computes `stepInduced` per pause by reading `m.state.debug[when]` AFTER `pendingRestore` runs:
-
-```ts
-const stepInduced = m.debugBreak?.before
-  ? !m.state.debug?.before
-  : !m.state.debug?.after;
+```
+paused at state <name> after applying command for symbols: [<syms>]
 ```
 
-After `pendingRestore`, `m.state.debug` reflects the user's authored value, not our temporary arm. If the relevant flag is unset, the pause exists only because we armed it → `stepInduced = true`. Main-thread `onPausedHandler` logs full break-state info only when `debugMode && !stepInduced`, otherwise generic `paused`.
+Same format for user-authored breakpoints (`state.debug.before` or `state.debug.after`) — uses the appropriate `before`/`after` verb. The `debug` toggle gates whether user-authored breaks fire, not how pauses are logged.
 
 ### Halt-iter quirks (engine-side)
 
@@ -218,9 +213,7 @@ On `paused`:
 
 1. Rebuild `mirrorMachine` from the snapshot tapes (snap, no animation) — same path as `ran`.
 2. Replay the buffered `commands: Command[][]` to the Log via `report` + `commandsEntry` — user sees the trace that led to the break.
-3. Append a single `ok`-styled log entry. Format depends on `debugMode && !paused.stepInduced`:
-   - **`true`** (debug on AND user-authored break): `paused at state <name> [before|after] applying command for symbols: [<syms>]`.
-   - **`false`** (debug off, OR worker-armed Step boundary): generic `paused`.
+3. Append a single `ok`-styled log entry: `paused at state <name> [before|after] applying command for symbols: [<syms>]`. Same format whether the break is user-authored or worker-armed for Step.
 4. Update `lastSnapshots`, set `executionMode = 'RUNNING_PAUSED_AT_BREAK'`.
 
 On `resume` (Continue clicked): nothing changes locally — wait for the next worker response (`paused`, `ran`, or `error`).
@@ -272,4 +265,4 @@ Make `_runMirrorStep` async and `await mirrorMachine.run(...)`. Propagate to its
 
 - [turing-machine-js#106](https://github.com/mellonis/turing-machine-js/issues/106) — `debug: boolean` parameter on `run()`. The worker can pass it straight through; the off-path flag-check inside `onDebugBreak` goes away (the runtime-toggle still requires our wrapper).
 - [turing-machine-js#108](https://github.com/mellonis/turing-machine-js/issues/108) — drain `pendingAfterFromPrev` after the engine's main loop so the halting iter's `after`-fire actually fires; warn-then-throw on `haltState.debug.after` assignment. The "halt-iter quirks" subsection in Step semantics goes away when this lands.
-- [turing-machine-js#107](https://github.com/mellonis/turing-machine-js/issues/107) — un-substituted snapshot for `after`-break consumers. **No longer needed for our Step path** — we arm `.after` (not `.before`) on the next iteration, and `m.state` for an after-fire payload is already `prevYield` (the just-executed state), which is exactly what we need to read for `stepInduced`. Filed before the `.after`-arming approach was settled; can stay open for other consumers.
+- [turing-machine-js#107](https://github.com/mellonis/turing-machine-js/issues/107) — un-substituted snapshot for `after`-break consumers. Not needed by our Step path (`.after`-arming on the next iteration uses `m.state` = `prevYield`, which is exactly the just-executed state we want to display). Stays open for other consumers that might want the un-substituted `machineState` at after-fires.

--- a/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
+++ b/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
@@ -19,13 +19,16 @@ Extend `run` with an optional `debug` flag. Add `resume` request and `paused` re
 
 | Direction | Type | Payload |
 |---|---|---|
-| → | `run` | `{ maxSteps?, debug? }` |
+| → | `run` | `{ maxSteps?, debug?, step? }` |
 | → | `resume` | `{ step? }` |
-| ← | `paused` | `{ tapes, commands, stepsApplied, state, currentSymbols, debugBreak }` |
+| → | `setDebug` | `{ on }` |
+| ← | `paused` | `{ tapes, commands, stepsApplied, state, currentSymbols, debugBreak, stepInduced }` |
 
-`debug: boolean` defaults to `false` — no surprise pauses if user code has leftover `state.debug` assignments. When `true`, the worker's `onDebugBreak` posts `paused` and awaits `resume`. When `false`, `onDebugBreak` returns immediately (pauses short-circuited at the wrapper level).
+`debug: boolean` defaults to `false` — no surprise pauses if user code has leftover `state.debug` assignments. The worker's `onDebugBreak` is **always** wired and self-gates on a module-scoped `debugEnabled` flag, so a `setDebug` request from the main thread can flip behavior mid-run (the user toggling the checkbox without restarting). When `debugEnabled` is off, the hook returns immediately unless the user just clicked Step (see Step semantics below).
 
-Field shapes:
+`step: boolean` defaults to `false`. When `true`, the worker arms the initial state's `debug.after = true` so iter 1's after-fire is the step boundary (preserving any user-authored `state.debug.before`). Used by the cold-start Step path so the run pauses at the first iter without firing user-unauthored before-pauses.
+
+Field shapes (paused):
 
 - `tapes: TapeSnapshot[]` — full snapshot at break time (same producer as `built` / `ran` / `error`).
 - `commands: Command[][]` — per-step commands buffered since the previous `paused` (or since `run` started). Mirror replays them in the Log; tape state is restored from `tapes`.
@@ -33,27 +36,49 @@ Field shapes:
 - `state: string` — `m.state.name`. The user's `State` instance does not cross the boundary.
 - `currentSymbols: string[]` — the symbols under each head at break time.
 - `debugBreak: { before?: true; after?: true }` — copied from `m.debugBreak` (omitted shape = field absent, never `undefined`).
+- `stepInduced: boolean` — `true` when the pause exists only because the worker temporarily armed `state.debug[when]` for Step semantics, `false` when the user's own `state.debug` would have fired the break regardless. Computed by reading `m.state.debug[when]` AFTER `pendingRestore` runs (so we see the user's authored value, not our arm). Drives main-thread log format: full break-state info when `debug && !stepInduced`, generic `paused` otherwise.
 
 Inside the worker, `run` now calls:
 
 ```ts
-const debug = req.debug ?? false;
+debugEnabled = req.debug ?? false;
+stepPending = false;
+
+if (req.step && initialState) {
+  // Cold-start arm: always .after, preserve user-authored .before.
+  const target = initialState as { debug: ... };
+  const original = target.debug;
+  target.debug = {
+    after: true,
+    ...(original?.before !== undefined ? { before: original.before } : {}),
+  };
+  pendingRestore = () => { target.debug = original; };
+  stepPending = true;
+}
+
 await machine.run({
   initialState,
   stepsLimit: req.maxSteps ?? MAX_STEPS,
   onStep: (m) => { /* buffer per-step commands */ },
-  onDebugBreak: debug
-    ? async (m) => {
-        send({ type: 'paused', ... });
-        await new Promise<void>((resolve) => { resumeResolve = resolve });
-      }
-    : undefined,
+  onDebugBreak: async (m) => {
+    if (pendingRestore) { pendingRestore(); pendingRestore = null; }
+    if (debugEnabled) {
+      stepPending = false; // pause at every break
+    } else if (!stepPending || !m.debugBreak?.after) {
+      return; // debug=off + non-Step-armed → no pause
+    } else {
+      stepPending = false;
+    }
+    send({ type: 'paused', ..., stepInduced: /* computed */ });
+    await new Promise<{ step: boolean }>((resolve) => { resumeResolve = resolve });
+    // on resume: if action.step, arm next pause via state.debug.after (see below)
+  },
 });
 ```
 
-When `debug` is `false`, `onDebugBreak` is omitted entirely — upstream's `run()` then skips break-handling without our wrapper paying any per-step cost. Once [turing-machine-js#106](https://github.com/mellonis/turing-machine-js/issues/106) lands, we can pass `debug` straight through to upstream and drop this conditional.
+When `debugEnabled` is `false` AND no Step is pending, `onDebugBreak` returns immediately (upstream's `run()` continues without us paying any per-step cost beyond a flag check). Once [turing-machine-js#106](https://github.com/mellonis/turing-machine-js/issues/106) lands, we can pass `debug` straight through to upstream — the runtime-toggle still requires our wrapper, but the off-path flag check goes away.
 
-A module-scoped `resumeResolve: (() => void) | null` holds the pending Promise. The `resume` request handler resolves it and clears the slot. `run` and `resume` are the only message types that touch this slot; concurrent `run` is rejected by the phase machine (see below).
+A module-scoped `resumeResolve: ((action: { step: boolean }) => void) | null` holds the pending Promise. The `resume` request handler resolves it with the action and clears the slot. `run` and `resume` are the only message types that touch this slot; concurrent `run` is rejected by the phase machine (see below).
 
 After `run()` resolves (halt or stepsLimit), the worker sends the existing `ran` response. Errors thrown from inside `run()` (e.g. no edge for current symbol) flow through the existing catch and produce `error` with partial tape state.
 
@@ -79,6 +104,7 @@ Allowed transitions:
 | `step` | `built { halted: false }` | `built { halted: <post-step> }` |
 | `run` | `built { halted: false }` | `running` → `paused` or `built { halted: true }` |
 | `resume` | `paused` | `running` → `paused` or `built { halted: true }` |
+| `setDebug` | any | unchanged (side-channel mutation of `debugEnabled`) |
 
 A request from a disallowed phase throws `worker phase <current>, expected <allowed>`, which the existing catch converts into an `error` response. Main thread logs it as a bug via `report('...', 'error')` — this is supposed to be unreachable, so a loud surfacing helps catch UI-side regressions early.
 
@@ -108,57 +134,74 @@ Build from `RUNNING_PAUSED_AT_BREAK` is allowed and follows the existing pattern
 
 `runDisabled` / `stepDisabled` / etc. derived flags pick up `RUNNING_PAUSED_AT_BREAK` so existing UI gating composes.
 
-### Step from `RUNNING_PAUSED_AT_BREAK`
+### Step semantics (cold-start and from paused)
 
-Step advances exactly one engine iteration and re-pauses, by mutating `nextState.debug = { before: true }` so the next iteration breaks regardless of the user's `state.debug` config. Stash the original `debug` value; restore on entry to the synthesized break before pausing again.
+Step is the unified entry point for advancing one engine iteration with a pause boundary. Three cases:
 
-Two paths depending on which kind of break we're paused at:
+1. **Cold-start Step (DEMO / MANUAL / HALTED → click Step)** — `MachineView.doStep` calls `runner.run({ debug, step: true, onPaused: onPausedHandler })`. The worker arms `initialState.debug.after = true` (preserving user-authored `.before`) so iter 1's after-fire is the step boundary. `stepPending = true`. After iter 1's command applies, the after-fire pauses; main thread enters `RUNNING_PAUSED_AT_BREAK`.
 
-- **`before` break.** `m` is the current `machineState`; `m.nextState` is the actual next iteration's state. Apply the trick directly inside `onDebugBreak`.
-- **`after` break.** `m` is `prevYield` (the engine substitutes for context). The un-substituted `machineState` isn't reachable here. Set a `pendingStepNext` flag and defer the trick to the *next* `onStep` call, which fires with the un-substituted yield. (Once [turing-machine-js#107](https://github.com/mellonis/turing-machine-js/issues/107) lands — escape hatch for the un-substituted snapshot — this defer can collapse back into `onDebugBreak`.)
+2. **Step from `RUNNING_PAUSED_AT_BREAK`** — `runner.resume({ step: true })`. Inside `onDebugBreak` (during the resume flow), the worker arms `target.debug.after = true` and sets `pendingRestore` to undo the mutation before the user observes the next break. The target depends on which kind of break we're paused at:
+   - **`before` break.** `m.state` is the current iteration's state. Arm `m.state.debug.after`. Iter K's command applies, then iter K's after-fire fires (deferred to iter K+1's start, with `prevYield` substituted).
+   - **`after` break.** `m.state` is already `prevYield` (the engine substitutes for context). Arm `m.nextState.debug.after`. Iter K+1 starts with `state.debug.after` set, fires its own after-fire at iter K+2's start.
+
+3. **`RUNNING_STEP` (auto-step paused) + Step click** — keeps the legacy `runner.step()` path for one-iteration advancement. Auto-step refactor to run-mode is tracked in [#43](https://github.com/mellonis/machines-demo/issues/43); until that lands, this path doesn't pause at breakpoints.
+
+The unified rule: Step always arms `.after` (never `.before`). Step boundaries are at the *end* of an iteration, not the start, matching the legacy step-by-step mental model — Step click → "I've now seen the result of one more iteration".
 
 ```ts
-let pendingStepNext = false;
-let pendingRestore: (() => void) | null = null;
-let resumeAction: 'continue' | 'step' = 'continue';
-
-await machine.run({
-  initialState,
-  stepsLimit: req.maxSteps ?? MAX_STEPS,
-  onStep: (m) => {
-    if (pendingStepNext) {
-      const ns = m.nextState;
-      const original = ns.debug;
-      ns.debug = { before: true };
-      pendingRestore = () => { ns.debug = original; };
-      pendingStepNext = false;
-    }
-    // existing per-step buffering
-  },
-  onDebugBreak: async (m) => {
-    if (pendingRestore) { pendingRestore(); pendingRestore = null; }
-    // post `paused`, await `resume` — sets resumeAction = 'continue' | 'step'
-    if (resumeAction === 'step') {
-      if (m.debugBreak?.before) {
-        const ns = m.nextState;
-        const original = ns.debug;
-        ns.debug = { before: true };
-        pendingRestore = () => { ns.debug = original; };
-      } else {
-        pendingStepNext = true;
-      }
-    }
-  },
-});
+// Inside onDebugBreak, on resume(step: true):
+if (action.step) {
+  stepPending = true;
+  const target = (
+    m.debugBreak?.before ? m.state : m.nextState
+  ) as { debug: { before?: unknown; after?: unknown } | null };
+  const original = target.debug;
+  // Preserve user-authored .before (read via getter — DebugConfig accessor; spread skips it).
+  target.debug = {
+    after: true,
+    ...(original?.before !== undefined ? { before: original.before } : {}),
+  };
+  pendingRestore = () => { target.debug = original; };
+}
 ```
 
-`nextState.debug` mutation is shared across `withOverrodeHaltState` wrappers (per upstream docs); the stash-and-restore covers this — whatever the user had on the underlying state is preserved.
+### `stepInduced`
+
+The user's mental model: "full break-state info should appear only when *I* authored a breakpoint". Worker-armed Step boundaries shouldn't surface state identity in the log — that would suggest the user set something they didn't.
+
+Worker computes `stepInduced` per pause by reading `m.state.debug[when]` AFTER `pendingRestore` runs:
+
+```ts
+const stepInduced = m.debugBreak?.before
+  ? !m.state.debug?.before
+  : !m.state.debug?.after;
+```
+
+After `pendingRestore`, `m.state.debug` reflects the user's authored value, not our temporary arm. If the relevant flag is unset, the pause exists only because we armed it → `stepInduced = true`. Main-thread `onPausedHandler` logs full break-state info only when `debugMode && !stepInduced`, otherwise generic `paused`.
+
+### Halt-iter quirks (engine-side)
+
+Two halt-related quirks visible in the trace, neither caused by our code:
+
+- **Halting iter's `after`-fire never fires.** The engine fires after-fire at iter K+1's start using `prevYield`. When iter K transitions to `haltState`, the `while (!state.isHalt)` loop exits — no iter K+1 — `prevYield`'s after-fire is silently lost.
+- **`haltState.debug.after` has no anchor.** Halt is terminal; there's no "iteration after halt" for an after-fire to attach to. The engine silently ignores it. (`haltState.debug.before` IS honored — fires on the iter that transitions to halt, OR'd into that iter's `beforeMatch`.)
+
+Both filed upstream in [turing-machine-js#108](https://github.com/mellonis/turing-machine-js/issues/108) — proposed fix: drain `pendingAfterFromPrev` after the loop, and warn-then-throw on `haltState.debug.after` assignment.
+
+### Halt-iter step entry (uniform)
+
+Cold-start Step (run-mode) reports the halting iter's command via `ran.commands`. `runner.step()` legacy path also reports the halting iter's `res.commands` before logging halt. No path absorbs the halting iter's step entry into the halt log line.
 
 ## "Debug mode" UI
 
 A checkbox lives in `Toolbar.svelte` next to `with pause`. State name `debugMode`, owned by `MachineView.svelte`, persisted to `localStorage` under `machines-demo:<engine>:debugMode` (mirroring the existing `withPause` pattern). Default off.
 
-The checkbox is purely a request-payload gate: every `run` request includes `debug: debugMode`. The UI never disables `withPause` when `debugMode` is on (or vice versa) — they target different execution modes:
+The checkbox feeds two paths:
+
+1. **Run-time**: every `run` request includes `debug: debugMode` so the worker initializes `debugEnabled` correctly at run start.
+2. **Mid-run**: a `$effect` in `MachineView.svelte` watches `debugMode` and fires `runner.setDebug(debugMode)` whenever it changes (gated on `workerLive`). The worker's `setDebug` handler updates `debugEnabled` without restarting — flipping the checkbox during a paused break changes how *future* breaks are handled.
+
+The UI never disables `withPause` when `debugMode` is on (or vice versa) — they target different execution modes:
 
 | `withPause` | `debugMode` | Run button → | Breakpoints fire? |
 |---|---|---|---|
@@ -175,12 +218,14 @@ On `paused`:
 
 1. Rebuild `mirrorMachine` from the snapshot tapes (snap, no animation) — same path as `ran`.
 2. Replay the buffered `commands: Command[][]` to the Log via `report` + `commandsEntry` — user sees the trace that led to the break.
-3. Append a single `ok`-styled log entry: `paused at <state.name> [before|after]: <symbols-under-heads>`.
+3. Append a single `ok`-styled log entry. Format depends on `debugMode && !paused.stepInduced`:
+   - **`true`** (debug on AND user-authored break): `paused at state <name> [before|after] applying command for symbols: [<syms>]`.
+   - **`false`** (debug off, OR worker-armed Step boundary): generic `paused`.
 4. Update `lastSnapshots`, set `executionMode = 'RUNNING_PAUSED_AT_BREAK'`.
 
 On `resume` (Continue clicked): nothing changes locally — wait for the next worker response (`paused`, `ran`, or `error`).
 
-On the final `ran`: existing flow — render final tapes, batch-log buffered commands, mode → `HALTED`.
+On the final `ran`: existing flow — render final tapes, batch-log buffered commands, mode → `HALTED`. Both run-mode Step (cold-start path) and the legacy `runner.step()` path log the halting iter's command before the halt entry.
 
 ## Default snippets: don't run the machine
 
@@ -225,5 +270,6 @@ Make `_runMirrorStep` async and `await mirrorMachine.run(...)`. Propagate to its
 
 ## Future simplifications when upstream lands
 
-- [turing-machine-js#106](https://github.com/mellonis/turing-machine-js/issues/106) — `debug: boolean` parameter on `run()`. The worker can pass it straight through and drop the conditional `onDebugBreak` wrapper.
-- [turing-machine-js#107](https://github.com/mellonis/turing-machine-js/issues/107) — escape hatch on the substituted `m` for `after`-break consumers. The Step path's `onStep`-deferral collapses back into `onDebugBreak`.
+- [turing-machine-js#106](https://github.com/mellonis/turing-machine-js/issues/106) — `debug: boolean` parameter on `run()`. The worker can pass it straight through; the off-path flag-check inside `onDebugBreak` goes away (the runtime-toggle still requires our wrapper).
+- [turing-machine-js#108](https://github.com/mellonis/turing-machine-js/issues/108) — drain `pendingAfterFromPrev` after the engine's main loop so the halting iter's `after`-fire actually fires; warn-then-throw on `haltState.debug.after` assignment. The "halt-iter quirks" subsection in Step semantics goes away when this lands.
+- [turing-machine-js#107](https://github.com/mellonis/turing-machine-js/issues/107) — un-substituted snapshot for `after`-break consumers. **No longer needed for our Step path** — we arm `.after` (not `.before`) on the next iteration, and `m.state` for an after-fire payload is already `prevYield` (the just-executed state), which is exactly what we need to read for `stepInduced`. Filed before the `.after`-arming approach was settled; can stay open for other consumers.

--- a/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
+++ b/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
@@ -180,3 +180,8 @@ Make `_runMirrorStep` async and `await mirrorMachine.run(...)`. Propagate to its
 - Public `onDebugBreak` parameter on `PostMachine.run()` — closed as not planned ([post-machine-js#62](https://github.com/mellonis/post-machine-js/issues/62)). The worker calls the underscored hook directly when running a `PostMachine`.
 - Public state-by-instruction-label lookup on `PostMachine` ([post-machine-js#63](https://github.com/mellonis/post-machine-js/issues/63)).
 - Breakpoints in `RUNNING_AUTO` (engine constraint — documented in the #38 example).
+
+## Future simplifications when upstream lands
+
+- [turing-machine-js#106](https://github.com/mellonis/turing-machine-js/issues/106) — `debug: boolean` parameter on `run()`. The worker can pass it straight through and drop the conditional `onDebugBreak` wrapper.
+- [turing-machine-js#107](https://github.com/mellonis/turing-machine-js/issues/107) — escape hatch on the substituted `m` for `after`-break consumers. The Step path's `onStep`-deferral collapses back into `onDebugBreak`.

--- a/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
+++ b/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
@@ -53,9 +53,36 @@ await machine.run({
 
 When `debug` is `false`, `onDebugBreak` is omitted entirely — upstream's `run()` then skips break-handling without our wrapper paying any per-step cost. Once [turing-machine-js#106](https://github.com/mellonis/turing-machine-js/issues/106) lands, we can pass `debug` straight through to upstream and drop this conditional.
 
-A module-scoped `resumeResolve: (() => void) | null` holds the pending Promise. The `resume` request handler resolves it and clears the slot. `run` and `resume` are the only message types that touch this slot; concurrent `run` is rejected (existing `not built` / state-error pattern).
+A module-scoped `resumeResolve: (() => void) | null` holds the pending Promise. The `resume` request handler resolves it and clears the slot. `run` and `resume` are the only message types that touch this slot; concurrent `run` is rejected by the phase machine (see below).
 
 After `run()` resolves (halt or stepsLimit), the worker sends the existing `ran` response. Errors thrown from inside `run()` (e.g. no edge for current symbol) flow through the existing catch and produce `error` with partial tape state.
+
+### Worker phases
+
+Defense in depth against bad requests from the main thread. The mode machine on the main side gates buttons, but a future refactor could let an invalid request through; without worker-side validation, that becomes a silent hang (e.g. `resume` with no pending Promise = no-op, paused forever).
+
+```ts
+type WorkerPhase =
+  | { kind: 'idle' }
+  | { kind: 'built'; halted: boolean }
+  | { kind: 'running' }
+  | { kind: 'paused' };
+
+let phase: WorkerPhase = { kind: 'idle' };
+```
+
+Allowed transitions:
+
+| Request | Allowed from | New phase |
+|---|---|---|
+| `build` | any | `built { halted: <first-yield-done> }` |
+| `step` | `built { halted: false }` | `built { halted: <post-step> }` |
+| `run` | `built { halted: false }` | `running` → `paused` or `built { halted: true }` |
+| `resume` | `paused` | `running` → `paused` or `built { halted: true }` |
+
+A request from a disallowed phase throws `worker phase <current>, expected <allowed>`, which the existing catch converts into an `error` response. Main thread logs it as a bug via `report('...', 'error')` — this is supposed to be unreachable, so a loud surfacing helps catch UI-side regressions early.
+
+`build` from any phase is intentional: the existing UI allows Build at any time (terminate worker is implicit in the runner; from the worker's POV the request is fresh), and we want to keep that.
 
 ## Main-thread modes
 
@@ -93,31 +120,36 @@ Two paths depending on which kind of break we're paused at:
 ```ts
 let pendingStepNext = false;
 let pendingRestore: (() => void) | null = null;
+let resumeAction: 'continue' | 'step' = 'continue';
 
-onStep: (m) => {
-  if (pendingStepNext) {
-    const ns = m.nextState;
-    const original = ns.debug;
-    ns.debug = { before: true };
-    pendingRestore = () => { ns.debug = original; };
-    pendingStepNext = false;
-  }
-  // existing per-step buffering
-},
-onDebugBreak: async (m) => {
-  if (pendingRestore) { pendingRestore(); pendingRestore = null; }
-  // post `paused`, await `resume` (sets resumeAction = 'continue' | 'step')
-  if (resumeAction === 'step') {
-    if (m.debugBreak?.before) {
+await machine.run({
+  initialState,
+  stepsLimit: req.maxSteps ?? MAX_STEPS,
+  onStep: (m) => {
+    if (pendingStepNext) {
       const ns = m.nextState;
       const original = ns.debug;
       ns.debug = { before: true };
       pendingRestore = () => { ns.debug = original; };
-    } else {
-      pendingStepNext = true;
+      pendingStepNext = false;
     }
-  }
-}
+    // existing per-step buffering
+  },
+  onDebugBreak: async (m) => {
+    if (pendingRestore) { pendingRestore(); pendingRestore = null; }
+    // post `paused`, await `resume` — sets resumeAction = 'continue' | 'step'
+    if (resumeAction === 'step') {
+      if (m.debugBreak?.before) {
+        const ns = m.nextState;
+        const original = ns.debug;
+        ns.debug = { before: true };
+        pendingRestore = () => { ns.debug = original; };
+      } else {
+        pendingStepNext = true;
+      }
+    }
+  },
+});
 ```
 
 `nextState.debug` mutation is shared across `withOverrodeHaltState` wrappers (per upstream docs); the stash-and-restore covers this — whatever the user had on the underlying state is preserved.

--- a/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
+++ b/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
@@ -8,47 +8,52 @@ The worker drives execution through `runStepByStep` only (`src/lib/machineWorker
 
 ## Decisions
 
-- **Always-runWithBreaks dispatch.** The Run button always uses the new path. If user code never sets `state.debug` / `haltState.debug`, no breaks fire and behavior is identical to today's sync run. The old `run` request type is dropped — one path, no main-thread introspection of user State needed to choose.
+- **Extend the existing `run` request.** Keep the request type name `run`; add an optional `debug` flag and break-pause support. The worker switches from the synchronous `runToEnd` helper to `await machine.run({ ... })`. Single request type, no dispatch decision on the main thread.
 - **Dedicated paused-at-break mode.** A new `RUNNING_PAUSED_AT_BREAK` is introduced rather than overloading the existing `RUNNING_STEP`. The two states are conceptually different: `RUNNING_STEP` is paused between full steps and *can* single-step; `RUNNING_PAUSED_AT_BREAK` is paused inside `run()` and *cannot* (the engine's `for` loop owns the iteration).
 - **`RUNNING_AUTO` unchanged.** Auto-step uses `runStepByStep`, so breakpoints don't fire there. Documented as a known constraint in the #38 example.
-- **"Debug mode" UI gate.** A user-facing checkbox controls whether breaks pause execution at all, so `state.debug` / `haltState.debug` assignments in user code stay valid across both modes (no edit-and-comment-out churn). Demo-side emulation today (the worker's `onDebugBreak` resolves instantly when off); cross-references [turing-machine-js#106](https://github.com/mellonis/turing-machine-js/issues/106) which proposes the same gate as a `debug: boolean` parameter on upstream `run()`.
+- **"Debug mode" UI gate.** A user-facing checkbox controls whether breaks pause execution at all, so `state.debug` / `haltState.debug` assignments in user code stay valid across both modes (no edit-and-comment-out churn). Demo-side emulation today (the worker's `onDebugBreak` resolves instantly when off); cross-references [turing-machine-js#106](https://github.com/mellonis/turing-machine-js/issues/106) which proposes the same gate as a `debug: boolean` parameter on upstream `run()`. The wire shape matches that proposal.
 
 ## Worker contract
 
-Drop `run`. Add `runWithBreaks` and `resume`. Add `paused` response. `build` / `step` unchanged. `stepped` / `ran` / `error` shapes unchanged.
+Extend `run` with an optional `debug` flag. Add `resume` request and `paused` response. `build` / `step` unchanged. `stepped` / `ran` / `error` shapes unchanged.
 
 | Direction | Type | Payload |
 |---|---|---|
-| → | `runWithBreaks` | `{ maxSteps?, debug }` |
+| → | `run` | `{ maxSteps?, debug? }` |
 | → | `resume` | `{}` |
 | ← | `paused` | `{ tapes, commands, stepsApplied, state, currentSymbols, debugBreak }` |
 
-`debug: boolean` is required (no default at the wire — main thread is always explicit). When `false`, the worker's `onDebugBreak` resolves instantly without posting `paused`. When `true`, the pause/resume flow runs.
+`debug: boolean` defaults to `false` — no surprise pauses if user code has leftover `state.debug` assignments. When `true`, the worker's `onDebugBreak` posts `paused` and awaits `resume`. When `false`, `onDebugBreak` returns immediately (pauses short-circuited at the wrapper level).
 
 Field shapes:
 
 - `tapes: TapeSnapshot[]` — full snapshot at break time (same producer as `built` / `ran` / `error`).
-- `commands: Command[][]` — per-step commands buffered since the previous `paused` (or since `runWithBreaks` started). Mirror replays them in the Log; tape state is restored from `tapes`.
+- `commands: Command[][]` — per-step commands buffered since the previous `paused` (or since `run` started). Mirror replays them in the Log; tape state is restored from `tapes`.
 - `stepsApplied: number` — running total across all segments of this run (matches `stepped` / `ran` semantics).
 - `state: string` — `m.state.name`. The user's `State` instance does not cross the boundary.
 - `currentSymbols: string[]` — the symbols under each head at break time.
 - `debugBreak: { before?: true; after?: true }` — copied from `m.debugBreak` (omitted shape = field absent, never `undefined`).
 
-Inside the worker, `runWithBreaks` calls:
+Inside the worker, `run` now calls:
 
 ```ts
+const debug = req.debug ?? false;
 await machine.run({
   initialState,
   stepsLimit: req.maxSteps ?? MAX_STEPS,
   onStep: (m) => { /* buffer per-step commands */ },
-  onDebugBreak: async (m) => {
-    send({ type: 'paused', ... });
-    await new Promise<void>((resolve) => { resumeResolve = resolve });
-  },
+  onDebugBreak: debug
+    ? async (m) => {
+        send({ type: 'paused', ... });
+        await new Promise<void>((resolve) => { resumeResolve = resolve });
+      }
+    : undefined,
 });
 ```
 
-A module-scoped `resumeResolve: (() => void) | null` holds the pending Promise. The `resume` request handler resolves it and clears the slot. `runWithBreaks` and `resume` are the only message types that touch this slot; concurrent `runWithBreaks` is rejected (existing `not built` / state-error pattern).
+When `debug` is `false`, `onDebugBreak` is omitted entirely — upstream's `run()` then skips break-handling without our wrapper paying any per-step cost. Once [turing-machine-js#106](https://github.com/mellonis/turing-machine-js/issues/106) lands, we can pass `debug` straight through to upstream and drop this conditional.
+
+A module-scoped `resumeResolve: (() => void) | null` holds the pending Promise. The `resume` request handler resolves it and clears the slot. `run` and `resume` are the only message types that touch this slot; concurrent `run` is rejected (existing `not built` / state-error pattern).
 
 After `run()` resolves (halt or stepsLimit), the worker sends the existing `ran` response. Errors thrown from inside `run()` (e.g. no edge for current symbol) flow through the existing catch and produce `error` with partial tape state.
 
@@ -59,7 +64,7 @@ ExecutionMode = 'DEMO' | 'MANUAL' | 'RUNNING_STEP' | 'RUNNING_AUTO'
               | 'RUNNING_CONTINUOUS' | 'RUNNING_PAUSED_AT_BREAK' | 'HALTED'
 ```
 
-`RUNNING_CONTINUOUS` now dispatches `runWithBreaks` instead of the dropped `run`.
+`RUNNING_CONTINUOUS` sends `run` with `debug` set to the user's "Debug mode" checkbox state.
 
 `RUNNING_PAUSED_AT_BREAK`:
 
@@ -80,7 +85,7 @@ Build from `RUNNING_PAUSED_AT_BREAK` is allowed and follows the existing pattern
 
 A checkbox lives in `Toolbar.svelte` next to `with pause`. State name `debugMode`, owned by `MachineView.svelte`, persisted to `localStorage` under `machines-demo:<engine>:debugMode` (mirroring the existing `withPause` pattern). Default off.
 
-The checkbox is purely a request-payload gate: every `runWithBreaks` request includes `debug: debugMode`. The UI never disables `withPause` when `debugMode` is on (or vice versa) — they target different execution modes:
+The checkbox is purely a request-payload gate: every `run` request includes `debug: debugMode`. The UI never disables `withPause` when `debugMode` is on (or vice versa) — they target different execution modes:
 
 | `withPause` | `debugMode` | Run button → | Breakpoints fire? |
 |---|---|---|---|
@@ -108,7 +113,7 @@ On the final `ran`: existing flow — render final tapes, batch-log buffered com
 
 Per-segment 5s budget instead of per-request:
 
-- `runWithBreaks` sent → start 5s.
+- `run` sent → start 5s.
 - `paused` received → stop the timer. (User is inspecting; no clock.)
 - `resume` sent → start a fresh 5s.
 - `ran` / `error` received → stop.
@@ -125,7 +130,7 @@ Still caps total work across all resumes. Enforced inside `run()` via `stepsLimi
 
 `MachineView.svelte:258` calls `mirrorMachine.run({ initialState: oneStep })` without `await`. Currently correct under v4 (the `run()` body runs synchronously when no `onDebugBreak` is set), but fragile against any internal yield the upstream might add.
 
-Make `_runMirrorStep` async and `await mirrorMachine.run(...)`. Propagate to its callers as needed. Aligns with the new `runWithBreaks` flow and is future-proof.
+Make `_runMirrorStep` async and `await mirrorMachine.run(...)`. Propagate to its callers as needed. Aligns with the new async `run` request flow and is future-proof.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
+++ b/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
@@ -215,7 +215,7 @@ Make `_runMirrorStep` async and `await mirrorMachine.run(...)`. Propagate to its
 - Click-to-toggle UI for breakpoints ([#37](https://github.com/mellonis/machines-demo/issues/37)).
 - Public `onDebugBreak` parameter on `PostMachine.run()` — closed as not planned ([post-machine-js#62](https://github.com/mellonis/post-machine-js/issues/62)). The worker calls the underscored hook directly when running a `PostMachine`.
 - Public state-by-instruction-label lookup on `PostMachine` ([post-machine-js#63](https://github.com/mellonis/post-machine-js/issues/63)).
-- Breakpoints in `RUNNING_AUTO` (engine constraint — documented in the #38 example).
+- Breakpoints in `RUNNING_AUTO` (today: engine `runStepByStep` has no `onDebugBreak`). Tracked as a follow-up in [#43](https://github.com/mellonis/machines-demo/issues/43): switch `RUNNING_AUTO` to `run()` with a throttled `onStep`. Until that lands, the constraint is documented in the #38 example.
 
 ## Future simplifications when upstream lands
 

--- a/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
+++ b/docs/superpowers/specs/2026-05-08-worker-run-mode-design.md
@@ -1,0 +1,118 @@
+# Worker `run()` mode with `onDebugBreak` hook
+
+Tracks: [#40](https://github.com/mellonis/machines-demo/issues/40). Prerequisite for [#38](https://github.com/mellonis/machines-demo/issues/38) (Debugger-breakpoints example).
+
+## Problem
+
+The worker drives execution through `runStepByStep` only (`src/lib/machineWorker.ts:205,239`). v4's `onDebugBreak` is a `run()`-only hook — it cannot fire from a step generator. To wire the v4 debugger end-to-end in the UI, the worker needs to call async `machine.run({ onStep, onDebugBreak })` and let the main thread suspend execution at a break.
+
+## Decisions
+
+- **Always-runWithBreaks dispatch.** The Run button always uses the new path. If user code never sets `state.debug` / `haltState.debug`, no breaks fire and behavior is identical to today's sync run. The old `run` request type is dropped — one path, no main-thread introspection of user State needed to choose.
+- **Dedicated paused-at-break mode.** A new `RUNNING_PAUSED_AT_BREAK` is introduced rather than overloading the existing `RUNNING_STEP`. The two states are conceptually different: `RUNNING_STEP` is paused between full steps and *can* single-step; `RUNNING_PAUSED_AT_BREAK` is paused inside `run()` and *cannot* (the engine's `for` loop owns the iteration).
+- **`RUNNING_AUTO` unchanged.** Auto-step uses `runStepByStep`, so breakpoints don't fire there. Documented as a known constraint in the #38 example.
+
+## Worker contract
+
+Drop `run`. Add `runWithBreaks` and `resume`. Add `paused` response. `build` / `step` unchanged. `stepped` / `ran` / `error` shapes unchanged.
+
+| Direction | Type | Payload |
+|---|---|---|
+| → | `runWithBreaks` | `{ maxSteps? }` |
+| → | `resume` | `{}` |
+| ← | `paused` | `{ tapes, commands, stepsApplied, state, currentSymbols, debugBreak }` |
+
+Field shapes:
+
+- `tapes: TapeSnapshot[]` — full snapshot at break time (same producer as `built` / `ran` / `error`).
+- `commands: Command[][]` — per-step commands buffered since the previous `paused` (or since `runWithBreaks` started). Mirror replays them in the Log; tape state is restored from `tapes`.
+- `stepsApplied: number` — running total across all segments of this run (matches `stepped` / `ran` semantics).
+- `state: string` — `m.state.name`. The user's `State` instance does not cross the boundary.
+- `currentSymbols: string[]` — the symbols under each head at break time.
+- `debugBreak: { before?: true; after?: true }` — copied from `m.debugBreak` (omitted shape = field absent, never `undefined`).
+
+Inside the worker, `runWithBreaks` calls:
+
+```ts
+await machine.run({
+  initialState,
+  stepsLimit: req.maxSteps ?? MAX_STEPS,
+  onStep: (m) => { /* buffer per-step commands */ },
+  onDebugBreak: async (m) => {
+    send({ type: 'paused', ... });
+    await new Promise<void>((resolve) => { resumeResolve = resolve });
+  },
+});
+```
+
+A module-scoped `resumeResolve: (() => void) | null` holds the pending Promise. The `resume` request handler resolves it and clears the slot. `runWithBreaks` and `resume` are the only message types that touch this slot; concurrent `runWithBreaks` is rejected (existing `not built` / state-error pattern).
+
+After `run()` resolves (halt or stepsLimit), the worker sends the existing `ran` response. Errors thrown from inside `run()` (e.g. no edge for current symbol) flow through the existing catch and produce `error` with partial tape state.
+
+## Main-thread modes
+
+```
+ExecutionMode = 'DEMO' | 'MANUAL' | 'RUNNING_STEP' | 'RUNNING_AUTO'
+              | 'RUNNING_CONTINUOUS' | 'RUNNING_PAUSED_AT_BREAK' | 'HALTED'
+```
+
+`RUNNING_CONTINUOUS` now dispatches `runWithBreaks` instead of the dropped `run`.
+
+`RUNNING_PAUSED_AT_BREAK`:
+
+| Affordance | State |
+|---|---|
+| Run button | label "Continue", icon retained, sends `resume` |
+| Step button | hidden |
+| Stop button | visible (terminates worker, → `HALTED`) |
+| Take Control | hidden (consistent with other RUNNING_* modes) |
+| Editor | read-only-effective (Build remains available, see below) |
+| Belt | snap-to-paused-state, transitions off |
+
+Build from `RUNNING_PAUSED_AT_BREAK` is allowed and follows the existing pattern: terminate worker, `reloadWorker(code)`, mode → `MANUAL`. The pending Promise dies with the worker.
+
+`runDisabled` / `stepDisabled` / etc. derived flags pick up `RUNNING_PAUSED_AT_BREAK` so existing UI gating composes.
+
+## Mirror behavior across breaks
+
+On `paused`:
+
+1. Rebuild `mirrorMachine` from the snapshot tapes (snap, no animation) — same path as `ran`.
+2. Replay the buffered `commands: Command[][]` to the Log via `report` + `commandsEntry` — user sees the trace that led to the break.
+3. Append a single `ok`-styled log entry: `paused at <state.name> [before|after]: <symbols-under-heads>`.
+4. Update `lastSnapshots`, set `executionMode = 'RUNNING_PAUSED_AT_BREAK'`.
+
+On `resume` (Continue clicked): nothing changes locally — wait for the next worker response (`paused`, `ran`, or `error`).
+
+On the final `ran`: existing flow — render final tapes, batch-log buffered commands, mode → `HALTED`.
+
+## Timeout
+
+Per-segment 5s budget instead of per-request:
+
+- `runWithBreaks` sent → start 5s.
+- `paused` received → stop the timer. (User is inspecting; no clock.)
+- `resume` sent → start a fresh 5s.
+- `ran` / `error` received → stop.
+
+If any segment exceeds 5s, the existing terminate-on-timeout path runs (worker killed, respawned on next request).
+
+`MachineRunner` gains internal `pauseTimeout()` / `resumeTimeout()` helpers; the rest of the API is unchanged.
+
+## `MAX_STEPS`
+
+Still caps total work across all resumes. Enforced inside `run()` via `stepsLimit`. On overrun, `run()` throws — surfaces as `error` with partial tapes (existing path).
+
+## Line 258 (mirror await)
+
+`MachineView.svelte:258` calls `mirrorMachine.run({ initialState: oneStep })` without `await`. Currently correct under v4 (the `run()` body runs synchronously when no `onDebugBreak` is set), but fragile against any internal yield the upstream might add.
+
+Make `_runMirrorStep` async and `await mirrorMachine.run(...)`. Propagate to its callers as needed. Aligns with the new `runWithBreaks` flow and is future-proof.
+
+## Out of scope
+
+- The bundled "Debugger breakpoints" example itself ([#38](https://github.com/mellonis/machines-demo/issues/38)).
+- Click-to-toggle UI for breakpoints ([#37](https://github.com/mellonis/machines-demo/issues/37)).
+- Public `onDebugBreak` parameter on `PostMachine.run()` — closed as not planned ([post-machine-js#62](https://github.com/mellonis/post-machine-js/issues/62)). The worker calls the underscored hook directly when running a `PostMachine`.
+- Public state-by-instruction-label lookup on `PostMachine` ([post-machine-js#63](https://github.com/mellonis/post-machine-js/issues/63)).
+- Breakpoints in `RUNNING_AUTO` (engine constraint — documented in the #38 example).

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -514,7 +514,10 @@
       setAllFromMirror();
       halted = true;
       reflectNeutral();
-      if (res.commands.length > 0) {
+      // Skip the per-step trace dump on truncated runs — at MAX_STEPS the
+      // payload is 100k entries and Svelte's reactive list freezes the page.
+      // Band-aid for #45 (proper log throttle/buffer split tracked there).
+      if (!res.truncated && res.commands.length > 0) {
         appendBatch(
           res.commands.map((commands, i) =>
             commandsEntry(commands, { stepNumber: res.startStep + i + 1 }, CARET_COLORS),

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -337,10 +337,11 @@
   function stopMachine(): void {
     if (executionMode === 'RUNNING_PAUSED_AT_BREAK') {
       // Pending run Promise will reject when we terminate; failHalted in the
-      // caller's catch sets the rest. We pre-empt the message here.
+      // caller's catch is suppressed via stopRequested. We don't clear
+      // workerLive — Run/Step from HALTED reload-from-code (same as halt-via-
+      // completion), so the UI gate stays open and the next click respawns.
       stopRequested = true;
       runner.terminate();
-      workerLive = false;
     }
     executionMode = 'HALTED';
     report('stopped', 'warn');

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -79,6 +79,14 @@
     saveDebugMode(engine, debugMode);
   });
 
+  // Push the checkbox state to the worker whenever it changes (or after a
+  // fresh build sets workerLive). Lets the user toggle debug mid-run — the
+  // worker re-checks debugEnabled at every break instead of capturing the
+  // value at run-start.
+  $effect(() => {
+    if (workerLive) runner.setDebug(debugMode);
+  });
+
   let intervalText = $state('1s');
   let workerLive = $state(false);
   // engine is fixed for a MachineView instance (parent remounts on engine change

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -255,7 +255,7 @@
     mirrorMachine = new turing.TuringMachine({ tapeBlock: mirrorTapeBlock });
   }
 
-  function _runMirrorStep(commands: Command[]): void {
+  async function _runMirrorStep(commands: Command[]): Promise<void> {
     if (!mirrorMachine || !mirrorTapeBlock) return;
     const oneStep = new turing.State({
       [turing.ifOtherSymbol]: {
@@ -269,7 +269,7 @@
         nextState: turing.haltState,
       },
     });
-    mirrorMachine.run({ initialState: oneStep });
+    await mirrorMachine.run({ initialState: oneStep });
   }
 
   // Push the current mirror tapes into the visible <Tape> instances. Used
@@ -286,9 +286,9 @@
   // (except RUNNING_CONTINUOUS, which rebuilds in one shot). Advances the
   // mirror with `commands`, then has each <Tape> read its updated mirror
   // tape's `.viewport` and play the slide animation if requested.
-  function renderFromMirror(commands: Command[], animate: boolean): void {
+  async function renderFromMirror(commands: Command[], animate: boolean): Promise<void> {
     if (!mirrorTapeBlock) return;
-    _runMirrorStep(commands);
+    await _runMirrorStep(commands);
     mirrorTapeBlock.tapes.forEach((tape, i) => {
       const command = commands[i];
       const delta = (command?.movement === 'L' ? -1 : command?.movement === 'R' ? 1 : 0) as -1 | 0 | 1;
@@ -411,7 +411,7 @@
       report(commandsEntry(res.commands, { stepNumber: res.stepsApplied }, CARET_COLORS));
     }
     if (res.commands) {
-      renderFromMirror(res.commands, true);
+      await renderFromMirror(res.commands, true);
       // Show what's queued for the *next* click, not what just applied.
       // Keeps panel state consistent under rapid clicks.
       if (res.nextCommands) reflectToActivePanel(res.nextCommands);
@@ -482,8 +482,8 @@
     reflectNeutral();
   }
 
-  function onApply(commands: Command[]): void {
-    renderFromMirror(commands, true);
+  async function onApply(commands: Command[]): Promise<void> {
+    await renderFromMirror(commands, true);
     report(commandsEntry(commands, 'applied', CARET_COLORS));
   }
 
@@ -567,7 +567,7 @@
       reflect: (commands) => panelRef?.reflect(commands),
       apply: (commands) => {
         panelRef?.flashApply();
-        renderFromMirror(commands, true);
+        void renderFromMirror(commands, true);
       },
       getAlphabets: () => alphabets,
     });
@@ -582,7 +582,7 @@
           if (executionMode !== 'RUNNING_AUTO') return;
           if (res.commands) {
             reflectToActivePanel(res.commands);
-            renderFromMirror(res.commands, true);
+            await renderFromMirror(res.commands, true);
           }
           if (res.halted) {
             report(`halted after ${res.stepsApplied} step(s)`, 'ok');
@@ -661,6 +661,7 @@
       examples={engineExamples}
       {selectedExampleId}
       bind:withPause
+      bind:debugMode
       bind:intervalText
       onBuild={() => doLoad({ userInitiated: true })}
       onStep={doStep}

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -459,9 +459,10 @@
     setAllFromMirror();
     // Format the break log entry. Engine's run() dispatches onDebugBreak
     // separately for before/after — exactly one is true at the wire.
-    const kind = paused.debugBreak.before ? 'before' : 'after';
-    const symbols = paused.currentSymbols.join(' ');
-    report(`paused at ${paused.state || '(unnamed)'} [${kind}]: ${symbols}`, 'ok');
+    const when = paused.debugBreak.before ? 'before' : 'after';
+    const symbols = paused.currentSymbols.map((s) => `'${s}'`).join(', ');
+    const stateRef = paused.state ? `state ${paused.state}` : 'unnamed state';
+    report(`paused at ${stateRef} ${when} applying command for symbols: [${symbols}]`, 'ok');
     executionMode = 'RUNNING_PAUSED_AT_BREAK';
   }
 

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -390,8 +390,8 @@
 
   async function doStep(): Promise<void> {
     // RUNNING_PAUSED_AT_BREAK → Step click means "advance one iteration in the
-    // run, then re-pause". Send resume with step flag; worker will arm the
-    // nextState.debug trick.
+    // run, then re-pause". Send resume with step flag; worker arms next
+    // state's debug.after.
     if (executionMode === 'RUNNING_PAUSED_AT_BREAK') {
       runner.resume(true);
       // Phase will be set by the next `paused` (or `ran` if the synthesized
@@ -405,50 +405,91 @@
       report('paused');
       return;
     }
-    // Soft-debounce: drop rapid clicks while a worker step is in flight. The
-    // belt animation does NOT block — the user can click again as soon as the
-    // worker returns (~ms), even mid-slide.
-    if (stepInFlight) return;
 
-    // First step from any non-RUNNING_STEP mode (DEMO / MANUAL / HALTED):
-    // reload so mirrorMachine and worker start from the current code (user
-    // may have edited it; HALTED entry effectively restarts the machine).
-    if (executionMode !== 'RUNNING_STEP') {
-      reportSeparator();
-      report('loading…');
-      const ok = await reloadWorker();
-      if (!ok) {
-        executionMode = userTookControl ? 'MANUAL' : 'DEMO';
+    // RUNNING_STEP (auto-step paused) keeps the legacy `runner.step()` path —
+    // each Step click advances one iteration with no run-mode pause cycle.
+    // The full Step+pause experience lives on the cold-start path below.
+    // (RUNNING_AUTO → run-mode is tracked in #43.)
+    if (executionMode === 'RUNNING_STEP') {
+      if (stepInFlight) return;
+      stepInFlight = true;
+      let res;
+      try {
+        res = await runner.step();
+      } catch (err) {
+        failHalted(err);
         return;
+      } finally {
+        stepInFlight = false;
       }
-      executionMode = 'RUNNING_STEP';
-      codeChangedWarned = false;
-      reflectNeutral();
+      halted = res.halted;
+      if (res.halted) {
+        report(`halted after ${res.stepsApplied} step(s)`, 'ok');
+        executionMode = 'HALTED';
+      } else {
+        report(commandsEntry(res.commands, { stepNumber: res.stepsApplied }, CARET_COLORS));
+      }
+      if (res.commands) {
+        await renderFromMirror(res.commands, true);
+        if (res.nextCommands) reflectToActivePanel(res.nextCommands);
+        else reflectNeutral();
+      }
+      return;
     }
 
-    stepInFlight = true;
-    let res;
+    // Cold-start Step (DEMO / MANUAL / HALTED): reload + run-mode with step:true.
+    // Worker arms the initial state's debug.after so iter 1's after-fire is
+    // the step boundary; user-authored state.debug.before still fires naturally.
+    // onPausedHandler takes over; subsequent Step clicks resume(step: true).
+    if (stepInFlight) return;
+    reportSeparator();
+    report('loading…');
+    const ok = await reloadWorker();
+    if (!ok) {
+      executionMode = userTookControl ? 'MANUAL' : 'DEMO';
+      return;
+    }
+    if (halted) {
+      report('halted immediately', 'ok');
+      executionMode = 'HALTED';
+      return;
+    }
+    codeChangedWarned = false;
+    reflectNeutral();
+
+    pendingOp = 'run';
     try {
-      res = await runner.step();
+      const res = await runner.run({
+        maxSteps: undefined,
+        debug: debugMode,
+        step: true,
+        onPaused: onPausedHandler,
+      });
+      // Reached only when the run halts without pausing — e.g. Continue from
+      // a paused state, or the armed break never fires before halt. Mirror
+      // the doRun completion path.
+      lastSnapshots = res.tapes;
+      _buildMirrorMachine(res.tapes, alphabets);
+      setAllFromMirror();
+      halted = true;
+      reflectNeutral();
+      if (!res.truncated && res.commands.length > 0) {
+        appendBatch(
+          res.commands.map((commands, i) =>
+            commandsEntry(commands, { stepNumber: res.startStep + i + 1 }, CARET_COLORS),
+          ),
+        );
+      }
+      if (res.truncated) {
+        report(`truncated at ${res.stepsApplied} steps (limit hit)`, 'warn');
+      } else {
+        report(`halted after ${res.stepsApplied} step(s)`, 'ok');
+      }
+      executionMode = 'HALTED';
     } catch (err) {
       failHalted(err);
-      return;
     } finally {
-      stepInFlight = false;
-    }
-    halted = res.halted;
-    if (res.halted) {
-      report(`halted after ${res.stepsApplied} step(s)`, 'ok');
-      executionMode = 'HALTED';
-    } else {
-      report(commandsEntry(res.commands, { stepNumber: res.stepsApplied }, CARET_COLORS));
-    }
-    if (res.commands) {
-      await renderFromMirror(res.commands, true);
-      // Show what's queued for the *next* click, not what just applied.
-      // Keeps panel state consistent under rapid clicks.
-      if (res.nextCommands) reflectToActivePanel(res.nextCommands);
-      else reflectNeutral();
+      pendingOp = null;
     }
   }
 
@@ -466,12 +507,19 @@
     lastSnapshots = paused.tapes;
     _buildMirrorMachine(paused.tapes, alphabets);
     setAllFromMirror();
-    // Format the break log entry. Engine's run() dispatches onDebugBreak
-    // separately for before/after — exactly one is true at the wire.
-    const when = paused.debugBreak.before ? 'before' : 'after';
-    const symbols = paused.currentSymbols.map((s) => `'${s}'`).join(', ');
-    const stateRef = paused.state ? `state ${paused.state}` : 'unnamed state';
-    report(`paused at ${stateRef} ${when} applying command for symbols: [${symbols}]`, 'ok');
+    // Log format depends on debug mode:
+    // - debug=on: full "paused at state X before/after applying command for symbols: [...]"
+    //   (the user wants this for any real break — user-set or Step-armed).
+    // - debug=off: generic "paused" (Step-induced pauses are explicit boundary
+    //   markers without state info).
+    if (debugMode) {
+      const when = paused.debugBreak.before ? 'before' : 'after';
+      const symbols = paused.currentSymbols.map((s) => `'${s}'`).join(', ');
+      const stateRef = paused.state ? `state ${paused.state}` : 'unnamed state';
+      report(`paused at ${stateRef} ${when} applying command for symbols: [${symbols}]`, 'ok');
+    } else {
+      report('paused', 'ok');
+    }
     executionMode = 'RUNNING_PAUSED_AT_BREAK';
   }
 

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -507,12 +507,14 @@
     lastSnapshots = paused.tapes;
     _buildMirrorMachine(paused.tapes, alphabets);
     setAllFromMirror();
-    // Log format depends on debug mode:
-    // - debug=on: full "paused at state X before/after applying command for symbols: [...]"
-    //   (the user wants this for any real break — user-set or Step-armed).
-    // - debug=off: generic "paused" (Step-induced pauses are explicit boundary
-    //   markers without state info).
-    if (debugMode) {
+    // Log format depends on whether the pause is at a user-authored breakpoint:
+    // - debug=on AND !stepInduced: full "paused at state X before/after applying
+    //   command for symbols: [...]" (the engine paused because the user set
+    //   state.debug — surface state identity).
+    // - everything else (debug=off, or debug=on with worker-armed Step pause):
+    //   generic "paused" — explicit pause marker without state info, so users
+    //   without authored breakpoints don't see misleading state references.
+    if (debugMode && !paused.stepInduced) {
       const when = paused.debugBreak.before ? 'before' : 'after';
       const symbols = paused.currentSymbols.map((s) => `'${s}'`).join(', ');
       const stateRef = paused.state ? `state ${paused.state}` : 'unnamed state';

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -460,6 +460,7 @@
     }
     codeChangedWarned = false;
     reflectNeutral();
+    report('running step by step…');
 
     pendingOp = 'run';
     try {
@@ -550,7 +551,7 @@
       }
       executionMode = 'RUNNING_AUTO';
       codeChangedWarned = false;
-      report(`auto-stepping every ${intervalMs}ms`);
+      report(`running, auto-stepping every ${intervalMs}ms`);
       // Auto-step loop is started by the $effect that watches executionMode.
       return;
     }

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -8,7 +8,7 @@
   import { MachineRunner, WorkerError } from '../lib/machineRunner.ts';
   import * as turing from '@turing-machine-js/machine';
   import { VIEWPORT_WIDTH } from '../lib/caps.ts';
-  import { type Alphabets, type Command, type Engine, type TapeSnapshot } from '../lib/types.ts';
+  import { type Alphabets, type Command, type Engine, type PausedResponse, type TapeSnapshot } from '../lib/types.ts';
   import { startDemoLoop } from '../lib/demoLoop.ts';
   import { startAutoStep, parseInterval } from '../lib/autoStep.ts';
   import { commandsEntry, tapesEntry } from '../lib/format.ts';
@@ -328,6 +328,12 @@
   }
 
   function stopMachine(): void {
+    if (executionMode === 'RUNNING_PAUSED_AT_BREAK') {
+      // Pending run Promise will reject when we terminate; failHalted in the
+      // caller's catch sets the rest. We pre-empt the message here.
+      runner.terminate();
+      workerLive = false;
+    }
     executionMode = 'HALTED';
     report('stopped', 'warn');
   }
@@ -366,6 +372,16 @@
   }
 
   async function doStep(): Promise<void> {
+    // RUNNING_PAUSED_AT_BREAK → Step click means "advance one iteration in the
+    // run, then re-pause". Send resume with step flag; worker will arm the
+    // nextState.debug trick.
+    if (executionMode === 'RUNNING_PAUSED_AT_BREAK') {
+      runner.resume(true);
+      // Phase will be set by the next `paused` (or `ran` if the synthesized
+      // step happens to land on halt).
+      return;
+    }
+
     // Step button doubles as "Pause" while RUNNING_AUTO.
     if (executionMode === 'RUNNING_AUTO') {
       executionMode = 'RUNNING_STEP';
@@ -419,7 +435,36 @@
     }
   }
 
+  function onPausedHandler(paused: PausedResponse): void {
+    // Replay buffered per-step commands so the trace leading to the break is visible.
+    if (paused.commands.length > 0) {
+      const startStep = paused.stepsApplied - paused.commands.length;
+      appendBatch(
+        paused.commands.map((commands, i) =>
+          commandsEntry(commands, { stepNumber: startStep + i + 1 }, CARET_COLORS),
+        ),
+      );
+    }
+    // Snap mirror to break-time tapes (no animation).
+    lastSnapshots = paused.tapes;
+    _buildMirrorMachine(paused.tapes, alphabets);
+    setAllFromMirror();
+    // Format the break log entry. Engine's run() dispatches onDebugBreak
+    // separately for before/after — exactly one is true at the wire.
+    const kind = paused.debugBreak.before ? 'before' : 'after';
+    const symbols = paused.currentSymbols.join(' ');
+    report(`paused at ${paused.state || '(unnamed)'} [${kind}]: ${symbols}`, 'ok');
+    executionMode = 'RUNNING_PAUSED_AT_BREAK';
+  }
+
   async function doRun(): Promise<void> {
+    // RUNNING_PAUSED_AT_BREAK → treat Run click as Continue.
+    if (executionMode === 'RUNNING_PAUSED_AT_BREAK') {
+      runner.resume(false);
+      executionMode = 'RUNNING_CONTINUOUS';
+      return;
+    }
+
     if (withPause) {
       // Resume auto-stepping from current RUNNING_STEP position without reload.
       if (executionMode !== 'RUNNING_STEP') {
@@ -434,7 +479,6 @@
       executionMode = 'RUNNING_AUTO';
       codeChangedWarned = false;
       report(`auto-stepping every ${intervalMs}ms`);
-      // Auto-step loop is started by the $effect that watches executionMode.
       return;
     }
 
@@ -450,7 +494,11 @@
     report('running…');
     pendingOp = 'run';
     try {
-      const res = await runner.run();
+      const res = await runner.run({
+        maxSteps: undefined,
+        debug: debugMode,
+        onPaused: (paused) => onPausedHandler(paused),
+      });
       lastSnapshots = res.tapes;
       _buildMirrorMachine(res.tapes, alphabets);
       setAllFromMirror();

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -26,6 +26,8 @@
     saveSnippet,
     deleteSnippet,
     renameSnippet,
+    loadDebugMode,
+    saveDebugMode,
     type Snippets,
   } from '../lib/persist.ts';
   import { icons } from '../lib/icons.ts';
@@ -52,6 +54,7 @@
     | 'RUNNING_STEP'
     | 'RUNNING_AUTO'
     | 'RUNNING_CONTINUOUS'
+    | 'RUNNING_PAUSED_AT_BREAK'
     | 'HALTED';
 
   /* ───── state ───── */
@@ -69,6 +72,12 @@
   let mirrorTapeBlock: turing.TapeBlock | null = null;
   let codeChangedWarned = false;
   let withPause = $state(false);
+  let debugMode = $state<boolean>(untrack(() => loadDebugMode(engine)));
+
+  $effect(() => {
+    saveDebugMode(engine, debugMode);
+  });
+
   let intervalText = $state('1s');
   let workerLive = $state(false);
   // engine is fixed for a MachineView instance (parent remounts on engine change
@@ -139,9 +148,14 @@
     executionMode === 'DEMO' || executionMode === 'MANUAL',
   );
   const takeControlVisible = $derived(
-    executionMode !== 'MANUAL' && executionMode !== 'RUNNING_CONTINUOUS',
+    executionMode !== 'MANUAL' &&
+    executionMode !== 'RUNNING_CONTINUOUS' &&
+    executionMode !== 'RUNNING_PAUSED_AT_BREAK',
   );
-  const beltTransitionsOn = $derived(executionMode !== 'RUNNING_CONTINUOUS');
+  const beltTransitionsOn = $derived(
+    executionMode !== 'RUNNING_CONTINUOUS' &&
+    executionMode !== 'RUNNING_PAUSED_AT_BREAK',
+  );
 
   // The code Reset would restore to: the loaded snippet's saved code, or the
   // selected bundled example's code, or null when the loaded snippet was

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -525,6 +525,7 @@
   }
 
   function takeControl(): void {
+    report('user took control', 'ok');
     userTookControl = true;
     executionMode = 'MANUAL';
     reflectNeutral();

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -71,6 +71,7 @@
   let mirrorMachine: turing.TuringMachine | null = null;
   let mirrorTapeBlock: turing.TapeBlock | null = null;
   let codeChangedWarned = false;
+  let stopRequested = $state(false);
   let withPause = $state(false);
   let debugMode = $state<boolean>(untrack(() => loadDebugMode(engine)));
 
@@ -172,11 +173,13 @@
       : 'Reset to selected example',
   );
 
-  const loadDisabled = $derived(pendingOp !== null);
+  const loadDisabled = $derived(
+    pendingOp !== null && executionMode !== 'RUNNING_PAUSED_AT_BREAK',
+  );
   // Step/Run stay enabled in HALTED — they reload-from-code on entry, which
   // also clears `halted`. Disabling would just force an extra Build click.
   const stepDisabled = $derived(
-    pendingOp !== null ||
+    (pendingOp !== null && executionMode !== 'RUNNING_PAUSED_AT_BREAK') ||
       !workerLive ||
       executionMode === 'RUNNING_CONTINUOUS',
   );
@@ -184,7 +187,7 @@
   // is fast (~ms), and we don't want the user to see flicker on rapid clicks.
   // Soft-debounced inside doStep() instead.
   const runDisabled = $derived(
-    pendingOp !== null ||
+    (pendingOp !== null && executionMode !== 'RUNNING_PAUSED_AT_BREAK') ||
       !workerLive ||
       executionMode === 'RUNNING_AUTO' ||
       executionMode === 'RUNNING_CONTINUOUS' ||
@@ -221,6 +224,10 @@
   /* ───── side-effect handlers (one source of truth on error) ───── */
 
   function failHalted(err: unknown): void {
+    if (stopRequested) {
+      stopRequested = false;
+      return;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     // Worker errored mid-step / mid-run. If it shipped a partial tape state,
     // sync the mirror + display to it so the user sees where execution stuck
@@ -331,6 +338,7 @@
     if (executionMode === 'RUNNING_PAUSED_AT_BREAK') {
       // Pending run Promise will reject when we terminate; failHalted in the
       // caller's catch sets the rest. We pre-empt the message here.
+      stopRequested = true;
       runner.terminate();
       workerLive = false;
     }
@@ -654,7 +662,7 @@
   $effect(() => {
     void code;  // subscribe; value unused (read happens via untrack below)
     untrack(() => {
-      if (executionMode === 'RUNNING_STEP' || executionMode === 'RUNNING_AUTO') {
+      if (executionMode === 'RUNNING_STEP' || executionMode === 'RUNNING_AUTO' || executionMode === 'RUNNING_PAUSED_AT_BREAK') {
         if (!codeChangedWarned) {
           codeChangedWarned = true;
           report('code changed — current execution continues from loaded state', 'warn');

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -423,11 +423,15 @@
         stepInFlight = false;
       }
       halted = res.halted;
+      if (res.commands) {
+        // Always log the iter's command — even on the halting iter — so the
+        // legacy step path matches the run-mode Step path. The halt entry
+        // follows separately when applicable.
+        report(commandsEntry(res.commands, { stepNumber: res.stepsApplied }, CARET_COLORS));
+      }
       if (res.halted) {
         report(`halted after ${res.stepsApplied} step(s)`, 'ok');
         executionMode = 'HALTED';
-      } else {
-        report(commandsEntry(res.commands, { stepNumber: res.stepsApplied }, CARET_COLORS));
       }
       if (res.commands) {
         await renderFromMirror(res.commands, true);
@@ -704,12 +708,12 @@
           if (res.commands) {
             reflectToActivePanel(res.commands);
             await renderFromMirror(res.commands, true);
+            // Always log the iter's command (incl. halting iter), then halt.
+            report(commandsEntry(res.commands, { stepNumber: res.stepsApplied }, CARET_COLORS));
           }
           if (res.halted) {
             report(`halted after ${res.stepsApplied} step(s)`, 'ok');
             executionMode = 'HALTED';
-          } else {
-            report(commandsEntry(res.commands, { stepNumber: res.stepsApplied }, CARET_COLORS));
           }
         } catch (err) {
           failHalted(err);

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -512,21 +512,14 @@
     lastSnapshots = paused.tapes;
     _buildMirrorMachine(paused.tapes, alphabets);
     setAllFromMirror();
-    // Log format depends on whether the pause is at a user-authored breakpoint:
-    // - debug=on AND !stepInduced: full "paused at state X before/after applying
-    //   command for symbols: [...]" (the engine paused because the user set
-    //   state.debug — surface state identity).
-    // - everything else (debug=off, or debug=on with worker-armed Step pause):
-    //   generic "paused" — explicit pause marker without state info, so users
-    //   without authored breakpoints don't see misleading state references.
-    if (debugMode && !paused.stepInduced) {
-      const when = paused.debugBreak.before ? 'before' : 'after';
-      const symbols = paused.currentSymbols.map((s) => `'${s}'`).join(', ');
-      const stateRef = paused.state ? `state ${paused.state}` : 'unnamed state';
-      report(`paused at ${stateRef} ${when} applying command for symbols: [${symbols}]`, 'ok');
-    } else {
-      report('paused', 'ok');
-    }
+    // Always log the full break-state description. Reads as "we made a step,
+    // here's the result": after-arming means iter K just ran, and the pause
+    // surfaces iter K's state and just-executed symbols. (debug toggle gates
+    // whether user-authored breaks fire, not how pauses are logged.)
+    const when = paused.debugBreak.before ? 'before' : 'after';
+    const symbols = paused.currentSymbols.map((s) => `'${s}'`).join(', ');
+    const stateRef = paused.state ? `state ${paused.state}` : 'unnamed state';
+    report(`paused at ${stateRef} ${when} applying command for symbols: [${symbols}]`, 'ok');
     executionMode = 'RUNNING_PAUSED_AT_BREAK';
   }
 

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -479,6 +479,7 @@
       executionMode = 'RUNNING_AUTO';
       codeChangedWarned = false;
       report(`auto-stepping every ${intervalMs}ms`);
+      // Auto-step loop is started by the $effect that watches executionMode.
       return;
     }
 
@@ -497,7 +498,7 @@
       const res = await runner.run({
         maxSteps: undefined,
         debug: debugMode,
-        onPaused: (paused) => onPausedHandler(paused),
+        onPaused: onPausedHandler,
       });
       lastSnapshots = res.tapes;
       _buildMirrorMachine(res.tapes, alphabets);

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -46,7 +46,7 @@
     examples,
     selectedExampleId,
     withPause = $bindable(),
-    debugMode = $bindable(false),
+    debugMode = $bindable(),
     intervalText = $bindable(),
     snippets,
     loadedSnippetId,

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -225,7 +225,12 @@
     executionMode !== 'RUNNING_AUTO' && executionMode !== 'RUNNING_CONTINUOUS',
   );
   const stopVisible = $derived(
-    executionMode === 'RUNNING_STEP' || executionMode === 'RUNNING_AUTO',
+    executionMode === 'RUNNING_STEP' ||
+      executionMode === 'RUNNING_AUTO' ||
+      executionMode === 'RUNNING_PAUSED_AT_BREAK',
+  );
+  const runLabel = $derived(
+    executionMode === 'RUNNING_PAUSED_AT_BREAK' ? 'Continue' : 'Run',
   );
 </script>
 
@@ -409,7 +414,7 @@
     <span class="btn-label">{executionMode === 'RUNNING_AUTO' ? 'Pause' : 'Step'}</span>
   </button>
   <button type="button" disabled={runDisabled} onclick={onRun}>
-    {@html icons.run}<span class="btn-label">Run</span>
+    {@html icons.run}<span class="btn-label">{runLabel}</span>
   </button>
   {#if configVisible}
     <label class="checkbox">

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -19,6 +19,7 @@
     examples: readonly Example[];
     selectedExampleId: string;
     withPause: boolean;
+    debugMode: boolean;
     intervalText: string;
     snippets: Snippets;
     loadedSnippetId: string | null;
@@ -44,6 +45,7 @@
     examples,
     selectedExampleId,
     withPause = $bindable(),
+    debugMode = $bindable(false),
     intervalText = $bindable(),
     snippets,
     loadedSnippetId,
@@ -412,6 +414,10 @@
     <label class="checkbox">
       <input type="checkbox" bind:checked={withPause} disabled={runDisabled} />
       <span>with pause</span>
+    </label>
+    <label class="checkbox" title="When on, breaks set via state.debug pause execution at a Continue/Step prompt.">
+      <input type="checkbox" bind:checked={debugMode} disabled={runDisabled} />
+      <span>debug</span>
     </label>
     {#if withPause}
       <input

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -8,6 +8,7 @@
   type Mode =
     | 'DEMO' | 'MANUAL'
     | 'RUNNING_STEP' | 'RUNNING_AUTO' | 'RUNNING_CONTINUOUS'
+    | 'RUNNING_PAUSED_AT_BREAK'
     | 'HALTED';
 
   type Props = {

--- a/src/lib/defaultCode.ts
+++ b/src/lib/defaultCode.ts
@@ -14,6 +14,8 @@ const TURING_REPLACE_B = `// Task: replace every 'b' on the tape with '*'.
  *   haltState, ifOtherSymbol, movements, symbolCommands, ...
  *
  * Return: { machine, initialState, tape }
+ *
+ * Note: the demo runs the machine; do not call .run() or .runStepByStep() yourself.
  */
 
 const {
@@ -51,6 +53,8 @@ const TURING_COPY_TWO_TAPES = `// Task: copy tape 0 ('abab') onto blank tape 1, 
  *   haltState, ifOtherSymbol, movements, symbolCommands, ...
  *
  * Return: { machine, initialState }
+ *
+ * Note: the demo runs the machine; do not call .run() or .runStepByStep() yourself.
  */
 
 const {
@@ -99,6 +103,8 @@ const POST_WALK_MARK = `// Task: walk right while marked; mark the first blank c
  *   call, check, erase, left, mark, noop, right, stop, ...
  *
  * Return: { machine } — initialState and tape default from the machine.
+ *
+ * Note: the demo runs the machine; do not call .run() or .runStepByStep() yourself.
  */
 
 const { PostMachine, Tape, check, mark, right, stop } = imports;

--- a/src/lib/machineRunner.ts
+++ b/src/lib/machineRunner.ts
@@ -184,6 +184,9 @@ export class MachineRunner {
   run(opts: {
     maxSteps?: number;
     debug?: boolean;
+    /** When true the worker arms the initial state's `debug.after` so the run
+     * pauses at iter 1's step-boundary — the cold-start path used by Step. */
+    step?: boolean;
     onPaused?: (data: PausedResponse) => void;
   } = {}): Promise<RanResponse> {
     if (!this.worker) throw new Error('worker not spawned — call build() first');
@@ -201,6 +204,7 @@ export class MachineRunner {
         type: 'run',
         maxSteps: opts.maxSteps ?? MAX_STEPS,
         debug: opts.debug ?? false,
+        step: opts.step ?? false,
       });
     });
   }

--- a/src/lib/machineRunner.ts
+++ b/src/lib/machineRunner.ts
@@ -3,6 +3,7 @@ import { MAX_STEPS, WORKER_TIMEOUT_MS } from './caps.ts';
 import {
   type BuiltResponse,
   type Engine,
+  type PausedResponse,
   type RanResponse,
   type SteppedResponse,
   type TapeSnapshot,
@@ -26,34 +27,44 @@ export class WorkerError extends Error {
   }
 }
 
-type Pending = {
+type SimplePending = {
   resolve: (data: WorkerResponse) => void;
   reject: (err: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
+  timeoutId: ReturnType<typeof setTimeout>;
+};
+
+type RunPending = {
+  resolveRan: (data: RanResponse) => void;
+  reject: (err: Error) => void;
+  timeoutId: ReturnType<typeof setTimeout> | null;
+  onPaused: ((data: PausedResponse) => void) | null;
 };
 
 export class MachineRunner {
   readonly engine: Engine;
   private worker: Worker | null = null;
-  private pending: Pending | null = null;
+  private simplePending: SimplePending | null = null;
+  private runPending: RunPending | null = null;
 
   constructor(engine: Engine) {
     this.engine = engine;
   }
 
-  private rejectPending(err: Error): void {
-    if (!this.pending) return;
-    clearTimeout(this.pending.timer);
-    this.pending.reject(err);
-    this.pending = null;
+  private rejectAll(err: Error): void {
+    if (this.simplePending) {
+      clearTimeout(this.simplePending.timeoutId);
+      this.simplePending.reject(err);
+      this.simplePending = null;
+    }
+    if (this.runPending) {
+      if (this.runPending.timeoutId) clearTimeout(this.runPending.timeoutId);
+      this.runPending.reject(err);
+      this.runPending = null;
+    }
   }
 
   private spawnWorker(): void {
-    // Reject any in-flight request before tearing down the worker. Without
-    // this, the pending request's timeout would survive the worker swap and
-    // fire later — clearing `this.pending` and rejecting whatever new request
-    // had taken its slot.
-    this.rejectPending(new Error('superseded by new worker'));
+    this.rejectAll(new Error('superseded by new worker'));
     if (this.worker) {
       this.worker.terminate();
       this.worker = null;
@@ -63,65 +74,147 @@ export class MachineRunner {
     this.worker.onerror = (e) => this.onWorkerError(e);
   }
 
+  private startRunTimer(): void {
+    if (!this.runPending) return;
+    if (this.runPending.timeoutId) clearTimeout(this.runPending.timeoutId);
+    this.runPending.timeoutId = setTimeout(() => {
+      const p = this.runPending;
+      this.runPending = null;
+      if (this.worker) {
+        this.worker.terminate();
+        this.worker = null;
+      }
+      p?.reject(new Error(`timeout after ${WORKER_TIMEOUT_MS}ms — worker terminated (likely infinite loop)`));
+    }, WORKER_TIMEOUT_MS);
+  }
+
+  private stopRunTimer(): void {
+    if (!this.runPending) return;
+    if (this.runPending.timeoutId) {
+      clearTimeout(this.runPending.timeoutId);
+      this.runPending.timeoutId = null;
+    }
+  }
+
   private onMessage(data: WorkerResponse): void {
-    if (!this.pending) return;
-    const p = this.pending;
-    this.pending = null;
-    clearTimeout(p.timer);
+    // `paused` is the only response that doesn't complete a Promise.
+    if (data.type === 'paused') {
+      if (!this.runPending) return;
+      this.stopRunTimer();
+      this.runPending.onPaused?.(data);
+      return;
+    }
+    // ran / error complete the run; stepped / built complete a simple request.
+    if (data.type === 'ran') {
+      const p = this.runPending;
+      this.runPending = null;
+      if (!p) return;
+      this.stopRunTimer();
+      p.resolveRan(data);
+      return;
+    }
     if (data.type === 'error') {
-      p.reject(new WorkerError(data.message, data.tapes ?? null));
-    } else {
+      const err = new WorkerError(data.message, data.tapes ?? null);
+      if (this.runPending) {
+        const p = this.runPending;
+        this.runPending = null;
+        this.stopRunTimer();
+        p.reject(err);
+        return;
+      }
+      if (this.simplePending) {
+        const p = this.simplePending;
+        this.simplePending = null;
+        clearTimeout(p.timeoutId);
+        p.reject(err);
+        return;
+      }
+      return;
+    }
+    // built / stepped
+    if (this.simplePending) {
+      const p = this.simplePending;
+      this.simplePending = null;
+      clearTimeout(p.timeoutId);
       p.resolve(data);
     }
   }
 
   private onWorkerError(e: ErrorEvent): void {
-    if (!this.pending) return;
-    const p = this.pending;
-    this.pending = null;
-    clearTimeout(p.timer);
-    p.reject(new Error(`worker error: ${e.message ?? 'unknown'}`));
+    this.rejectAll(new Error(`worker error: ${e.message ?? 'unknown'}`));
   }
 
-  private send(msg: WorkerRequest, timeoutMs: number = WORKER_TIMEOUT_MS): Promise<WorkerResponse> {
+  private sendSimple(msg: WorkerRequest): Promise<WorkerResponse> {
     if (!this.worker) throw new Error('worker not spawned — call build() first');
-    if (this.pending) throw new Error('previous request still pending');
+    if (this.simplePending || this.runPending) throw new Error('previous request still pending');
 
     return new Promise<WorkerResponse>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending = null;
+      const timeoutId = setTimeout(() => {
+        this.simplePending = null;
         if (this.worker) {
           this.worker.terminate();
           this.worker = null;
         }
-        reject(new Error(`timeout after ${timeoutMs}ms — worker terminated (likely infinite loop)`));
-      }, timeoutMs);
-      this.pending = { resolve, reject, timer };
+        reject(new Error(`timeout after ${WORKER_TIMEOUT_MS}ms — worker terminated (likely infinite loop)`));
+      }, WORKER_TIMEOUT_MS);
+      this.simplePending = { resolve, reject, timeoutId };
       this.worker!.postMessage(msg);
     });
   }
 
   async build(code: string): Promise<BuiltResponse> {
     this.spawnWorker();
-    const r = await this.send({ type: 'build', engine: this.engine, code });
+    const r = await this.sendSimple({ type: 'build', engine: this.engine, code });
     if (r.type !== 'built') throw new Error(`unexpected response: ${r.type}`);
     return r;
   }
 
   async step(): Promise<SteppedResponse> {
-    const r = await this.send({ type: 'step' });
+    const r = await this.sendSimple({ type: 'step' });
     if (r.type !== 'stepped') throw new Error(`unexpected response: ${r.type}`);
     return r;
   }
 
-  async run(maxSteps: number = MAX_STEPS): Promise<RanResponse> {
-    const r = await this.send({ type: 'run', maxSteps });
-    if (r.type !== 'ran') throw new Error(`unexpected response: ${r.type}`);
-    return r;
+  /**
+   * Async run with optional break-pause support. Returns when the worker
+   * sends `ran` (halt or stepsLimit). If `debug` is true and a break fires,
+   * `onPaused` is called; the consumer must call `resume()` to continue.
+   * The Promise stays pending across paused/resume cycles.
+   */
+  run(opts: {
+    maxSteps?: number;
+    debug?: boolean;
+    onPaused?: (data: PausedResponse) => void;
+  } = {}): Promise<RanResponse> {
+    if (!this.worker) throw new Error('worker not spawned — call build() first');
+    if (this.simplePending || this.runPending) throw new Error('previous request still pending');
+
+    return new Promise<RanResponse>((resolveRan, reject) => {
+      this.runPending = {
+        resolveRan,
+        reject,
+        timeoutId: null,
+        onPaused: opts.onPaused ?? null,
+      };
+      this.startRunTimer();
+      this.worker!.postMessage({
+        type: 'run',
+        maxSteps: opts.maxSteps ?? MAX_STEPS,
+        debug: opts.debug ?? false,
+      });
+    });
+  }
+
+  /** Send a `resume` to a paused worker. Reactivates the round-trip timer. */
+  resume(step: boolean = false): void {
+    if (!this.runPending) throw new Error('resume: no pending run');
+    if (!this.worker) throw new Error('resume: worker terminated');
+    this.startRunTimer();
+    this.worker.postMessage({ type: 'resume', step });
   }
 
   terminate(): void {
-    this.rejectPending(new Error('runner terminated'));
+    this.rejectAll(new Error('runner terminated'));
     if (this.worker) {
       this.worker.terminate();
       this.worker = null;

--- a/src/lib/machineRunner.ts
+++ b/src/lib/machineRunner.ts
@@ -213,6 +213,15 @@ export class MachineRunner {
     this.worker.postMessage({ type: 'resume', step });
   }
 
+  /**
+   * Flip the worker's debug-pause gate. Fire-and-forget. No-op if the worker
+   * isn't spawned yet (the next `run()` will pass `debug` through the request).
+   */
+  setDebug(on: boolean): void {
+    if (!this.worker) return;
+    this.worker.postMessage({ type: 'setDebug', on });
+  }
+
   terminate(): void {
     this.rejectAll(new Error('runner terminated'));
     if (this.worker) {

--- a/src/lib/machineRunner.ts
+++ b/src/lib/machineRunner.ts
@@ -109,7 +109,7 @@ export class MachineRunner {
       const p = this.runPending;
       this.runPending = null;
       if (!p) return;
-      this.stopRunTimer();
+      if (p.timeoutId) clearTimeout(p.timeoutId);
       p.resolveRan(data);
       return;
     }
@@ -118,7 +118,7 @@ export class MachineRunner {
       if (this.runPending) {
         const p = this.runPending;
         this.runPending = null;
-        this.stopRunTimer();
+        if (p.timeoutId) clearTimeout(p.timeoutId);
         p.reject(err);
         return;
       }

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -315,6 +315,8 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
   runCommandBuffer = [];
   phase = { kind: 'running' };
   debugEnabled = debug;
+  // eslint-disable-next-line no-console
+  console.log('[worker] run start', { debug, debugEnabled });
 
   let truncated = false;
 
@@ -322,6 +324,8 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
   // mid-run. The hook self-gates on `debugEnabled` and resolves immediately
   // when off — engine continues without pausing.
   const onDebugBreakFn = async (m: DebugBreakPayload) => {
+        // eslint-disable-next-line no-console
+        console.log('[worker] onDebugBreak fired', { debugEnabled, pendingRestore: !!pendingRestore, debugBreak: m.debugBreak, state: m.state.name });
         // Restore the synthesized one-shot before the user observes the break.
         // (Done unconditionally — clean up even when debug is currently off,
         // so a Step-armed mutation doesn't leak past a debug toggle.)
@@ -329,7 +333,11 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
           pendingRestore();
           pendingRestore = null;
         }
-        if (!debugEnabled) return;
+        if (!debugEnabled) {
+          // eslint-disable-next-line no-console
+          console.log('[worker] onDebugBreak early-return: debugEnabled=false');
+          return;
+        }
         const commandsBatch = runCommandBuffer;
         runCommandBuffer = [];
         phase = { kind: 'paused' };
@@ -491,6 +499,8 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
     }
 
     if (req.type === 'setDebug') {
+      // eslint-disable-next-line no-console
+      console.log('[worker] setDebug', req.on);
       // Side-channel mutation; allowed in any phase (no expectPhase). When the
       // worker is currently paused at a break, this changes how *future*
       // breaks are handled — the user still has to Continue past the current

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -368,16 +368,6 @@ async function run(
           if (!stepPending || !m.debugBreak?.after) return;
           stepPending = false;
         }
-        // Distinguish step-induced pauses (worker armed state.debug for Step
-        // semantics) from user-induced pauses (user's own state.debug). Read
-        // m.state.debug AFTER pendingRestore so we see the user's setting,
-        // not our arm. m.state for an after-fire payload is the prev (just-
-        // executed) state — exactly the state whose .after we'd be checking.
-        const stateNow = m.state as { debug?: { before?: unknown; after?: unknown } | null };
-        const stepInduced = m.debugBreak?.before
-          ? !stateNow.debug?.before
-          : !stateNow.debug?.after;
-
         const commandsBatch = runCommandBuffer;
         runCommandBuffer = [];
         phase = { kind: 'paused' };
@@ -389,7 +379,6 @@ async function run(
           state: m.state.name ?? '',
           currentSymbols: [...m.currentSymbols],
           debugBreak: { ...m.debugBreak },
-          stepInduced,
         });
         const action = await new Promise<{ step: boolean }>((resolve) => {
           resumeResolve = (a) => {

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -345,12 +345,15 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
             // machineState reaches us only via the next onStep call. If
             // turing-machine-js#107 lands (escape hatch for un-substituted
             // snapshot), this branch and pendingStepNext can collapse.
-            const ns = m.nextState as { debug: { before?: true; after?: true } | null };
+            // state.debug is a DebugConfig instance with accessor-defined
+            // before/after — spreading skips them (not own enumerable). Read
+            // .after explicitly so the after filter survives a self-loop arm.
+            const ns = m.nextState as { debug: { before?: unknown; after?: unknown } | null };
             const original = ns.debug;
-            // Spread to preserve any existing `after` flag — critical for
-            // self-loop states where ns === current state and after=true
-            // must remain so pendingAfterFromPrev still propagates.
-            ns.debug = { ...(original ?? {}), before: true };
+            const preservedAfter = original?.after;
+            ns.debug = preservedAfter !== undefined
+              ? { before: true, after: preservedAfter }
+              : { before: true };
             pendingRestore = () => { ns.debug = original; };
           } else {
             pendingStepNext = true;
@@ -365,12 +368,15 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
   // machine's `run` signature to route correctly.
   const runOpts: Parameters<AnyMachine['run']>[0] = {
     stepsLimit: maxSteps,
-    onStep: (m: MachineYield & { nextState?: { debug: { before?: true; after?: true } | null } }) => {
+    onStep: (m: MachineYield & { nextState?: { debug: { before?: unknown; after?: unknown } | null } }) => {
       if (pendingStepNext && m.nextState) {
-        const ns = m.nextState as { debug: { before?: true; after?: true } | null };
+        const ns = m.nextState as { debug: { before?: unknown; after?: unknown } | null };
         const original = ns.debug;
-        // Spread to preserve any existing `after` flag (see direct-arm branch).
-        ns.debug = { ...(original ?? {}), before: true };
+        // state.debug is a DebugConfig instance — see direct-arm branch.
+        const preservedAfter = original?.after;
+        ns.debug = preservedAfter !== undefined
+          ? { before: true, after: preservedAfter }
+          : { before: true };
         pendingRestore = () => { ns.debug = original; };
         pendingStepNext = false;
       }

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -368,6 +368,16 @@ async function run(
           if (!stepPending || !m.debugBreak?.after) return;
           stepPending = false;
         }
+        // Distinguish step-induced pauses (worker armed state.debug for Step
+        // semantics) from user-induced pauses (user's own state.debug). Read
+        // m.state.debug AFTER pendingRestore so we see the user's setting,
+        // not our arm. m.state for an after-fire payload is the prev (just-
+        // executed) state — exactly the state whose .after we'd be checking.
+        const stateNow = m.state as { debug?: { before?: unknown; after?: unknown } | null };
+        const stepInduced = m.debugBreak?.before
+          ? !stateNow.debug?.before
+          : !stateNow.debug?.after;
+
         const commandsBatch = runCommandBuffer;
         runCommandBuffer = [];
         phase = { kind: 'paused' };
@@ -379,6 +389,7 @@ async function run(
           state: m.state.name ?? '',
           currentSymbols: [...m.currentSymbols],
           debugBreak: { ...m.debugBreak },
+          stepInduced,
         });
         const action = await new Promise<{ step: boolean }>((resolve) => {
           resumeResolve = (a) => {

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -345,9 +345,12 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
             // machineState reaches us only via the next onStep call. If
             // turing-machine-js#107 lands (escape hatch for un-substituted
             // snapshot), this branch and pendingStepNext can collapse.
-            const ns = m.nextState as { debug: { before?: true } | null };
+            const ns = m.nextState as { debug: { before?: true; after?: true } | null };
             const original = ns.debug;
-            ns.debug = { before: true };
+            // Spread to preserve any existing `after` flag — critical for
+            // self-loop states where ns === current state and after=true
+            // must remain so pendingAfterFromPrev still propagates.
+            ns.debug = { ...(original ?? {}), before: true };
             pendingRestore = () => { ns.debug = original; };
           } else {
             pendingStepNext = true;
@@ -362,11 +365,12 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
   // machine's `run` signature to route correctly.
   const runOpts: Parameters<AnyMachine['run']>[0] = {
     stepsLimit: maxSteps,
-    onStep: (m: MachineYield & { nextState?: { debug: { before?: true } | null } }) => {
+    onStep: (m: MachineYield & { nextState?: { debug: { before?: true; after?: true } | null } }) => {
       if (pendingStepNext && m.nextState) {
-        const ns = m.nextState as { debug: { before?: true } | null };
+        const ns = m.nextState as { debug: { before?: true; after?: true } | null };
         const original = ns.debug;
-        ns.debug = { before: true };
+        // Spread to preserve any existing `after` flag (see direct-arm branch).
+        ns.debug = { ...(original ?? {}), before: true };
         pendingRestore = () => { ns.debug = original; };
         pendingStepNext = false;
       }

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -132,6 +132,13 @@ let pendingCommand: MachineYield | null = null;
 // requests are rejected by the phase machine before they reach this slot.
 let resumeResolve: ((action: { step: boolean }) => void) | null = null;
 
+// Step-from-break trick: when the user resumes with step:true, arm the next
+// iteration's nextState with a one-shot before-break so the machine pauses
+// exactly one step later. pendingRestore undoes the mutation before the user
+// observes the new break (so the state graph is clean for subsequent runs).
+let pendingStepNext = false;
+let pendingRestore: (() => void) | null = null;
+
 // Per-run buffer of commands captured by onStep. Drained on `paused` (sent
 // in the response) and on `ran` (sent in the response).
 let runCommandBuffer: Command[][] = [];
@@ -146,6 +153,8 @@ function reset(): void {
   stepsApplied = 0;
   pendingCommand = null;
   resumeResolve = null;
+  pendingStepNext = false;
+  pendingRestore = null;
   runCommandBuffer = [];
   runStartStep = 0;
 }
@@ -299,7 +308,11 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
 
   const onDebugBreakFn = debug
     ? async (m: DebugBreakPayload) => {
-        // Send the buffered run-segment so far, then wait for resume.
+        // Restore the synthesized one-shot before the user observes the break.
+        if (pendingRestore) {
+          pendingRestore();
+          pendingRestore = null;
+        }
         const commandsBatch = runCommandBuffer;
         runCommandBuffer = [];
         phase = { kind: 'paused' };
@@ -312,14 +325,29 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
           currentSymbols: [...m.currentSymbols],
           debugBreak: { ...m.debugBreak },
         });
-        await new Promise<void>((resolve) => {
-          // step flag: wired to the call site but consumed in Task 4 (nextState.debug trick)
-          resumeResolve = (_action) => {
+        const action = await new Promise<{ step: boolean }>((resolve) => {
+          resumeResolve = (a) => {
             resumeResolve = null;
-            resolve();
+            resolve(a);
           };
         });
         phase = { kind: 'running' };
+        if (action.step) {
+          if (m.debugBreak?.before) {
+            // m IS the current iteration — arm directly.
+            // onStep deferral path: when an `after` break fires, the engine
+            // substitutes m to prevYield in onDebugBreak, so the un-substituted
+            // machineState reaches us only via the next onStep call. If
+            // turing-machine-js#107 lands (escape hatch for un-substituted
+            // snapshot), this branch and pendingStepNext can collapse.
+            const ns = m.nextState as { debug: { before?: true } | null };
+            const original = ns.debug;
+            ns.debug = { before: true };
+            pendingRestore = () => { ns.debug = original; };
+          } else {
+            pendingStepNext = true;
+          }
+        }
       }
     : undefined;
 
@@ -329,7 +357,14 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
   // machine's `run` signature to route correctly.
   const runOpts: Parameters<AnyMachine['run']>[0] = {
     stepsLimit: maxSteps,
-    onStep: (m: MachineYield) => {
+    onStep: (m: MachineYield & { nextState?: { debug: { before?: true } | null } }) => {
+      if (pendingStepNext && m.nextState) {
+        const ns = m.nextState as { debug: { before?: true } | null };
+        const original = ns.debug;
+        ns.debug = { before: true };
+        pendingRestore = () => { ns.debug = original; };
+        pendingStepNext = false;
+      }
       runCommandBuffer.push(commandsFromYield(m));
       stepsApplied += 1;
     },

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -300,7 +300,11 @@ function step(): { commands: Command[] | null; nextCommands: Command[] | null; h
   return { commands, nextCommands, halted };
 }
 
-async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boolean; startStep: number }> {
+async function run(
+  maxSteps: number,
+  debug: boolean,
+  step: boolean,
+): Promise<{ truncated: boolean; startStep: number }> {
   expectPhase('built');
   const built = phase as Extract<WorkerPhase, { kind: 'built' }>;
   if (built.halted || !machine) throw new Error('cannot run: halted or not built');
@@ -321,6 +325,24 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
   phase = { kind: 'running' };
   debugEnabled = debug;
   stepPending = false;
+
+  // Cold-start Step: arm the initial state's .after = true so iter 1's
+  // after-fire pauses (the legacy step-by-step boundary — pause once iter
+  // 1's command has been applied). Always .after, regardless of debug
+  // toggle: the toggle gates whether user-authored breaks pause, not where
+  // the Step boundary lands. We preserve the user's .before (read via the
+  // DebugConfig getter — spread skips it) so a user-authored before-break
+  // still fires naturally on iter 1; we never inject one ourselves, since
+  // that would surface as an unauthored pre-iter pause.
+  if (step && initialState) {
+    const target = initialState as { debug: { before?: unknown; after?: unknown } | null };
+    const original = target.debug;
+    const newDebug: { before?: unknown; after?: unknown } = { after: true };
+    if (original?.before !== undefined) newDebug.before = original.before;
+    target.debug = newDebug;
+    pendingRestore = () => { target.debug = original; };
+    stepPending = true;
+  }
 
   let truncated = false;
 
@@ -470,7 +492,11 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
     }
 
     if (req.type === 'run') {
-      const { truncated, startStep } = await run(req.maxSteps ?? MAX_STEPS, req.debug ?? false);
+      const { truncated, startStep } = await run(
+        req.maxSteps ?? MAX_STEPS,
+        req.debug ?? false,
+        req.step ?? false,
+      );
       send({
         type: 'ran',
         tapes: snapshotTapes(),

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -149,10 +149,16 @@ let runStartStep = 0;
 // so the user can flip the checkbox without restarting.
 let debugEnabled = false;
 
-// User clicked Step: the next break must pause regardless of debugEnabled
-// (Step semantically means "advance one iteration and pause", so it shouldn't
-// be suppressed by an off debug toggle). Consumed on first break.
-let stepRequested = false;
+// Step semantics: with debug off, Step is "advance exactly one engine
+// iteration, then pause" (like the legacy runStepByStep mode). With debug on,
+// Step pauses at every break — the debug toggle dominates.
+//
+// `stepPending` is true between a Step click and its consuming pause.
+// `stepCountdown` decrements in onStep; pause-with-debug-off only fires
+// when both stepPending=true and stepCountdown=0 (one iteration boundary
+// crossed since the click).
+let stepPending = false;
+let stepCountdown = 0;
 
 function reset(): void {
   phase = { kind: 'idle' };
@@ -168,7 +174,8 @@ function reset(): void {
   runCommandBuffer = [];
   runStartStep = 0;
   debugEnabled = false;
-  stepRequested = false;
+  stepPending = false;
+  stepCountdown = 0;
 }
 
 function expectPhase(...allowed: WorkerPhase['kind'][]): void {
@@ -321,7 +328,8 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
   runCommandBuffer = [];
   phase = { kind: 'running' };
   debugEnabled = debug;
-  stepRequested = false;
+  stepPending = false;
+  stepCountdown = 0;
 
   let truncated = false;
 
@@ -337,9 +345,17 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
           pendingRestore();
           pendingRestore = null;
         }
-        const isStep = stepRequested;
-        stepRequested = false;
-        if (!debugEnabled && !isStep) return;
+        if (debugEnabled) {
+          // Debug on: pause at every break. Step still consumes its pending
+          // flag so a later debug-off click doesn't carry an old step over.
+          stepPending = false;
+          stepCountdown = 0;
+        } else {
+          // Debug off: only pause if we're stepping AND one iteration has
+          // already elapsed (countdown reached 0 via onStep).
+          if (!stepPending || stepCountdown > 0) return;
+          stepPending = false;
+        }
         const commandsBatch = runCommandBuffer;
         runCommandBuffer = [];
         phase = { kind: 'paused' };
@@ -360,7 +376,8 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
         });
         phase = { kind: 'running' };
         if (action.step) {
-          stepRequested = true;
+          stepPending = true;
+          stepCountdown = 1;
           if (m.debugBreak?.before) {
             // m IS the current iteration — arm directly.
             // onStep deferral path: when an `after` break fires, the engine
@@ -402,6 +419,9 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
         pendingRestore = () => { ns.debug = original; };
         pendingStepNext = false;
       }
+      // Step countdown: each engine iteration boundary decrements; pause
+      // (in onDebugBreak below) only fires when stepCountdown reaches 0.
+      if (stepCountdown > 0) stepCountdown--;
       runCommandBuffer.push(commandsFromYield(m));
       stepsApplied += 1;
     },

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -149,6 +149,11 @@ let runStartStep = 0;
 // so the user can flip the checkbox without restarting.
 let debugEnabled = false;
 
+// User clicked Step: the next break must pause regardless of debugEnabled
+// (Step semantically means "advance one iteration and pause", so it shouldn't
+// be suppressed by an off debug toggle). Consumed on first break.
+let stepRequested = false;
+
 function reset(): void {
   phase = { kind: 'idle' };
   machine = null;
@@ -163,6 +168,7 @@ function reset(): void {
   runCommandBuffer = [];
   runStartStep = 0;
   debugEnabled = false;
+  stepRequested = false;
 }
 
 function expectPhase(...allowed: WorkerPhase['kind'][]): void {
@@ -315,17 +321,15 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
   runCommandBuffer = [];
   phase = { kind: 'running' };
   debugEnabled = debug;
-  // eslint-disable-next-line no-console
-  console.log('[worker] run start', { debug, debugEnabled });
+  stepRequested = false;
 
   let truncated = false;
 
   // Always provide the hook so the runtime-toggle (setDebug) can flip behavior
   // mid-run. The hook self-gates on `debugEnabled` and resolves immediately
-  // when off — engine continues without pausing.
+  // when off — engine continues without pausing — UNLESS the user just
+  // clicked Step, in which case the next break always pauses.
   const onDebugBreakFn = async (m: DebugBreakPayload) => {
-        // eslint-disable-next-line no-console
-        console.log('[worker] onDebugBreak fired', { debugEnabled, pendingRestore: !!pendingRestore, debugBreak: m.debugBreak, state: m.state.name });
         // Restore the synthesized one-shot before the user observes the break.
         // (Done unconditionally — clean up even when debug is currently off,
         // so a Step-armed mutation doesn't leak past a debug toggle.)
@@ -333,11 +337,9 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
           pendingRestore();
           pendingRestore = null;
         }
-        if (!debugEnabled) {
-          // eslint-disable-next-line no-console
-          console.log('[worker] onDebugBreak early-return: debugEnabled=false');
-          return;
-        }
+        const isStep = stepRequested;
+        stepRequested = false;
+        if (!debugEnabled && !isStep) return;
         const commandsBatch = runCommandBuffer;
         runCommandBuffer = [];
         phase = { kind: 'paused' };
@@ -358,6 +360,7 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
         });
         phase = { kind: 'running' };
         if (action.step) {
+          stepRequested = true;
           if (m.debugBreak?.before) {
             // m IS the current iteration — arm directly.
             // onStep deferral path: when an `after` break fires, the engine
@@ -499,8 +502,6 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
     }
 
     if (req.type === 'setDebug') {
-      // eslint-disable-next-line no-console
-      console.log('[worker] setDebug', req.on);
       // Side-channel mutation; allowed in any phase (no expectPhase). When the
       // worker is currently paused at a break, this changes how *future*
       // breaks are handled — the user still has to Continue past the current

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -144,6 +144,11 @@ let pendingRestore: (() => void) | null = null;
 let runCommandBuffer: Command[][] = [];
 let runStartStep = 0;
 
+// Runtime-mutable gate consulted inside onDebugBreak. Initialized from the
+// `run` request's `debug` flag; toggled mid-run via the `setDebug` message
+// so the user can flip the checkbox without restarting.
+let debugEnabled = false;
+
 function reset(): void {
   phase = { kind: 'idle' };
   machine = null;
@@ -157,6 +162,7 @@ function reset(): void {
   pendingRestore = null;
   runCommandBuffer = [];
   runStartStep = 0;
+  debugEnabled = false;
 }
 
 function expectPhase(...allowed: WorkerPhase['kind'][]): void {
@@ -308,16 +314,22 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
   runStartStep = stepsApplied;
   runCommandBuffer = [];
   phase = { kind: 'running' };
+  debugEnabled = debug;
 
   let truncated = false;
 
-  const onDebugBreakFn = debug
-    ? async (m: DebugBreakPayload) => {
+  // Always provide the hook so the runtime-toggle (setDebug) can flip behavior
+  // mid-run. The hook self-gates on `debugEnabled` and resolves immediately
+  // when off — engine continues without pausing.
+  const onDebugBreakFn = async (m: DebugBreakPayload) => {
         // Restore the synthesized one-shot before the user observes the break.
+        // (Done unconditionally — clean up even when debug is currently off,
+        // so a Step-armed mutation doesn't leak past a debug toggle.)
         if (pendingRestore) {
           pendingRestore();
           pendingRestore = null;
         }
+        if (!debugEnabled) return;
         const commandsBatch = runCommandBuffer;
         runCommandBuffer = [];
         phase = { kind: 'paused' };
@@ -359,8 +371,7 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
             pendingStepNext = true;
           }
         }
-      }
-    : undefined;
+      };
 
   // PostMachine.run() uses `__onDebugBreak` and does not accept `initialState`
   // (uses its own #initialState). TuringMachine.run() uses `onDebugBreak` and
@@ -476,6 +487,15 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
       const r = resumeResolve;
       if (!r) throw new Error('resume: no pending Promise');
       r({ step: req.step ?? false });
+      return;
+    }
+
+    if (req.type === 'setDebug') {
+      // Side-channel mutation; allowed in any phase (no expectPhase). When the
+      // worker is currently paused at a break, this changes how *future*
+      // breaks are handled — the user still has to Continue past the current
+      // pause manually.
+      debugEnabled = req.on;
       return;
     }
 

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -1,11 +1,14 @@
 /// <reference lib="webworker" />
 
 /**
- * Worker that drives the upstream `runStepByStep` generator.
+ * Worker that drives the upstream machine via async `machine.run(...)`.
  *
- * The generator's first yield is the command queued to be applied by the next
- * call to `step()`. Each subsequent `next()` applies the previously-yielded
- * command and yields the next one. We track that as `pendingCommand`.
+ * Phase machine:
+ *   idle → (build) → built → (run) → running → (paused) → paused → (resume) → running
+ *                          → (step) → built (same, halted advances)
+ *
+ * A `paused` response is sent when `onDebugBreak` fires; the worker's `run()`
+ * Promise stays pending until a `resume` request resolves the internal Promise.
  */
 
 import * as turing from '@turing-machine-js/machine';
@@ -30,8 +33,23 @@ import {
  * The strong types live at the worker postMessage boundary instead.
  */
 
+// onDebugBreak payload subset we read. Engine's full type carries more.
+type DebugBreakPayload = {
+  state: { name?: string };
+  currentSymbols: string[];
+  nextState: { debug: { before?: true; after?: true } | null };
+  debugBreak?: { before?: true; after?: true };
+};
+
 type AnyMachine = {
   runStepByStep: (opts: { initialState: unknown }) => Generator<MachineYield, void, void>;
+  run: (opts: {
+    initialState?: unknown;
+    stepsLimit?: number;
+    onStep?: (m: MachineYield) => void;
+    onDebugBreak?: (m: DebugBreakPayload) => void | Promise<void>;
+    __onDebugBreak?: (m: DebugBreakPayload) => void | Promise<void>;
+  }) => Promise<void>;
   initialState?: unknown;
   tape?: AnyTape;
   tapeBlock?: { tapes?: AnyTape[] };
@@ -95,22 +113,49 @@ for (const name of SANDBOX_BLOCKED_GLOBALS) {
 
 /* ───── runtime state ───── */
 
+type WorkerPhase =
+  | { kind: 'idle' }
+  | { kind: 'built'; halted: boolean }
+  | { kind: 'running' }
+  | { kind: 'paused' };
+
+let phase: WorkerPhase = { kind: 'idle' };
 let machine: AnyMachine | null = null;
 let initialState: unknown = null;
 let tapes: AnyTape[] = [];
 let generator: Generator<MachineYield, void, void> | null = null;
-let halted = false;
 let stepsApplied = 0;
 let pendingCommand: MachineYield | null = null;
 
+// Holds the resolver of the Promise awaited inside onDebugBreak. Set when
+// the worker is paused at a break; cleared on `resume`. Concurrent `run`
+// requests are rejected by the phase machine before they reach this slot.
+let resumeResolve: ((action: { step: boolean }) => void) | null = null;
+
+// Per-run buffer of commands captured by onStep. Drained on `paused` (sent
+// in the response) and on `ran` (sent in the response).
+let runCommandBuffer: Command[][] = [];
+let runStartStep = 0;
+
 function reset(): void {
+  phase = { kind: 'idle' };
   machine = null;
   initialState = null;
   tapes = [];
   generator = null;
-  halted = false;
   stepsApplied = 0;
   pendingCommand = null;
+  resumeResolve = null;
+  runCommandBuffer = [];
+  runStartStep = 0;
+}
+
+function expectPhase(...allowed: WorkerPhase['kind'][]): void {
+  if (!allowed.includes(phase.kind)) {
+    throw new Error(
+      `worker phase ${phase.kind}, expected ${allowed.join('|')}`,
+    );
+  }
 }
 
 function movementCode(m: symbol): Movement {
@@ -205,48 +250,119 @@ function build(engine: Engine, code: string): void {
   generator = machine.runStepByStep({ initialState });
   const first = generator.next();
   if (first.done) {
-    halted = true;
+    phase = { kind: 'built', halted: true };
     pendingCommand = null;
   } else {
+    phase = { kind: 'built', halted: false };
     pendingCommand = first.value;
   }
 }
 
-function step(): { commands: Command[] | null; nextCommands: Command[] | null } {
-  if (halted || !pendingCommand || !generator) {
-    return { commands: null, nextCommands: null };
+function step(): { commands: Command[] | null; nextCommands: Command[] | null; halted: boolean } {
+  expectPhase('built');
+  const built = phase as Extract<WorkerPhase, { kind: 'built' }>;
+  if (built.halted || !pendingCommand || !generator) {
+    return { commands: null, nextCommands: null, halted: true };
   }
   const commands = commandsFromYield(pendingCommand);
   const r = generator.next();
   stepsApplied += 1;
+  let halted: boolean;
   if (r.done) {
     halted = true;
     pendingCommand = null;
   } else {
+    halted = false;
     pendingCommand = r.value;
   }
+  phase = { kind: 'built', halted };
   const nextCommands = pendingCommand ? commandsFromYield(pendingCommand) : null;
-  return { commands, nextCommands };
+  return { commands, nextCommands, halted };
 }
 
-function runToEnd(maxSteps: number): { commands: Command[][]; truncated: boolean; startStep: number } {
-  if (!generator) throw new Error('not built');
-  const startStep = stepsApplied;
-  const commands: Command[][] = [];
-  let extra = 0;
-  while (!halted && pendingCommand && extra < maxSteps) {
-    commands.push(commandsFromYield(pendingCommand));
-    const r = generator.next();
-    stepsApplied += 1;
-    extra += 1;
-    if (r.done) {
-      halted = true;
-      pendingCommand = null;
-      break;
-    }
-    pendingCommand = r.value;
+async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boolean; startStep: number }> {
+  expectPhase('built');
+  const built = phase as Extract<WorkerPhase, { kind: 'built' }>;
+  if (built.halted || !machine) throw new Error('cannot run: halted or not built');
+
+  // Initial-yield handling: build() always primes pendingCommand. We discard
+  // the engine's runStepByStep generator and start a fresh `run()` from the
+  // current initial state — the engine handles its own iteration internally.
+  generator = null;
+  pendingCommand = null;
+
+  runStartStep = stepsApplied;
+  runCommandBuffer = [];
+  phase = { kind: 'running' };
+
+  let truncated = false;
+
+  const onDebugBreakFn = debug
+    ? async (m: DebugBreakPayload) => {
+        // Send the buffered run-segment so far, then wait for resume.
+        const commandsBatch = runCommandBuffer;
+        runCommandBuffer = [];
+        phase = { kind: 'paused' };
+        send({
+          type: 'paused',
+          tapes: snapshotTapes(),
+          commands: commandsBatch,
+          stepsApplied,
+          state: m.state.name ?? '',
+          currentSymbols: [...m.currentSymbols],
+          debugBreak: { ...m.debugBreak } as { before?: true; after?: true },
+        });
+        await new Promise<void>((resolve) => {
+          resumeResolve = (_action) => {
+            resumeResolve = null;
+            resolve();
+          };
+        });
+        phase = { kind: 'running' };
+      }
+    : undefined;
+
+  // PostMachine.run() uses `__onDebugBreak` and does not accept `initialState`
+  // (uses its own #initialState). TuringMachine.run() uses `onDebugBreak` and
+  // requires `initialState`. Branch on the presence of `__onDebugBreak` in the
+  // machine's `run` signature to route correctly.
+  const runOpts: Parameters<AnyMachine['run']>[0] = {
+    stepsLimit: maxSteps,
+    onStep: (m: MachineYield) => {
+      runCommandBuffer.push(commandsFromYield(m));
+      stepsApplied += 1;
+    },
+  };
+
+  if (machine instanceof post.PostMachine) {
+    // PostMachine.run() uses `__onDebugBreak` and ignores `initialState`
+    // (it carries its own #initialState internally).
+    runOpts.__onDebugBreak = onDebugBreakFn;
+  } else {
+    // TuringMachine.run() uses `onDebugBreak` and requires `initialState`.
+    runOpts.initialState = initialState;
+    runOpts.onDebugBreak = onDebugBreakFn;
   }
-  return { commands, truncated: !halted && extra >= maxSteps, startStep };
+
+  try {
+    await machine.run(runOpts);
+  } catch (err) {
+    // The engine throws 'Long execution' when stepsLimit is reached. Check the
+    // step counter at catch time — more reliable than a flag set in onStep
+    // (engine may throw before the flag-setting iteration's onStep runs).
+    if (stepsApplied - runStartStep >= maxSteps) {
+      truncated = true;
+      // fall through, send `ran` with truncated: true
+    } else {
+      // Reset phase before rethrow so the catch in handleRequest sees a known
+      // state. tapes still hold partial state (existing error path).
+      phase = { kind: 'built', halted: false };
+      throw err;
+    }
+  }
+
+  phase = { kind: 'built', halted: true };
+  return { truncated, startStep: runStartStep };
 }
 
 function send(msg: WorkerResponse): void {
@@ -261,21 +377,25 @@ self.onmessage = (e: MessageEvent<unknown>) => {
   }
 
   const req = msg as WorkerRequest;
+  void handleRequest(req);
+};
+
+async function handleRequest(req: WorkerRequest): Promise<void> {
   try {
     if (req.type === 'build') {
       build(req.engine, req.code);
+      const built = phase as Extract<WorkerPhase, { kind: 'built' }>;
       send({
         type: 'built',
         tapes: snapshotTapes(),
         alphabets: snapshotAlphabets(),
-        halted,
+        halted: built.halted,
       });
       return;
     }
 
     if (req.type === 'step') {
-      if (!machine) throw new Error('not built');
-      const { commands, nextCommands } = step();
+      const { commands, nextCommands, halted } = step();
       send({
         type: 'stepped',
         halted,
@@ -287,16 +407,24 @@ self.onmessage = (e: MessageEvent<unknown>) => {
     }
 
     if (req.type === 'run') {
-      if (!machine) throw new Error('not built');
-      const { commands, truncated, startStep } = runToEnd(req.maxSteps ?? MAX_STEPS);
+      const { truncated, startStep } = await run(req.maxSteps ?? MAX_STEPS, req.debug ?? false);
       send({
         type: 'ran',
         tapes: snapshotTapes(),
         truncated,
-        commands,
+        commands: runCommandBuffer,
         startStep,
         stepsApplied,
       });
+      runCommandBuffer = [];
+      return;
+    }
+
+    if (req.type === 'resume') {
+      expectPhase('paused');
+      const r = resumeResolve;
+      if (!r) throw new Error('resume: no pending Promise');
+      r({ step: req.step ?? false });
       return;
     }
 
@@ -312,4 +440,4 @@ self.onmessage = (e: MessageEvent<unknown>) => {
       tapes: tapes.length > 0 ? snapshotTapes() : undefined,
     });
   }
-};
+}

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -297,7 +297,12 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
   // Initial-yield handling: build() always primes pendingCommand. We discard
   // the engine's runStepByStep generator and start a fresh `run()` from the
   // current initial state — the engine handles its own iteration internally.
-  generator = null;
+  // .return() triggers the generator's `finally` so it unlocks the tapeBlock;
+  // without it, the new run()'s internal generator hits "Lock check failed".
+  if (generator) {
+    generator.return();
+    generator = null;
+  }
   pendingCommand = null;
 
   runStartStep = stepsApplied;

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -310,9 +310,10 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
           stepsApplied,
           state: m.state.name ?? '',
           currentSymbols: [...m.currentSymbols],
-          debugBreak: { ...m.debugBreak } as { before?: true; after?: true },
+          debugBreak: { ...m.debugBreak },
         });
         await new Promise<void>((resolve) => {
+          // step flag: wired to the call site but consumed in Task 4 (nextState.debug trick)
           resumeResolve = (_action) => {
             resumeResolve = null;
             resolve();
@@ -362,7 +363,7 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
   }
 
   phase = { kind: 'built', halted: true };
-  return { truncated, startStep: runStartStep };
+  return { truncated, startStep: stepsApplied - runCommandBuffer.length };
 }
 
 function send(msg: WorkerResponse): void {

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -132,11 +132,10 @@ let pendingCommand: MachineYield | null = null;
 // requests are rejected by the phase machine before they reach this slot.
 let resumeResolve: ((action: { step: boolean }) => void) | null = null;
 
-// Step-from-break trick: when the user resumes with step:true, arm the next
-// iteration's nextState with a one-shot before-break so the machine pauses
-// exactly one step later. pendingRestore undoes the mutation before the user
-// observes the new break (so the state graph is clean for subsequent runs).
-let pendingStepNext = false;
+// Step trick: when the user clicks Step, arm the iteration-we're-stepping-
+// through's state.debug.after = true so the engine fires an after-break in
+// the next iteration's body and we pause there. pendingRestore undoes the
+// mutation before the user observes the new break.
 let pendingRestore: (() => void) | null = null;
 
 // Per-run buffer of commands captured by onStep. Drained on `paused` (sent
@@ -149,16 +148,11 @@ let runStartStep = 0;
 // so the user can flip the checkbox without restarting.
 let debugEnabled = false;
 
-// Step semantics: with debug off, Step is "advance exactly one engine
-// iteration, then pause" (like the legacy runStepByStep mode). With debug on,
-// Step pauses at every break — the debug toggle dominates.
-//
-// `stepPending` is true between a Step click and its consuming pause.
-// `stepCountdown` decrements in onStep; pause-with-debug-off only fires
-// when both stepPending=true and stepCountdown=0 (one iteration boundary
-// crossed since the click).
+// Step semantics: with debug off, Step pauses at the next "after" break
+// event (= one iteration's command applied), matching the legacy step-by-
+// step mental model. Before-fires are skipped. With debug on, Step pauses
+// at every break (debug toggle dominates).
 let stepPending = false;
-let stepCountdown = 0;
 
 function reset(): void {
   phase = { kind: 'idle' };
@@ -169,13 +163,11 @@ function reset(): void {
   stepsApplied = 0;
   pendingCommand = null;
   resumeResolve = null;
-  pendingStepNext = false;
   pendingRestore = null;
   runCommandBuffer = [];
   runStartStep = 0;
   debugEnabled = false;
   stepPending = false;
-  stepCountdown = 0;
 }
 
 function expectPhase(...allowed: WorkerPhase['kind'][]): void {
@@ -329,7 +321,6 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
   phase = { kind: 'running' };
   debugEnabled = debug;
   stepPending = false;
-  stepCountdown = 0;
 
   let truncated = false;
 
@@ -346,14 +337,13 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
           pendingRestore = null;
         }
         if (debugEnabled) {
-          // Debug on: pause at every break. Step still consumes its pending
-          // flag so a later debug-off click doesn't carry an old step over.
+          // Debug on: pause at every break.
           stepPending = false;
-          stepCountdown = 0;
         } else {
-          // Debug off: only pause if we're stepping AND one iteration has
-          // already elapsed (countdown reached 0 via onStep).
-          if (!stepPending || stepCountdown > 0) return;
+          // Debug off: Step pauses only at after-fires (= one iteration's
+          // command applied). Before-fires are skipped — they signal the
+          // start of an iteration, not its result.
+          if (!stepPending || !m.debugBreak?.after) return;
           stepPending = false;
         }
         const commandsBatch = runCommandBuffer;
@@ -377,27 +367,21 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
         phase = { kind: 'running' };
         if (action.step) {
           stepPending = true;
-          stepCountdown = 1;
-          if (m.debugBreak?.before) {
-            // m IS the current iteration — arm directly.
-            // onStep deferral path: when an `after` break fires, the engine
-            // substitutes m to prevYield in onDebugBreak, so the un-substituted
-            // machineState reaches us only via the next onStep call. If
-            // turing-machine-js#107 lands (escape hatch for un-substituted
-            // snapshot), this branch and pendingStepNext can collapse.
-            // state.debug is a DebugConfig instance with accessor-defined
-            // before/after — spreading skips them (not own enumerable). Read
-            // .after explicitly so the after filter survives a self-loop arm.
-            const ns = m.nextState as { debug: { before?: unknown; after?: unknown } | null };
-            const original = ns.debug;
-            const preservedAfter = original?.after;
-            ns.debug = preservedAfter !== undefined
-              ? { before: true, after: preservedAfter }
-              : { before: true };
-            pendingRestore = () => { ns.debug = original; };
-          } else {
-            pendingStepNext = true;
-          }
+          // Arm the iteration-we're-stepping-through's state.debug.after = true
+          // so its after-fire fires (in the next iteration's body) and we can
+          // pause there. For a `before` break: m IS that iteration (m.state).
+          // For an `after` break (m substituted to prevYield): the next iter's
+          // state lives at m.nextState. Preserve any original `before` filter.
+          // Read .before via the getter (DebugConfig accessor — spread skips it).
+          const target = (
+            m.debugBreak?.before ? m.state : m.nextState
+          ) as { debug: { before?: unknown; after?: unknown } | null };
+          const original = target.debug;
+          const preservedBefore = original?.before;
+          const newDebug: { before?: unknown; after?: unknown } = { after: true };
+          if (preservedBefore !== undefined) newDebug.before = preservedBefore;
+          target.debug = newDebug;
+          pendingRestore = () => { target.debug = original; };
         }
       };
 
@@ -407,21 +391,7 @@ async function run(maxSteps: number, debug: boolean): Promise<{ truncated: boole
   // machine's `run` signature to route correctly.
   const runOpts: Parameters<AnyMachine['run']>[0] = {
     stepsLimit: maxSteps,
-    onStep: (m: MachineYield & { nextState?: { debug: { before?: unknown; after?: unknown } | null } }) => {
-      if (pendingStepNext && m.nextState) {
-        const ns = m.nextState as { debug: { before?: unknown; after?: unknown } | null };
-        const original = ns.debug;
-        // state.debug is a DebugConfig instance — see direct-arm branch.
-        const preservedAfter = original?.after;
-        ns.debug = preservedAfter !== undefined
-          ? { before: true, after: preservedAfter }
-          : { before: true };
-        pendingRestore = () => { ns.debug = original; };
-        pendingStepNext = false;
-      }
-      // Step countdown: each engine iteration boundary decrements; pause
-      // (in onDebugBreak below) only fires when stepCountdown reaches 0.
-      if (stepCountdown > 0) stepCountdown--;
+    onStep: (m: MachineYield) => {
       runCommandBuffer.push(commandsFromYield(m));
       stepsApplied += 1;
     },

--- a/src/lib/persist.ts
+++ b/src/lib/persist.ts
@@ -61,6 +61,22 @@ export function saveExampleId(engine: Engine, id: string): void {
   }
 }
 
+export function loadDebugMode(engine: Engine): boolean {
+  try {
+    return localStorage.getItem(engineKey(engine, 'debugMode')) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function saveDebugMode(engine: Engine, on: boolean): void {
+  try {
+    localStorage.setItem(engineKey(engine, 'debugMode'), on ? 'true' : 'false');
+  } catch {
+    /* quota or private mode — ignore */
+  }
+}
+
 export function loadSnippets(engine: Engine): Snippets {
   try {
     const v = localStorage.getItem(engineKey(engine, 'snippets'));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,7 +48,7 @@ export type TapeSnapshot = {
 export type WorkerRequest =
   | { type: 'build'; engine: Engine; code: string }
   | { type: 'step' }
-  | { type: 'run'; maxSteps?: number; debug?: boolean }
+  | { type: 'run'; maxSteps?: number; debug?: boolean; step?: boolean } // step?: true → arm initial state's debug.after so iter 1 pauses at the step-boundary (preserves user-authored debug.before)
   | { type: 'resume'; step?: boolean } // step?: true → advance one iteration, then re-pause
   | { type: 'setDebug'; on: boolean }; // runtime-toggle debug-break pausing during a run
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -49,7 +49,8 @@ export type WorkerRequest =
   | { type: 'build'; engine: Engine; code: string }
   | { type: 'step' }
   | { type: 'run'; maxSteps?: number; debug?: boolean }
-  | { type: 'resume'; step?: boolean }; // step?: true → advance one iteration, then re-pause
+  | { type: 'resume'; step?: boolean } // step?: true → advance one iteration, then re-pause
+  | { type: 'setDebug'; on: boolean }; // runtime-toggle debug-break pausing during a run
 
 /* Multi-tape: every shape is per-tape arrays. N=1 for single-tape machines,
  * N=K for K-tape machines (TapeBlock.fromTapes([...K])). */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -111,12 +111,6 @@ export type PausedResponse = {
   /** At least one of `before` / `after` is `true`. Field shape mirrors the
    * upstream `m.debugBreak` type (omitted-key = false, never `undefined`). */
   debugBreak: { before?: true; after?: true };
-  /** True when this pause exists only because the worker temporarily armed
-   * `state.debug[when]` for Step semantics (cold-start arm or resume-step
-   * arm), false when the user's own `state.debug` would have fired the break
-   * regardless. Drives log format on the main thread: full break-state info
-   * for user breaks, generic 'paused' for step-induced pauses. */
-  stepInduced: boolean;
 };
 
 export type ErrorResponse = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,7 +48,8 @@ export type TapeSnapshot = {
 export type WorkerRequest =
   | { type: 'build'; engine: Engine; code: string }
   | { type: 'step' }
-  | { type: 'run'; maxSteps?: number };
+  | { type: 'run'; maxSteps?: number; debug?: boolean }
+  | { type: 'resume'; step?: boolean };
 
 /* Multi-tape: every shape is per-tape arrays. N=1 for single-tape machines,
  * N=K for K-tape machines (TapeBlock.fromTapes([...K])). */
@@ -84,6 +85,32 @@ export type RanResponse = {
   stepsApplied: number;
 };
 
+/**
+ * Sent by the worker when `machine.run({ debug: true, ... })` hit a break
+ * point (state.debug or haltState.debug). The main thread responds with a
+ * `resume` request (optionally `step: true`) to continue, or terminates the
+ * worker via the runner to stop. The worker's `run()` Promise stays pending
+ * across paused/resume cycles; only `ran` / `error` complete it.
+ */
+export type PausedResponse = {
+  type: 'paused';
+  tapes: TapeSnapshot[];
+  /**
+   * Per-step commands buffered since the previous `paused` (or since the
+   * `run` request started). The main thread replays these in the Log so the
+   * user sees the trace leading up to the break; tape state is restored
+   * from `tapes` (snap, no animation), same path as `ran`.
+   */
+  commands: Command[][];
+  stepsApplied: number;
+  /** `m.state.name` — the user's State instance does not cross the boundary. */
+  state: string;
+  currentSymbols: string[];
+  /** At least one of `before` / `after` is `true`. Field shape mirrors the
+   * upstream `m.debugBreak` type (omitted-key = false, never `undefined`). */
+  debugBreak: { before?: true; after?: true };
+};
+
 export type ErrorResponse = {
   type: 'error';
   message: string;
@@ -101,4 +128,5 @@ export type WorkerResponse =
   | BuiltResponse
   | SteppedResponse
   | RanResponse
+  | PausedResponse
   | ErrorResponse;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -111,6 +111,12 @@ export type PausedResponse = {
   /** At least one of `before` / `after` is `true`. Field shape mirrors the
    * upstream `m.debugBreak` type (omitted-key = false, never `undefined`). */
   debugBreak: { before?: true; after?: true };
+  /** True when this pause exists only because the worker temporarily armed
+   * `state.debug[when]` for Step semantics (cold-start arm or resume-step
+   * arm), false when the user's own `state.debug` would have fired the break
+   * regardless. Drives log format on the main thread: full break-state info
+   * for user breaks, generic 'paused' for step-induced pauses. */
+  stepInduced: boolean;
 };
 
 export type ErrorResponse = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -49,7 +49,7 @@ export type WorkerRequest =
   | { type: 'build'; engine: Engine; code: string }
   | { type: 'step' }
   | { type: 'run'; maxSteps?: number; debug?: boolean }
-  | { type: 'resume'; step?: boolean };
+  | { type: 'resume'; step?: boolean }; // step?: true → advance one iteration, then re-pause
 
 /* Multi-tape: every shape is per-tape arrays. N=1 for single-tape machines,
  * N=K for K-tape machines (TapeBlock.fromTapes([...K])). */
@@ -105,6 +105,7 @@ export type PausedResponse = {
   stepsApplied: number;
   /** `m.state.name` — the user's State instance does not cross the boundary. */
   state: string;
+  /** Symbol currently under each tape head — per-tape array, length = tape count. */
   currentSymbols: string[];
   /** At least one of `before` / `after` is `true`. Field shape mirrors the
    * upstream `m.debugBreak` type (omitted-key = false, never `undefined`). */


### PR DESCRIPTION
Closes #40.

## Summary

Adds a debugger UX for the v4 engine's `state.debug` runtime breakpoints. Worker exposes async `run()` with an `onDebugBreak` hook; main thread surfaces a `debug` checkbox + `RUNNING_PAUSED_AT_BREAK` execution mode + Continue/Step controls.

## What's new

- **Worker run-mode.** `runner.run({ debug, step, onPaused })` drives the engine via `machine.run(...)` instead of stepping the generator manually. Worker sends `paused` responses on every `onDebugBreak` fire (gated by `debugEnabled`); main thread responds with `resume` (continue) or `resume(step: true)` (advance one iter, re-pause). Per-segment timeout: timer suspends on `paused`, resumes on `resume`-send.
- **Step → run-mode.** Cold-start Step (DEMO/MANUAL/HALTED → click Step) reloads + runs in `step: true` mode. Worker arms `initialState.debug.after = true` so iter 1's after-fire is the step boundary; user-authored `state.debug.before` still fires naturally on iter 1.
- **`debug` checkbox in Toolbar.** Runtime-toggles whether user-authored breaks pause; mid-pause toggle works (worker re-checks `debugEnabled` at each break).
- **Honest paused log.** `PausedResponse.stepInduced` distinguishes worker-armed Step boundaries from user-authored breakpoints. Full `paused at state X before/after applying command for symbols: [...]` only fires for user breaks (`debugMode && !stepInduced`); otherwise generic `paused`.
- **Continue from paused.** Run button auto-labels "Continue" from `RUNNING_PAUSED_AT_BREAK`; `resume(step: false)` runs to halt without further pauses (`stepPending=false` gate skips Step-armed breaks).
- **Halt step entry uniform.** Both run-mode and legacy `runner.step()` paths now log the halting iter's step entry before the halt entry — no more silent absorption.
- **Persisted `debugMode`** per engine (`machines-demo:<engine>:debugMode`).

## Wire shape

- Request: adds `{ type: 'run'; …; step? }`, `{ type: 'resume'; step? }`, `{ type: 'setDebug'; on }`.
- Response: adds `{ type: 'paused'; tapes; commands; stepsApplied; state; currentSymbols; debugBreak; stepInduced }`.

## Scope

Focused on the worker / runner / MachineView paths. `RUNNING_AUTO` still uses legacy `runner.step()` (no debug pauses) — refactor tracked in #43.

## Follow-ups filed

- #46 — Behavioral spec: execution modes & transitions (block: this PR; blocks #47)
- #47 — Test infrastructure (Vitest + component + e2e), citing scenario IDs from #46
- #43 — `RUNNING_AUTO` via `run()` with throttled `onStep` (so breakpoints fire)
- #45 — Log: buffer + throttled render for large run traces
- mellonis/turing-machine-js#108 — halt semantics: halting-iter `after`-fire missing; `haltState.debug.after` warn-then-throw deprecation

## Test plan

- [ ] Cold-start Run (debug=off): tape advances, halt logged
- [ ] Cold-start Step (debug=off): `step` + generic `paused` between iters; halt absorbs trailing `paused`
- [ ] Cold-start Step (debug=on, no `state.debug` in code): identical to debug=off (no unauthored pauses)
- [ ] Cold-start Step (debug=on, `initialState.debug = {before, after}`): full state info on both `before` and `after` for iters 1..N-1; iter N shows only `before` (engine quirk per turing-machine-js#108)
- [ ] Run+debug=on with user breakpoints + Continue: pauses at user breaks with full state info; Continue resumes
- [ ] Continue from paused (debug=off): runs to halt without pauses
- [ ] Stop from paused: halts, leaves Run/Step enabled for re-entry
- [ ] Mid-pause `debug` toggle: changes future pause behavior (`setDebug` message)
- [ ] PostMachine: cold-start Step works (uses `__onDebugBreak`, no `initialState` arg passed to run)