### PR TITLE
CI: build + rsync to VPS on master push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: CD
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: 24
+  VPS_STATIC_PATH: /var/web-apps/demo.machines.mellonis.ru
+
+jobs:
+  vps-static:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Build
+        run: |
+          npm ci
+          npm run build
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_KEY }}
+      - name: Sync to VPS
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+        run: |
+          rsync -avz --delete \
+            -e "ssh -o StrictHostKeyChecking=no" \
+            ./dist/ \
+            "$SSH_USER@$SSH_HOST:${{ env.VPS_STATIC_PATH }}/"


### PR DESCRIPTION
Matches the deploy pattern in \`mellonis/contacts\` — every push to master triggers a build + rsync to \`/var/web-apps/demo.machines.mellonis.ru/\` on the VPS.

Retires the manual \`build → commit dist into vps repo → rsync\` workflow and the convention of carrying built artifacts inside \`mellonis/vps\`. Going forward only stubs (under-construction placeholders) live in \`vps/static/\`; demo.machines is CI-deployed direct.

## Required secrets (machines-demo repo)

Same as in \`mellonis/contacts\`:

- \`SSH_KEY\` — private key authorized on the VPS for the deploy user.
- \`SSH_HOST\` — VPS hostname (e.g. \`mellonis.ru\`).
- \`SSH_USER\` — deploy user (e.g. \`root\`).

Add via \`gh secret set\` or the GitHub UI **before** merging — first run will fail otherwise.

## Follow-up (vps repo)

Separately retiring \`vps/static/demo.machines.mellonis.ru/\` and updating \`vps/CLAUDE.md\` to clarify the stubs-only policy.