### PR TITLE
docs: execution-model behavioral spec (closes #46)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,35 +56,7 @@ src/
 - `$effect`s for the demo loop, auto-step loop, belt-transitions toggle, and a code-changed warning (debounced via `codeChangedWarned` flag — fires once per running session)
 - `runner = new MachineRunner(engine)` and the `doLoad` / `doStep` / `doRun` / `takeControl` / `stopMachine` / `resetCodeToSelected` handlers; `reloadWorker(source?)` is the shared "build worker + rebuild mirrorMachine" helper, taking optional source code (defaults to current `code`) so DEMO can run the canonical `selectedExample.code` regardless of editor state
 
-## Execution modes
-
-`ExecutionMode = 'DEMO' | 'MANUAL' | 'RUNNING_STEP' | 'RUNNING_AUTO' | 'RUNNING_CONTINUOUS' | 'RUNNING_PAUSED_AT_BREAK' | 'HALTED'`
-
-| Mode | Panel | Apply visible | Take control | Belt behavior |
-|---|---|---|---|---|
-| `DEMO` | disabled mirror | yes (flashes) | yes | timer-driven random commands generated per tick from each tape's alphabet (40% keep, otherwise uniform). Loads `selectedExample.code` (canonical), not the editor's `code`. Auto-stops on first user-clicked Build (`demoEnabled = false`). |
-| `MANUAL` | enabled | yes | hidden | user-driven via Apply (writes to `mirrorMachine` via the same `ifOtherSymbol` one-step path used by Step) |
-| `RUNNING_STEP` | disabled mirror | hidden | yes | legacy step path — **only** entered as the paused state for `RUNNING_AUTO`. Cold-start Step now goes through run-mode → `RUNNING_PAUSED_AT_BREAK` instead. |
-| `RUNNING_AUTO` | disabled mirror | hidden | yes | timer-driven worker steps via `runner.step()`; Step button shows pause icon + "Pause" label; click → `RUNNING_STEP`. Doesn't pause at debug breakpoints (no `onDebugBreak` plumbing on this path; tracked in #43). |
-| `RUNNING_CONTINUOUS` | neutral cmd shown | hidden | hidden | snap-to-final, transitions off; per-step commands batch-logged after the worker returns |
-| `RUNNING_PAUSED_AT_BREAK` | disabled mirror | hidden | hidden | worker is paused inside `machine.run({ ... })` at an `onDebugBreak` fire (user-authored or Step-armed). Run button labels "Continue"; Step sends `resume(step: true)`; Stop terminates the worker. |
-| `HALTED` | disabled mirror | hidden | yes | frozen at final state. Build/Step/Run remain enabled — Step/Run reload-from-code on entry (the same path as MANUAL/DEMO), effectively restarting the machine without an explicit Build click. |
-
-Take control is the only entry into `MANUAL`. Once the user takes control, demo never restarts. From `MANUAL` (or `DEMO`/`HALTED`), Step and Run both call `reloadWorker(code)` first — the user's manual `Apply`s and code edits are reconciled by always rebuilding the worker + `mirrorMachine` from the current editor `code`. **Cold-start Step then enters run-mode via `runner.run({ step: true, debug, onPaused })`** — the worker arms `initialState.debug.after = true` so iter 1's after-fire is the step boundary, then transitions to `RUNNING_PAUSED_AT_BREAK`.
-
-A `Stop` button is shown next to Run while `RUNNING_STEP` / `RUNNING_AUTO` / `RUNNING_PAUSED_AT_BREAK` (`stopVisible`); clicking it sets `executionMode = 'HALTED'` and reports `'stopped'`. From `RUNNING_PAUSED_AT_BREAK` it also terminates the worker (the `runner.run()` Promise rejects; `failHalted` is suppressed via `stopRequested`). The auto-step `$effect` cleans itself up when mode leaves `RUNNING_AUTO`.
-
-## Debugger UX (debug mode + breakpoints)
-
-A `debug` checkbox in the Toolbar controls whether user-authored `state.debug` / `haltState.debug` breakpoints pause execution. State `debugMode` is owned by `MachineView.svelte`, persisted to `localStorage` under `machines-demo:<engine>:debugMode`. Mid-run toggle works via `runner.setDebug(on)` — a `$effect` watches `debugMode` and pushes the change to the worker, which flips an internal `debugEnabled` flag without restarting.
-
-Step (cold-start and from break) always uses run-mode and arms `state.debug.after = true` on the relevant state to fire one boundary pause:
-- **Cold-start**: arms `initialState.debug.after = true` before invoking `machine.run(...)` (preserves any user-authored `state.debug.before`).
-- **From `RUNNING_PAUSED_AT_BREAK`**: `resume(step: true)` arms `m.state.debug.after` (when paused at before) or `m.nextState.debug.after` (when paused at after). `pendingRestore` undoes the mutation before the user observes the next break.
-
-`MachineView#onPausedHandler` always logs `paused at state X <when> applying command for symbols: [...]`. Reads as "we made a step, look at the result": `.after`-arming means iter K just ran when we pause, and the log surfaces iter K's state + just-executed symbols. The `debug` toggle gates whether user-authored breaks fire, not how pauses are logged.
-
-**Engine quirks at halt** (filed upstream as [`turing-machine-js#108`](https://github.com/mellonis/turing-machine-js/issues/108)): the halting iter's `after`-fire never fires (the engine's `prevYield`-deferred after pattern needs an iter K+1 that doesn't exist when iter K transitions to halt); `haltState.debug.after` is silently ignored (no halt-pause anchor). `haltState.debug.before` IS honored — fires on the iter that transitions to halt, OR'd into that iter's `beforeMatch`.
+**Execution model and debugger semantics:** see [`docs/execution-model.md`](docs/execution-model.md).
 
 ## Worker contract
 

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -429,3 +429,31 @@ A run that doesn't halt naturally hits `MAX_STEPS = 100_000` inside the worker's
 - `timeout after 5000ms — worker terminated (likely infinite loop)`
 
 **Edge case.** A user code that uses `setTimeout` / async patterns inside `state.debug.before` / `state.debug.after` callbacks (if any) could ostensibly stall a segment indefinitely; the per-segment cap protects the demo from such cases.
+
+## 11. Current divergences from spec
+
+A punchlist of where today's code differs from the spec, each with a tracking-issue link. Acts as a TODO list for follow-up PRs; #47 cites scenario IDs and `it.skip` divergent ones until they close.
+
+- **IDLE mode does not exist.** Today's code encodes the post-Build, pre-Take-Control resting state via `(executionMode = DEMO, demoEnabled = false)`. Affects all `S-*-idle-*` IDs — they're served by `S-*-demo-*` paths today. Step from DEMO completes back to a still-running auto-loop that overwrites the result. Implementation tracked alongside [#46](https://github.com/mellonis/machines-demo/issues/46) (this spec); follow-up PR introduces IDLE and drops `demoEnabled`.
+- **RUNNING_STEP exists as a separate paused state.** Affects `S-step-auto-{off,on}` (today: → RUNNING_STEP, not PAUSED) and any `S-step-step-*` / `S-run-step-*` IDs that exist only as legacy citations. Tracked in [#43](https://github.com/mellonis/machines-demo/issues/43).
+- **Today's code names the paused-mode `RUNNING_PAUSED_AT_BREAK`.** The spec uses the shorter `RUNNING_PAUSED` (consistent with `RUNNING_AUTO` / `RUNNING_CONTINUOUS`). Cosmetic rename folded into the same alignment work as the RUNNING_STEP collapse ([#43](https://github.com/mellonis/machines-demo/issues/43)).
+- **Auto-step path uses `runner.step()`, not `run()`.** Affects all `S-step-auto-*`, `S-debug-toggle-auto` (today: flag only, no `setDebug()` call). Tracked in [#43](https://github.com/mellonis/machines-demo/issues/43).
+- **Step (debug=on) on auto-step path doesn't honor breaks.** Affects `S-step-auto-on`. Tracked in [#43](https://github.com/mellonis/machines-demo/issues/43).
+- **Halting iter's `state.debug.after` never fires.** Affects walk-through 1 edge case. Tracked in [turing-machine-js#108](https://github.com/mellonis/turing-machine-js/issues/108).
+- **`haltState.debug.after` silently ignored; `haltState.debug.before` IS honored.** Tracked in [turing-machine-js#108](https://github.com/mellonis/turing-machine-js/issues/108).
+
+## 12. Engine quirks
+
+Upstream behaviors the spec encodes (won't change without a major upstream version, so the spec works around them):
+
+- `onDebugBreak` after-fire payload substitutes `m` to `prevYield` — the un-substituted `machineState` is not exposed. Affects step-over-from-after implementations. Cross-ref [turing-machine-js#107](https://github.com/mellonis/turing-machine-js/issues/107).
+- `onStep` and `onDebugBreak` after-fire payloads carry semantically identical `MachineState`. Both hooks are documented; the demo wires both for orthogonal reasons (per-step buffer vs. pause cycle). Cross-ref [turing-machine-js#109](https://github.com/mellonis/turing-machine-js/issues/109).
+
+§11 vs §12: §11 lists demo-side gaps to be closed; §12 lists engine semantics that won't change. Items can move from §12 to §11 if the upstream issue lands and a corresponding demo-side simplification becomes possible.
+
+## 13. Cross-references
+
+- [`CLAUDE.md`](../CLAUDE.md) — working conventions, file structure, build commands. Runtime-behavior content moved here.
+- [`docs/superpowers/specs/2026-05-08-worker-run-mode-design.md`](superpowers/specs/2026-05-08-worker-run-mode-design.md) — the [#40](https://github.com/mellonis/machines-demo/issues/40) design; gives the *why* behind RUNNING_PAUSED and the worker contract.
+- [#47](https://github.com/mellonis/machines-demo/issues/47) — test infrastructure that consumes the scenario IDs defined in this doc.
+- [#46](https://github.com/mellonis/machines-demo/issues/46) — issue this spec resolves.

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -123,3 +123,21 @@ The loop is entirely a main-thread effect; the worker doesn't see DEMO. The mirr
 - `S-takectl-demo` — `userTookControl = true`, → MANUAL.
 
 DEMO is entered only on initial page load. After any of the exits above, the user never returns to DEMO.
+
+## 5. IDLE mode
+
+IDLE is the post-interaction, pre-Take-Control resting state. The user has clicked Build / Step / Run (from DEMO or after a previous run) but hasn't committed to the manual track. The auto-loop is dead; the worker is built; the panel mirrors the worker's state but is read-only.
+
+IDLE differs from MANUAL only by the `userTookControl` latch — once Take Control fires, IDLE → MANUAL and never returns.
+
+**Exits.** Build (→ IDLE, reload — same code, fresh worker); Step / Run (→ RUNNING_*; cold-start path); Take Control (→ MANUAL, latch flips). Errors during cold-start lead → HALTED via the cold-start error branch.
+
+**Visible controls.** Build, Step, Run, Take Control. Apply is hidden (Apply is MANUAL-only). Stop is hidden (no run in flight).
+
+**Scenario IDs.**
+- `S-build-idle` — reload, → IDLE.
+- `S-step-idle-{off,on}` — cold-start Step. Per §7.
+- `S-run-idle-{off,on}-{auto,cont}` — cold-start Run. Per §7.
+- `S-takectl-idle` — `userTookControl = true`, → MANUAL.
+
+A user who has run a machine to completion without ever clicking Take Control returns to IDLE — the spec preserves the IDLE track until the user explicitly opts in to MANUAL.

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -105,3 +105,21 @@ Four flags govern transitions and per-action behavior. Three are user-visible UI
 - **`userTookControl`** — `boolean`. Sticky latch, starts `false`, set `true` on Take Control click, never re-enables. Marks the "manual track": after RUNNING_* / HALTED, post-action mode resolution lands MANUAL when true, IDLE when false.
 
 The `demoEnabled` flag from earlier versions of the code is dropped — the DEMO ↔ IDLE mode distinction encodes "is the auto-loop alive" directly.
+
+## 4. DEMO mode
+
+DEMO is the page-load entry state — a teaser that shows the machine reacting to inputs without requiring the user to do anything. The demo loop fires on a timer (~1 Hz) and applies one randomly chosen command per tick, drawn from the current tape's alphabet (40 % chance the head stays put with no write; otherwise pick a random symbol and a random direction).
+
+The loop is entirely a main-thread effect; the worker doesn't see DEMO. The mirror machine receives commands directly via the same `ifOtherSymbol` one-step path used by Apply.
+
+**Exits.** DEMO → IDLE on Build / Step / Run (cold-start path; the click signals intent and kills the loop); DEMO → MANUAL on Take Control (the user commits to the manual track). Errors during cold-start lead → HALTED via the cold-start error branch.
+
+**Visible controls.** Build, Step, Run, Take Control. Apply is hidden (the loop generates commands itself; there's no role for a user-fired Apply in DEMO). Stop is hidden (no worker-side run to interrupt).
+
+**Scenario IDs.**
+- `S-build-demo` — reload, → IDLE.
+- `S-step-demo-{off,on}` — cold-start Step. Worker arms `initialState.debug.after = true`, runs, → RUNNING_PAUSED. Per §7.
+- `S-run-demo-{off,on}-{auto,cont}` — cold-start Run. → RUNNING_AUTO or RUNNING_CONTINUOUS by withPause. Per §7.
+- `S-takectl-demo` — `userTookControl = true`, → MANUAL.
+
+DEMO is entered only on initial page load. After any of the exits above, the user never returns to DEMO.

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -141,3 +141,23 @@ IDLE differs from MANUAL only by the `userTookControl` latch — once Take Contr
 - `S-takectl-idle` — `userTookControl = true`, → MANUAL.
 
 A user who has run a machine to completion without ever clicking Take Control returns to IDLE — the spec preserves the IDLE track until the user explicitly opts in to MANUAL.
+
+## 6. MANUAL mode
+
+MANUAL is the committed resting state. `userTookControl = true`; the user is driving the machine via Apply. The panel is enabled and the user composes a `Command` (movement + symbol) which writes to the mirror via the same `ifOtherSymbol` one-step state used internally by Step.
+
+Once entered, MANUAL is sticky: subsequent Build / Step / Run / completion all return to MANUAL.
+
+**Exits.** Build (→ MANUAL, reload); Step / Run (→ RUNNING_*; cold-start); Apply (stays MANUAL, in-place mirror write). Errors during cold-start lead → HALTED.
+
+**Visible controls.** Build, Step, Run, Apply. Take Control is hidden (already taken). Stop is hidden (no run in flight).
+
+**Apply scenario.**
+- `S-apply-manual` — main thread applies the user-composed `Command` to `mirrorMachine` via the `ifOtherSymbol` one-step state. No worker round-trip; the worker stays idle. Mode stays MANUAL. The log gets a single command entry per Apply.
+
+The Apply button is **hidden** in DEMO, IDLE, and HALTED — it's MANUAL-only. Earlier code variants displayed a flashing "next random command" Apply button in DEMO; the spec drops that affordance and lets the DEMO loop render its commands inline on the panel.
+
+**Cold-start scenarios from MANUAL.** See §7.
+- `S-build-manual` — reload, → MANUAL.
+- `S-step-manual-{off,on}` — cold-start Step.
+- `S-run-manual-{off,on}-{auto,cont}` — cold-start Run.

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -110,7 +110,7 @@ The `demoEnabled` flag from earlier versions of the code is dropped — the DEMO
 
 DEMO is the page-load entry state — a teaser that shows the machine reacting to inputs without requiring the user to do anything. The demo loop fires on a timer (~1 Hz) and applies one randomly chosen command per tick, drawn from the current tape's alphabet (40 % chance the head stays put with no write; otherwise pick a random symbol and a random direction).
 
-The loop is entirely a main-thread effect; the worker doesn't see DEMO. The mirror machine receives commands directly via the same `ifOtherSymbol` one-step path used by Apply.
+The loop is entirely a main-thread effect; the worker doesn't see DEMO. The mirror machine receives commands directly via the same `ifOtherSymbol` one-step write path that §6 MANUAL exposes through Apply.
 
 **Exits.** DEMO → IDLE on Build / Step / Run (cold-start path; the click signals intent and kills the loop); DEMO → MANUAL on Take Control (the user commits to the manual track). Errors during cold-start lead → HALTED via the cold-start error branch.
 
@@ -193,9 +193,6 @@ flowchart TD
     RunAuto --> AutoOut[→ RUNNING_AUTO]
     WithPause -->|false| RunCont[runner.run debug=debugMode, no throttle]
     RunCont --> ContOut[→ RUNNING_CONTINUOUS]
-    AutoOut -. user-authored break .-> PauseOut
-    ContOut -. user-authored break .-> PauseOut
-    RunStep -. user-authored .before fires before iter 1 after .-> PauseOut
 ```
 
 **Cold-start scenario IDs.** Each origin (IDLE / MANUAL / HALTED) gets the same set:
@@ -428,7 +425,7 @@ A run that doesn't halt naturally hits `MAX_STEPS = 100_000` inside the worker's
 **Log entries**
 - `timeout after 5000ms — worker terminated (likely infinite loop)`
 
-**Edge case.** A user code that uses `setTimeout` / async patterns inside `state.debug.before` / `state.debug.after` callbacks (if any) could ostensibly stall a segment indefinitely; the per-segment cap protects the demo from such cases.
+**Edge case.** Today's API doesn't expose any callback hook to user code — `state.debug.before` / `state.debug.after` are filter values (`true | string[] | null`), not user-supplied functions, and the worker's `onStep` / `onDebugBreak` wrap the run on the demo side. So a "stall via async user callback" isn't reachable in the current surface. The per-segment cap defends against the cases that *are* reachable: infinite loops in user code, hung worker-side Promises, and any future API surface that might let user-supplied async logic interpose.
 
 ## 11. Current divergences from spec
 

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -351,3 +351,42 @@ A Run with `debug=on` and user-authored `state.debug` triggers a sequence of pau
 
 **Worker calls**
 - `resume({ step: false })`
+
+### Walk-through 4 — Stop from each running mode
+
+Stop is visible while in RUNNING_AUTO, RUNNING_CONTINUOUS, and RUNNING_PAUSED.
+
+- `S-stop-auto` / `S-stop-cont` — main thread calls `runner.terminate()`. Worker is killed; `runner.run()` rejects with `runner terminated`. `failHalted` runs: rebuild mirror from worker's last-known tape state (or zeroed state if none), → HALTED with `stopped` log entry.
+- `S-stop-paused` — same as above, but `stopRequested` is set on the runner first so `failHalted` is **suppressed** when the rejected Promise surfaces (the rejection is the expected outcome of Stop, not an error). → HALTED with `stopped` log entry only — no error log.
+
+**Log entries**
+- `stopped`
+- (state mirror snapshot in matrix view)
+
+**Edge case.** A Stop click that races with run completion: worker may have already sent `ran` when `terminate()` is called. The runner's `runPending` slot has been cleared; `terminate()` is a no-op on the runner side. The HALTED transition still happens via the normal completion path, with a `halted after N step(s)` log entry instead of `stopped`. No user-visible bug.
+
+### Walk-through 5 — debug toggle mid-run
+
+The `debugMode` UI checkbox is reactive across mode transitions. A change while in any RUNNING_* mode pushes `setDebug(on)` to the worker.
+
+- `S-debug-toggle-auto` / `S-debug-toggle-cont` — `runner.setDebug(on)` posts a fire-and-forget message. Worker flips an internal `debugEnabled` flag. Subsequent `onDebugBreak` calls honor the new value (no run restart).
+- `S-debug-toggle-paused` — same `setDebug()` send. The current paused state is unaffected; the next break (after Continue) is gated by the new flag value.
+- In DEMO / IDLE / MANUAL / HALTED — flag flip only; no worker call (the worker is idle, the flag is read at the next `run()`).
+
+**Log entries**
+- (none — toggle is silent)
+
+**Edge case.** Toggling debug=on while paused doesn't cause an immediate break — the user is already paused. After Continue, breaks fire normally.
+
+### Walk-through 6 — Take Control mid-run
+
+Take Control is visible in DEMO, IDLE (visible during cold-start RUNNING_*), HALTED (when `!userTookControl`), and any RUNNING_* mode.
+
+- `S-takectl-auto` / `S-takectl-cont` / `S-takectl-paused` — main thread calls `runner.terminate()`. Worker is killed; `runner.run()` rejects via `rejectAll`. `userTookControl = true`. `failHalted` is suppressed via the same path as `S-stop-paused`. Mode → MANUAL.
+- `S-takectl-demo` / `S-takectl-idle` — no run in flight, just latch + mode change. → MANUAL.
+- `S-takectl-halted` — `userTookControl = true`, → MANUAL. Available only when `!userTookControl`.
+
+**Log entries**
+- `took control`
+
+**Edge case.** Take Control from RUNNING_PAUSED is functionally identical to from RUNNING_AUTO / RUNNING_CONTINUOUS — the worker is paused, but `terminate()` kills it the same way. `runPending`'s onPaused callback is never called again because the runner's pending slot is cleared on terminate.

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -207,3 +207,14 @@ flowchart TD
 **DEMO origin.** Build / Step / Run from DEMO uses the same cold-start path; the click signals intent (kills the auto-loop) but doesn't flip `userTookControl`, so post-RUNNING_* completion and Build resolution land IDLE. Scenario IDs `S-build-demo`, `S-step-demo-{off,on}`, `S-run-demo-{off,on}-{auto,cont}` mirror the IDLE entries.
 
 **Post-RUNNING_* completion** — when a run reaches halt naturally (or via Stop), the resolution is HALTED. The next Build / Step / Run from HALTED then resolves to IDLE or MANUAL by `userTookControl`. The track is preserved across the run.
+
+### Resume from PAUSED
+
+The Run / Continue button (Run while in RUNNING_PAUSED) doesn't reload — it sends `runner.resume({ step: false })` and the worker continues inside the same in-flight `machine.run()` invocation. Two outcomes by `debug`:
+
+- `S-continue-paused-off` — `runner.resume({ step: false })`. Debug breaks are not honored (worker-side `debugEnabled = false`), so the run continues to halt → HALTED on completion. Stop / error / timeout still terminate the worker normally.
+- `S-continue-paused-on` — `runner.resume({ step: false })`. Debug breaks fire as encountered → next RUNNING_PAUSED. The user can click Continue again, repeating across multiple paused / resume cycles until halt or Stop.
+
+The button's label changes by mode: "Run" in non-PAUSED modes (cold-start), "Continue" in RUNNING_PAUSED. Same underlying action class; the label just clarifies intent.
+
+Walk-through 3 expands these scenarios with per-segment timer behavior, log replay, and edge cases.

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -94,3 +94,14 @@ Exit: Step (arm next `.after`, → RUNNING_PAUSED via re-pause), Continue (→ R
 Terminal state. The machine reached its halt state, errored, timed out, or hit `MAX_STEPS` truncation. Tape is frozen at the final state. Build / Step / Run reload-from-code. Take Control is visible only when `!userTookControl`.
 Entry: run completion, Stop, error, timeout, or truncation from any RUNNING_*; build error from any cold-start.
 Exit: Build (→ IDLE if `!userTookControl`, → MANUAL if `userTookControl`), Step / Run (→ RUNNING_* via cold-start), Take Control (→ MANUAL, only if `!userTookControl`).
+
+## 3. Flag reference
+
+Four flags govern transitions and per-action behavior. Three are user-visible UI controls; one is a sticky latch.
+
+- **`debugMode`** — `boolean`. UI checkbox in the Toolbar, persisted to `localStorage:machines-demo:<engine>:debugMode`. Gates whether user-authored `state.debug` / `haltState.debug` breaks pause execution. Mid-run toggle pushes `setDebug(on)` to the worker (the only mode-aware effect on a flag toggle).
+- **`withPause`** — `boolean`. UI checkbox + interval input in the Toolbar. Selects RUNNING_AUTO (with throttle) vs RUNNING_CONTINUOUS (snap-to-final) on the next Run. The toggle itself (`S-withpause-toggle`) has no immediate runtime effect; it's read at Run-click time.
+- **`halted`** — `boolean`. Derived from worker `built` / `ran` / `error` responses. Drives the HALTED-mode transition.
+- **`userTookControl`** — `boolean`. Sticky latch, starts `false`, set `true` on Take Control click, never re-enables. Marks the "manual track": after RUNNING_* / HALTED, post-action mode resolution lands MANUAL when true, IDLE when false.
+
+The `demoEnabled` flag from earlier versions of the code is dropped — the DEMO ↔ IDLE mode distinction encodes "is the auto-loop alive" directly.

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -255,3 +255,99 @@ HALTED is the terminal state — the machine reached its halt state, was stopped
 - `S-takectl-halted` — `userTookControl = true`, → MANUAL. Available only when `!userTookControl`.
 
 HALTED can be reached from any non-resting state. Build / Step / Run from HALTED, plus error and timeout handling, are walk-throughs in §10.
+
+## 10. Scenario walk-throughs
+
+Each walk-through expands a contested or non-obvious path with sequence, log entries, worker calls, and edge cases. Boundary cases only — straightforward paths (Build, Apply, cold-start Run with no breaks) are sufficiently covered by the matrix and §7.
+
+### `S-step-paused-off` / `S-step-paused-on` — Step from break
+
+**Sequence**
+1. User clicks Step while in RUNNING_PAUSED.
+2. Main thread arms `.after` on the relevant state — `m.state` if the current pause was a `before`-fire, `m.nextState` if it was an `after`-fire. The mutation is captured in `pendingRestore` for later un-application.
+3. `runner.resume({ step: true })` resolves the worker's pending Promise with the step intent.
+4. Worker un-applies any prior `pendingRestore`, then runs until the armed `.after` fire (or until a user-authored break interposes when `debug=on`).
+5. Worker sends `paused`; main thread enters RUNNING_PAUSED with the new break info, runs `pendingRestore` for the new arm.
+
+**Log entries**
+- `paused at state <X> after applying command for symbols: [<syms>]`
+
+**Worker calls**
+- `resume({ step: true })`
+
+**Edge cases**
+- `debug=on`: a user-authored `.before` may interpose before the armed `.after` fires. Both produce a normal `paused` response; the long-format log line distinguishes them by `before` vs `after`.
+- The halting iter's armed `.after` never fires (engine quirk). If the next iter halts the machine, the worker sends `ran` instead of a final `paused` — the run lands in HALTED. Tracked in [turing-machine-js#108](https://github.com/mellonis/turing-machine-js/issues/108).
+
+The sequence diagram below shows the complete cycle: Run (debug=on) → break → Step → re-pause → Continue → halt or further breaks.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Main as Main thread (MachineView)
+    participant Worker
+    participant Engine as machine.run()
+
+    User->>Main: click Run [debug=on]
+    Main->>Worker: postMessage { type: 'run', debug: true }
+    Worker->>Engine: machine.run({ onDebugBreak })
+    Engine-->>Worker: yield N, state.debug.before fires
+    Worker-->>Main: { type: 'paused', state, currentSymbols, debugBreak: { before: true } }
+    Note over Worker: timer suspended
+    Note over Main: → RUNNING_PAUSED — log paused at state X before applying ...
+
+    User->>Main: click Step
+    Main->>Main: arm m.state.debug.after = true (pendingRestore captured)
+    Main->>Worker: postMessage { type: 'resume', step: true }
+    Note over Worker: timer restarted
+    Worker->>Engine: resolve onDebugBreak Promise
+    Engine-->>Worker: yield N+1, state.debug.after fires (armed)
+    Worker->>Worker: pendingRestore() — undo arm
+    Worker-->>Main: { type: 'paused', debugBreak: { after: true } }
+    Note over Worker: timer suspended
+    Note over Main: → RUNNING_PAUSED — log paused at state X after applying ...
+
+    User->>Main: click Run (Continue)
+    Main->>Worker: postMessage { type: 'resume', step: false }
+    Note over Worker: timer restarted
+    Worker->>Engine: resolve
+    alt run completes naturally
+        Engine-->>Worker: ... runs to halt
+        Worker-->>Main: { type: 'ran', tapes, commands }
+        Note over Main: → HALTED — log halted after N step(s)
+    else another debug break fires (debug=on)
+        Engine-->>Worker: yield M, state.debug.before fires
+        Worker-->>Main: { type: 'paused', state, currentSymbols, debugBreak: { before: true } }
+        Note over Main: → RUNNING_PAUSED — back to the break-cycle above
+    end
+```
+
+### Walk-through 2 — Run with breakpoints (multi-paused cycle)
+
+A Run with `debug=on` and user-authored `state.debug` triggers a sequence of paused / resume cycles. Each `paused` includes the current state, current symbols, and the `debugBreak` shape (`{ before: true }` or `{ after: true }`).
+
+**Per-segment timer.** The worker's per-segment `WORKER_TIMEOUT_MS` (5 s) suspends on every `paused` and restarts on every `resume`-send. A user inspecting a paused state for minutes does not trigger the timeout; only worker-side execution time counts.
+
+**Log replay.** Each `paused` carries a `commands` array — the per-step commands buffered between this `paused` and the previous one. The main thread appends them to the log in order, so the trace is preserved across pauses without the worker re-sending the full history.
+
+**Edge case — Stop while paused.** Worker is terminated; `runner.run()` rejects; `failHalted` is suppressed via `stopRequested`. Mode → HALTED with a `stopped` log entry. See walk-through 4.
+
+### Walk-through 3 — Continue from break (`S-continue-paused-{off,on}`)
+
+**Sequence (debug=off).**
+1. User clicks Run while in RUNNING_PAUSED. The button reads "Continue".
+2. Main thread sends `resume({ step: false })`.
+3. Worker resolves the pending Promise. `debugEnabled = false` so `onDebugBreak` returns immediately on subsequent breaks.
+4. Run continues to halt; worker sends `ran` → HALTED.
+
+**Sequence (debug=on).**
+1. Same start.
+2. Worker resolves; `debugEnabled = true` so subsequent breaks pause normally.
+3. Run continues until next break (→ another `paused` → RUNNING_PAUSED again), Stop, or halt (→ HALTED).
+
+**Log entries**
+- (debug=off, halt) `halted after N step(s)`
+- (debug=on, next break) — same long-format line as walk-through 1's log: `paused at state <X> {before|after} applying command for symbols: [<syms>]`
+
+**Worker calls**
+- `resume({ step: false })`

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -1,0 +1,57 @@
+# Execution model and debugger semantics
+
+> Canonical reference for what each mode does, what each user action triggers, and where the machine lands. Tests in [#47](https://github.com/mellonis/machines-demo/issues/47) cite the scenario IDs (`S-...`) defined throughout. Working conventions and file structure remain in [`CLAUDE.md`](../CLAUDE.md).
+
+## 1. Overview
+
+The demo runs user-typed JavaScript inside a Web Worker that drives a `@turing-machine-js/machine` v4 instance. The main thread tracks the worker's progress with a 7-mode state machine: three resting states (DEMO, IDLE, MANUAL), three running states (RUNNING_AUTO, RUNNING_CONTINUOUS, RUNNING_PAUSED), and one terminal (HALTED).
+
+Most user actions are mode transitions; a few — debug toggle, withPause toggle, Apply — are flag changes or in-place mirror writes that don't move the mode.
+
+The diagram below shows every mode-to-mode user-action edge. Conditions appear inline in `[brackets]`; alternations use `or`. Event-driven exits (run completion, error, timeout, truncation, build error) are summarized in the bottom note.
+
+```mermaid
+stateDiagram-v2
+    [*] --> DEMO
+
+    DEMO --> IDLE : Build
+    DEMO --> RUNNING_PAUSED : Step (cold-start)
+    DEMO --> RUNNING_AUTO : Run [withPause=on]
+    DEMO --> RUNNING_CONTINUOUS : Run [withPause=off]
+    DEMO --> MANUAL : Take Control
+
+    IDLE --> IDLE : Build
+    IDLE --> RUNNING_PAUSED : Step (cold-start)
+    IDLE --> RUNNING_AUTO : Run [withPause=on]
+    IDLE --> RUNNING_CONTINUOUS : Run [withPause=off]
+    IDLE --> MANUAL : Take Control
+
+    MANUAL --> MANUAL : Build or Apply
+    MANUAL --> RUNNING_PAUSED : Step (cold-start)
+    MANUAL --> RUNNING_AUTO : Run [withPause=on]
+    MANUAL --> RUNNING_CONTINUOUS : Run [withPause=off]
+
+    RUNNING_AUTO --> RUNNING_PAUSED : Pause
+    RUNNING_AUTO --> RUNNING_PAUSED : break [debug=on]
+    RUNNING_AUTO --> HALTED : Stop or completion
+    RUNNING_AUTO --> MANUAL : Take Control
+
+    RUNNING_CONTINUOUS --> RUNNING_PAUSED : break [debug=on]
+    RUNNING_CONTINUOUS --> HALTED : Stop or completion
+    RUNNING_CONTINUOUS --> MANUAL : Take Control
+
+    RUNNING_PAUSED --> RUNNING_PAUSED : Step or next break
+    RUNNING_PAUSED --> RUNNING_AUTO : Continue [withPause=on]
+    RUNNING_PAUSED --> RUNNING_CONTINUOUS : Continue [withPause=off]
+    RUNNING_PAUSED --> HALTED : Stop or Continue→halt
+    RUNNING_PAUSED --> MANUAL : Take Control
+
+    HALTED --> IDLE : Build [!userTookControl]
+    HALTED --> MANUAL : Build [userTookControl]
+    HALTED --> RUNNING_PAUSED : Step (cold-start)
+    HALTED --> RUNNING_AUTO : Run [withPause=on]
+    HALTED --> RUNNING_CONTINUOUS : Run [withPause=off]
+    HALTED --> MANUAL : Take Control [!userTookControl]
+
+    note right of HALTED : Error, timeout, truncation, or cold-start build error from any non-resting state lands HALTED.
+```

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -161,3 +161,49 @@ The Apply button is **hidden** in DEMO, IDLE, and HALTED — it's MANUAL-only. E
 - `S-build-manual` — reload, → MANUAL.
 - `S-step-manual-{off,on}` — cold-start Step.
 - `S-run-manual-{off,on}-{auto,cont}` — cold-start Run.
+
+## 7. Starting and resuming runs
+
+The cold-start path (Build / Step / Run from IDLE, MANUAL, or HALTED — and DEMO's user-clicked equivalent) is unified: reload the worker, then either land back in a resting mode (Build) or enter `machine.run()` (Step / Run). The Resume sub-section covers Continue from RUNNING_PAUSED, which uses the same in-flight `run()` rather than reloading.
+
+### Cold-start
+
+The path is identical from IDLE, MANUAL, and HALTED. Each Build / Step / Run reloads the worker, builds a fresh mirror, then routes by action:
+
+- **Build** — reload only. → IDLE if `!userTookControl`, → MANUAL if `userTookControl`.
+- **Step** — reload, arm `initialState.debug.after = true` (preserving any user-authored `state.debug.before`), call `runner.run({ debug: debugMode, step: true })`. Worker pauses at iter 1's after-fire → RUNNING_PAUSED. With `debug=on` and a user-authored `state.debug.before` on `initialState`, the before-fire interposes first; same target mode.
+- **Run** — reload, call `runner.run({ debug: debugMode })`. → RUNNING_AUTO (`withPause=on`, with throttled `onStep`) or RUNNING_CONTINUOUS (`withPause=off`, no throttle). Debug breaks during the run land → RUNNING_PAUSED.
+
+If the reload itself fails (build error in user code), → HALTED with an error log; covered by walk-through 7.
+
+```mermaid
+flowchart TD
+    Start([User clicks Build, Step, or Run from IDLE / MANUAL / HALTED])
+    Start --> Reload[reload worker — build, mirror, alphabets]
+    Reload --> Action{which action?}
+    Reload -. build error .-> ErrorOut[→ HALTED with error log]
+    Action -->|Build| Resolve1{userTookControl?}
+    Resolve1 -->|true| ManualOut[→ MANUAL]
+    Resolve1 -->|false| IdleOut[→ IDLE]
+    Action -->|Step| ArmAfter[arm initialState.debug.after = true; preserve user-authored .before]
+    ArmAfter --> RunStep[runner.run debug=debugMode, step=true]
+    RunStep --> PauseOut[→ RUNNING_PAUSED at iter 1 after-fire]
+    Action -->|Run| WithPause{withPause?}
+    WithPause -->|true| RunAuto[runner.run debug=debugMode, with throttled onStep]
+    RunAuto --> AutoOut[→ RUNNING_AUTO]
+    WithPause -->|false| RunCont[runner.run debug=debugMode, no throttle]
+    RunCont --> ContOut[→ RUNNING_CONTINUOUS]
+    AutoOut -. user-authored break .-> PauseOut
+    ContOut -. user-authored break .-> PauseOut
+    RunStep -. user-authored .before fires before iter 1 after .-> PauseOut
+```
+
+**Cold-start scenario IDs.** Each origin (IDLE / MANUAL / HALTED) gets the same set:
+
+- `S-build-{idle,manual,halted}` — reload, → IDLE / MANUAL by `userTookControl`.
+- `S-step-{idle,manual,halted}-{off,on}` — Step cold-start. Off / on selects `debug` flag.
+- `S-run-{idle,manual,halted}-{off,on}-{auto,cont}` — Run cold-start. Off / on selects `debug`; auto / cont selects `withPause`.
+
+**DEMO origin.** Build / Step / Run from DEMO uses the same cold-start path; the click signals intent (kills the auto-loop) but doesn't flip `userTookControl`, so post-RUNNING_* completion and Build resolution land IDLE. Scenario IDs `S-build-demo`, `S-step-demo-{off,on}`, `S-run-demo-{off,on}-{auto,cont}` mirror the IDLE entries.
+
+**Post-RUNNING_* completion** — when a run reaches halt naturally (or via Stop), the resolution is HALTED. The next Build / Step / Run from HALTED then resolves to IDLE or MANUAL by `userTookControl`. The track is preserved across the run.

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -218,3 +218,24 @@ The Run / Continue button (Run while in RUNNING_PAUSED) doesn't reload — it se
 The button's label changes by mode: "Run" in non-PAUSED modes (cold-start), "Continue" in RUNNING_PAUSED. Same underlying action class; the label just clarifies intent.
 
 Walk-through 3 expands these scenarios with per-segment timer behavior, log replay, and edge cases.
+
+## 8. Action matrix
+
+Mode-transition outcomes for user actions across the three running / paused modes. Each cell is a scenario ID + one-line outcome, or `—` for hidden / disabled.
+
+**Matrix scope.** The matrix lists *user-action* exits only. Event-driven transitions — debug break firing, run completion, error, timeout, truncation — are not matrix rows. They appear in three other places: §1's master state diagram (edges), each mode's "Exit" line in §2 Mode reference, and walk-throughs 2 and 7-9. A reader looking only at the matrix should not conclude that, e.g., RUNNING_CONTINUOUS exits only via Stop or Take Control.
+
+| Action | RUNNING_AUTO | RUNNING_CONTINUOUS | RUNNING_PAUSED |
+|---|---|---|---|
+| **Step (debug=off)** | `S-step-auto-off`: pause label — suspend run loop, → PAUSED | — | `S-step-paused-off`: arm `.after` on next state, resume(step), → PAUSED |
+| **Step (debug=on)** | `S-step-auto-on`: pause label — suspend, → PAUSED | — | `S-step-paused-on`: arm `.after`, resume(step), → PAUSED (a user break may interpose first) |
+| **Stop** | `S-stop-auto`: terminate, → HALTED | `S-stop-cont`: terminate, → HALTED | `S-stop-paused`: terminate, suppress failHalted, → HALTED |
+| **Take Control** | `S-takectl-auto`: latch userTookControl=true, terminate, → MANUAL | `S-takectl-cont`: latch, terminate, → MANUAL | `S-takectl-paused`: latch, terminate, → MANUAL |
+
+Notes:
+- Every cell is a mode transition (or `—` for hidden / disabled). Flag-change actions (debug toggle, withPause toggle) live in §3 — they don't cause mode transitions.
+- **Build is hidden in RUNNING_AUTO / RUNNING_CONTINUOUS / RUNNING_PAUSED** — a pending worker request blocks Build. To rebuild, the user clicks Stop or Take Control first (terminate the worker), then Build is available from HALTED / MANUAL.
+- All RUNNING_* paths use `run()`. "Pause" from RUNNING_AUTO suspends inside run-mode (the throttle's setTimeout) and lands in PAUSED — the same paused state used by debug breaks.
+- **RUNNING_CONTINUOUS has the same control surface as RUNNING_AUTO** — Stop, Take Control, debug toggle all available. The modes differ only in throttle / animation; the control surface does not become a third axis of difference. Take Control mid-CONTINUOUS can lose the race to completion, but no race produces a broken state — terminate-or-complete are both clean exits.
+- Run / Continue is a single-column action (only meaningful from RUNNING_PAUSED). It's documented in §7 Resume from PAUSED rather than in the matrix.
+- DEMO, IDLE, MANUAL, HALTED are not matrix columns — they have their own sections (§4, §5, §6, §9).

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -390,3 +390,42 @@ Take Control is visible in DEMO, IDLE (visible during cold-start RUNNING_*), HAL
 - `took control`
 
 **Edge case.** Take Control from RUNNING_PAUSED is functionally identical to from RUNNING_AUTO / RUNNING_CONTINUOUS — the worker is paused, but `terminate()` kills it the same way. `runPending`'s onPaused callback is never called again because the runner's pending slot is cleared on terminate.
+
+### Walk-through 7 — Error mid-run (and cold-start build error)
+
+Errors come from two sources:
+
+1. **Build error** — the worker's user-code build (cold-start) throws (parse error, runtime exception during initial setup). Worker sends `error` with no `tapes`. → HALTED with error log.
+2. **Mid-run error** — the worker's `machine.run()` throws (typically: no edge in the state graph for the current symbol). Worker sends `error` with partial `tapes` (the snapshot at throw-time). → HALTED with error log.
+
+Both surface as `WorkerError` in the runner; main thread's `failHalted` rebuilds the mirror from the partial `tapes` (when present) so the user sees the state where execution actually stuck — not the loaded tape with no record of the steps that ran.
+
+- `S-error-{auto,cont,paused}` — mid-run error from each running mode. Same flow.
+
+**Log entries**
+- `error: <message>`
+
+**Edge case.** Cold-start build errors don't have running-mode-specific scenario IDs in the matrix because they happen before any RUNNING_* mode is entered. Tested against from each cold-start origin (IDLE / MANUAL / HALTED / DEMO) — see §7's flowchart error branch.
+
+### Walk-through 8 — Truncation (`S-truncate-{auto,cont}`)
+
+A run that doesn't halt naturally hits `MAX_STEPS = 100_000` inside the worker's `runToEnd` cap. Worker sends `ran` with `truncated: true`.
+
+- `S-truncate-auto` / `S-truncate-cont` — main thread receives `ran`. → HALTED with `truncated: did not halt within MAX_STEPS steps` log entry. Per-step entries are **suppressed** when `truncated: true` (band-aid until [#45](https://github.com/mellonis/machines-demo/issues/45) lands; rendering 100k log entries freezes the main thread for seconds).
+
+**Log entries**
+- `truncated: did not halt within MAX_STEPS steps`
+
+**Edge case.** A debug-paused run that's then continued without `debug=off` won't truncate at the same point — the per-segment cap accrues across resume cycles, so a long-paused-then-resumed run could still hit MAX_STEPS in a later segment.
+
+### Walk-through 9 — Worker timeout per segment (`S-timeout-{auto,cont,paused}`)
+
+`WORKER_TIMEOUT_MS = 5_000` caps wall-clock time on each worker request **segment**. For `build` / `step` / `run`-without-pause it's a round-trip cap; for `run` with paused / resume cycles it's per-segment (suspends on `paused`, restarts on `resume`-send).
+
+- `S-timeout-auto` / `S-timeout-cont` — segment exceeds 5 s. Runner kills the worker (terminate) and rejects with `timeout after 5000ms — worker terminated (likely infinite loop)`. → HALTED with timeout log.
+- `S-timeout-paused` — only fires if the user clicks Continue or Step and the **resumed** segment exceeds 5 s. A paused state is not subject to timeout.
+
+**Log entries**
+- `timeout after 5000ms — worker terminated (likely infinite loop)`
+
+**Edge case.** A user code that uses `setTimeout` / async patterns inside `state.debug.before` / `state.debug.after` callbacks (if any) could ostensibly stall a segment indefinitely; the per-segment cap protects the demo from such cases.

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -55,3 +55,42 @@ stateDiagram-v2
 
     note right of HALTED : Error, timeout, truncation, or cold-start build error from any non-resting state lands HALTED.
 ```
+
+## 2. Mode reference
+
+Three lines per mode: what it means, how it's entered, how it's exited. UI / log detail belongs in §8 Action matrix and §10 walk-throughs.
+
+### DEMO
+Page-load entry state. A timer-based loop generates random commands and applies them to the mirror, demonstrating the machine without user input. `userTookControl` is false; auto-loop is live.
+Entry: page load only.
+Exit: Build (→ IDLE), Step or Run (→ RUNNING_*; cold-start path), Take Control (→ MANUAL).
+
+### IDLE
+Uncommitted resting state. The user has signaled intent (Build / Step / Run from DEMO, or completed a run from IDLE-track) but has not yet taken control. Auto-loop is dead. Apply is hidden. Take Control is visible.
+Entry: Build / Step / Run from DEMO; post-RUNNING_* completion when `!userTookControl`; Build from HALTED when `!userTookControl`.
+Exit: Build (→ IDLE, reload), Take Control (→ MANUAL), Step (→ RUNNING_PAUSED), Run (→ RUNNING_AUTO / RUNNING_CONTINUOUS).
+
+### MANUAL
+Committed resting state. The user drives the machine via Apply. Worker is built but idle (no run/step pending). Take Control is hidden (already taken).
+Entry: Take Control from any non-MANUAL mode; post-RUNNING_* completion or Build from HALTED when `userTookControl`.
+Exit: Step / Run via §7 cold-start (→ RUNNING_AUTO / RUNNING_CONTINUOUS / RUNNING_PAUSED), Build (→ MANUAL, reload), Apply (stays MANUAL, writes to mirror).
+
+### RUNNING_AUTO
+The worker is running inside `machine.run({ onStep })` with a per-step throttle (the `withPause` interval). Belt animations follow the cadence; the user can click Pause to suspend.
+Entry: Run from IDLE / MANUAL / HALTED with `withPause=on`; Continue from RUNNING_PAUSED with `withPause=on`.
+Exit: Pause (→ RUNNING_PAUSED), debug break with `debug=on` (→ RUNNING_PAUSED), Stop (→ HALTED), run completion (→ HALTED), Take Control (→ MANUAL).
+
+### RUNNING_CONTINUOUS
+The worker is running inside `machine.run({ onStep })` with no throttle — snap-to-final. Belt animation is suppressed; per-step commands batch-log on completion. Same control surface as RUNNING_AUTO.
+Entry: Run from IDLE / MANUAL / HALTED with `withPause=off`; Continue from RUNNING_PAUSED with `withPause=off`.
+Exit: debug break with `debug=on` (→ RUNNING_PAUSED), Stop (→ HALTED), run completion (→ HALTED), Take Control (→ MANUAL).
+
+### RUNNING_PAUSED
+The worker is suspended inside `machine.run()` awaiting a `resume` message from the main thread. Reachable from any RUNNING_* mode via debug break, click-pause, or cold-start arming. The button labeled "Run" elsewhere reads "Continue" here.
+Entry: cold-start Step (arms `initialState.debug.after`); break fires from RUNNING_AUTO / RUNNING_CONTINUOUS with `debug=on`; click-pause from RUNNING_AUTO; Step self-loop from RUNNING_PAUSED.
+Exit: Step (arm next `.after`, → RUNNING_PAUSED via re-pause), Continue (→ RUNNING_AUTO / RUNNING_CONTINUOUS for the duration of the resume), Stop (terminate worker → HALTED), Take Control (→ MANUAL).
+
+### HALTED
+Terminal state. The machine reached its halt state, errored, timed out, or hit `MAX_STEPS` truncation. Tape is frozen at the final state. Build / Step / Run reload-from-code. Take Control is visible only when `!userTookControl`.
+Entry: run completion, Stop, error, timeout, or truncation from any RUNNING_*; build error from any cold-start.
+Exit: Build (→ IDLE if `!userTookControl`, → MANUAL if `userTookControl`), Step / Run (→ RUNNING_* via cold-start), Take Control (→ MANUAL, only if `!userTookControl`).

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -239,3 +239,19 @@ Notes:
 - **RUNNING_CONTINUOUS has the same control surface as RUNNING_AUTO** — Stop, Take Control, debug toggle all available. The modes differ only in throttle / animation; the control surface does not become a third axis of difference. Take Control mid-CONTINUOUS can lose the race to completion, but no race produces a broken state — terminate-or-complete are both clean exits.
 - Run / Continue is a single-column action (only meaningful from RUNNING_PAUSED). It's documented in §7 Resume from PAUSED rather than in the matrix.
 - DEMO, IDLE, MANUAL, HALTED are not matrix columns — they have their own sections (§4, §5, §6, §9).
+
+## 9. HALTED mode
+
+HALTED is the terminal state — the machine reached its halt state, was stopped, or hit an error / timeout / `MAX_STEPS` truncation. The tape is frozen at the final state; the worker is alive but idle (no run in flight). Build / Step / Run reload-from-code; Take Control flips the latch.
+
+**Exits.** Build (→ IDLE if `!userTookControl`, → MANUAL if `userTookControl`), Step / Run (→ RUNNING_* via cold-start, see §7), Take Control (→ MANUAL, only when `!userTookControl` — otherwise the button is hidden).
+
+**Visible controls.** Build, Step, Run. Take Control if `!userTookControl`. Apply hidden (Apply is MANUAL-only). Stop hidden (nothing to stop).
+
+**Scenario IDs.**
+- `S-build-halted` — reload, → IDLE / MANUAL by `userTookControl`. See §7.
+- `S-step-halted-{off,on}` — cold-start Step. See §7.
+- `S-run-halted-{off,on}-{auto,cont}` — cold-start Run. See §7.
+- `S-takectl-halted` — `userTookControl = true`, → MANUAL. Available only when `!userTookControl`.
+
+HALTED can be reached from any non-resting state. Build / Step / Run from HALTED, plus error and timeout handling, are walk-throughs in §10.

--- a/docs/superpowers/plans/2026-05-09-execution-model-spec.md
+++ b/docs/superpowers/plans/2026-05-09-execution-model-spec.md
@@ -1,0 +1,948 @@
+# Execution-model behavioral spec — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land `docs/execution-model.md` as the canonical execution-model and debugger reference. Replace the duplicated runtime-behavior sections in `CLAUDE.md` with a one-line link. Closes [#46](https://github.com/mellonis/machines-demo/issues/46). Unblocks [#47](https://github.com/mellonis/machines-demo/issues/47) (test infrastructure).
+
+**Architecture:** New 13-section Markdown doc with three Mermaid diagrams (master state diagram, cold-start flowchart, paused-cycle sequence diagram). Documents the **ideal** behavior; known divergences from today's code are listed in §11 with tracking-issue links so #47 can write tests against the ideal and `it.skip` the divergent ones until they close. `CLAUDE.md` edit removes ~50 lines of duplicated runtime-behavior content and adds a one-line link. No source-code changes.
+
+**Tech Stack:** GitHub-flavored Markdown, Mermaid (`stateDiagram-v2`, `flowchart`, `sequenceDiagram`).
+
+**Spec (source of truth for content):** `docs/superpowers/specs/2026-05-08-execution-model-spec-design.md`
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `docs/execution-model.md` | **Create** — 13 sections, three Mermaid diagrams. New canonical reference. |
+| `CLAUDE.md` | **Modify** — strip "Execution modes" table (~30 lines starting at "## Execution modes") and "Debugger UX (debug mode + breakpoints)" section; replace both with a one-line link. |
+
+---
+
+## Verification model
+
+No code changes, no test runner involved. Each task that adds content finishes with:
+
+1. **Render check.** Open the doc in an IDE markdown preview with Mermaid support (VS Code + "Markdown Preview Mermaid Support" extension renders inline; alternatively push to a draft PR and view on GitHub). Verify:
+   - All Mermaid blocks render visually, not as raw text
+   - Internal links (`§N`, file links) resolve
+   - Tables render with all columns
+   - No broken markdown formatting
+2. **Scenario ID grep** (when the task adds IDs). Run `grep -oE 'S-[a-z-]+' docs/execution-model.md | sort -u` to spot duplicates / typos. Compare against the §Scenario ID grammar in the spec design.
+3. **Commit.**
+
+Diagrams must use **plain Mermaid syntax only** (no YAML frontmatter, no HTML tags like `<br/>`, no light-fill `classDef` colors that fail on GitHub's dark theme). The spec design's §Diagram shapes section restates this constraint with examples.
+
+A final review task (Task 14) does a full sweep: scenario-ID dedup, all §N cross-refs, all three Mermaid blocks rendering on GitHub.
+
+---
+
+## Task 1: Scaffold + Overview (§1)
+
+**Files:**
+- Create: `docs/execution-model.md`
+
+- [ ] **Step 1: Create the file with title, intro, and master state diagram**
+
+Create `docs/execution-model.md` with this content:
+
+````markdown
+# Execution model and debugger semantics
+
+> Canonical reference for what each mode does, what each user action triggers, and where the machine lands. Tests in [#47](https://github.com/mellonis/machines-demo/issues/47) cite the scenario IDs (`S-...`) defined throughout. Working conventions and file structure remain in [`CLAUDE.md`](../CLAUDE.md).
+
+## 1. Overview
+
+The demo runs user-typed JavaScript inside a Web Worker that drives a `@turing-machine-js/machine` v4 instance. The main thread tracks the worker's progress with a 7-mode state machine: three resting states (DEMO, IDLE, MANUAL), three running states (RUNNING_AUTO, RUNNING_CONTINUOUS, RUNNING_PAUSED), and one terminal (HALTED).
+
+Most user actions are mode transitions; a few — debug toggle, withPause toggle, Apply — are flag changes or in-place mirror writes that don't move the mode.
+
+The diagram below shows every mode-to-mode user-action edge. Conditions appear inline in `[brackets]`; alternations use `or`. Event-driven exits (run completion, error, timeout, truncation, build error) are summarized in the bottom note.
+
+```mermaid
+stateDiagram-v2
+    [*] --> DEMO
+
+    DEMO --> IDLE : Build
+    DEMO --> RUNNING_PAUSED : Step (cold-start)
+    DEMO --> RUNNING_AUTO : Run [withPause=on]
+    DEMO --> RUNNING_CONTINUOUS : Run [withPause=off]
+    DEMO --> MANUAL : Take Control
+
+    IDLE --> IDLE : Build
+    IDLE --> RUNNING_PAUSED : Step (cold-start)
+    IDLE --> RUNNING_AUTO : Run [withPause=on]
+    IDLE --> RUNNING_CONTINUOUS : Run [withPause=off]
+    IDLE --> MANUAL : Take Control
+
+    MANUAL --> MANUAL : Build or Apply
+    MANUAL --> RUNNING_PAUSED : Step (cold-start)
+    MANUAL --> RUNNING_AUTO : Run [withPause=on]
+    MANUAL --> RUNNING_CONTINUOUS : Run [withPause=off]
+
+    RUNNING_AUTO --> RUNNING_PAUSED : Pause
+    RUNNING_AUTO --> RUNNING_PAUSED : break [debug=on]
+    RUNNING_AUTO --> HALTED : Stop or completion
+    RUNNING_AUTO --> MANUAL : Take Control
+
+    RUNNING_CONTINUOUS --> RUNNING_PAUSED : break [debug=on]
+    RUNNING_CONTINUOUS --> HALTED : Stop or completion
+    RUNNING_CONTINUOUS --> MANUAL : Take Control
+
+    RUNNING_PAUSED --> RUNNING_PAUSED : Step or next break
+    RUNNING_PAUSED --> RUNNING_AUTO : Continue [withPause=on]
+    RUNNING_PAUSED --> RUNNING_CONTINUOUS : Continue [withPause=off]
+    RUNNING_PAUSED --> HALTED : Stop or Continue→halt
+    RUNNING_PAUSED --> MANUAL : Take Control
+
+    HALTED --> IDLE : Build [!userTookControl]
+    HALTED --> MANUAL : Build [userTookControl]
+    HALTED --> RUNNING_PAUSED : Step (cold-start)
+    HALTED --> RUNNING_AUTO : Run [withPause=on]
+    HALTED --> RUNNING_CONTINUOUS : Run [withPause=off]
+    HALTED --> MANUAL : Take Control [!userTookControl]
+
+    note right of HALTED : Error, timeout, truncation, or cold-start build error from any non-resting state lands HALTED.
+```
+````
+
+- [ ] **Step 2: Render check**
+
+Open `docs/execution-model.md` in your IDE's markdown preview with Mermaid rendering, OR commit and view on GitHub. Confirm the state diagram renders with all 7 modes and labeled edges (no raw `stateDiagram-v2` text).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): scaffold + master state diagram (§1)"
+```
+
+---
+
+## Task 2: Mode reference (§2)
+
+**Files:**
+- Modify: `docs/execution-model.md`
+
+- [ ] **Step 1: Append the Mode reference section**
+
+Append this content to `docs/execution-model.md`:
+
+```markdown
+## 2. Mode reference
+
+Three lines per mode: what it means, how it's entered, how it's exited. UI / log detail belongs in §8 Action matrix and §10 walk-throughs.
+
+### DEMO
+Page-load entry state. A timer-based loop generates random commands and applies them to the mirror, demonstrating the machine without user input. `userTookControl` is false; auto-loop is live.
+Entry: page load only.
+Exit: Build (→ IDLE), Step or Run (→ RUNNING_*; cold-start path), Take Control (→ MANUAL).
+
+### IDLE
+Uncommitted resting state. The user has signaled intent (Build / Step / Run from DEMO, or completed a run from IDLE-track) but has not yet taken control. Auto-loop is dead. Apply is hidden. Take Control is visible.
+Entry: Build / Step / Run from DEMO; post-RUNNING_* completion when `!userTookControl`; Build from HALTED when `!userTookControl`.
+Exit: Build (→ IDLE, reload), Take Control (→ MANUAL), Step (→ RUNNING_PAUSED), Run (→ RUNNING_AUTO / RUNNING_CONTINUOUS).
+
+### MANUAL
+Committed resting state. The user drives the machine via Apply. Worker is built but idle (no run/step pending). Take Control is hidden (already taken).
+Entry: Take Control from any non-MANUAL mode; post-RUNNING_* completion or Build from HALTED when `userTookControl`.
+Exit: Step / Run via §7 cold-start (→ RUNNING_AUTO / RUNNING_CONTINUOUS / RUNNING_PAUSED), Build (→ MANUAL, reload), Apply (stays MANUAL, writes to mirror).
+
+### RUNNING_AUTO
+The worker is running inside `machine.run({ onStep })` with a per-step throttle (the `withPause` interval). Belt animations follow the cadence; the user can click Pause to suspend.
+Entry: Run from IDLE / MANUAL / HALTED with `withPause=on`; Continue from RUNNING_PAUSED with `withPause=on`.
+Exit: Pause (→ RUNNING_PAUSED), debug break with `debug=on` (→ RUNNING_PAUSED), Stop (→ HALTED), run completion (→ HALTED), Take Control (→ MANUAL).
+
+### RUNNING_CONTINUOUS
+The worker is running inside `machine.run({ onStep })` with no throttle — snap-to-final. Belt animation is suppressed; per-step commands batch-log on completion. Same control surface as RUNNING_AUTO.
+Entry: Run from IDLE / MANUAL / HALTED with `withPause=off`; Continue from RUNNING_PAUSED with `withPause=off`.
+Exit: debug break with `debug=on` (→ RUNNING_PAUSED), Stop (→ HALTED), run completion (→ HALTED), Take Control (→ MANUAL).
+
+### RUNNING_PAUSED
+The worker is suspended inside `machine.run()` awaiting a `resume` message from the main thread. Reachable from any RUNNING_* mode via debug break, click-pause, or cold-start arming. The button labeled "Run" elsewhere reads "Continue" here.
+Entry: cold-start Step (arms `initialState.debug.after`); break fires from RUNNING_AUTO / RUNNING_CONTINUOUS with `debug=on`; click-pause from RUNNING_AUTO; Step self-loop from RUNNING_PAUSED.
+Exit: Step (arm next `.after`, → RUNNING_PAUSED via re-pause), Continue (→ RUNNING_AUTO / RUNNING_CONTINUOUS for the duration of the resume), Stop (terminate worker → HALTED), Take Control (→ MANUAL).
+
+### HALTED
+Terminal state. The machine reached its halt state, errored, timed out, or hit `MAX_STEPS` truncation. Tape is frozen at the final state. Build / Step / Run reload-from-code. Take Control is visible only when `!userTookControl`.
+Entry: run completion, Stop, error, timeout, or truncation from any RUNNING_*; build error from any cold-start.
+Exit: Build (→ IDLE if `!userTookControl`, → MANUAL if `userTookControl`), Step / Run (→ RUNNING_* via cold-start), Take Control (→ MANUAL, only if `!userTookControl`).
+```
+
+- [ ] **Step 2: Render check**
+
+Verify all 7 mode cards display as headings with their three labeled lines. No broken markdown.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): mode reference (7 cards) (§2)"
+```
+
+---
+
+## Task 3: Flag reference (§3)
+
+**Files:**
+- Modify: `docs/execution-model.md`
+
+- [ ] **Step 1: Append the Flag reference section**
+
+Append this content to `docs/execution-model.md`:
+
+```markdown
+## 3. Flag reference
+
+Four flags govern transitions and per-action behavior. Three are user-visible UI controls; one is a sticky latch.
+
+- **`debugMode`** — `boolean`. UI checkbox in the Toolbar, persisted to `localStorage:machines-demo:<engine>:debugMode`. Gates whether user-authored `state.debug` / `haltState.debug` breaks pause execution. Mid-run toggle pushes `setDebug(on)` to the worker (the only mode-aware effect on a flag toggle).
+- **`withPause`** — `boolean`. UI checkbox + interval input in the Toolbar. Selects RUNNING_AUTO (with throttle) vs RUNNING_CONTINUOUS (snap-to-final) on the next Run. The toggle itself (`S-withpause-toggle`) has no immediate runtime effect; it's read at Run-click time.
+- **`halted`** — `boolean`. Derived from worker `built` / `ran` / `error` responses. Drives the HALTED-mode transition.
+- **`userTookControl`** — `boolean`. Sticky latch, starts `false`, set `true` on Take Control click, never re-enables. Marks the "manual track": after RUNNING_* / HALTED, post-action mode resolution lands MANUAL when true, IDLE when false.
+
+The `demoEnabled` flag from earlier versions of the code is dropped — the DEMO ↔ IDLE mode distinction encodes "is the auto-loop alive" directly.
+```
+
+- [ ] **Step 2: Render check + scenario-ID grep**
+
+```bash
+grep -oE 'S-[a-z-]+' docs/execution-model.md | sort -u
+```
+
+Expected: `S-withpause-toggle` (added in this task) plus IDs from prior tasks.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): flag reference (4 flags) (§3)"
+```
+
+---
+
+## Task 4: DEMO mode (§4)
+
+**Files:**
+- Modify: `docs/execution-model.md`
+
+- [ ] **Step 1: Append the DEMO section**
+
+Append this content to `docs/execution-model.md`:
+
+```markdown
+## 4. DEMO mode
+
+DEMO is the page-load entry state — a teaser that shows the machine reacting to inputs without requiring the user to do anything. The demo loop fires on a timer (~1 Hz) and applies one randomly chosen command per tick, drawn from the current tape's alphabet (40 % chance the head stays put with no write; otherwise pick a random symbol and a random direction).
+
+The loop is entirely a main-thread effect; the worker doesn't see DEMO. The mirror machine receives commands directly via the same `ifOtherSymbol` one-step path used by Apply.
+
+**Exits.** DEMO → IDLE on Build / Step / Run (cold-start path; the click signals intent and kills the loop); DEMO → MANUAL on Take Control (the user commits to the manual track). Errors during cold-start lead → HALTED via the cold-start error branch.
+
+**Visible controls.** Build, Step, Run, Take Control. Apply is hidden (the loop generates commands itself; there's no role for a user-fired Apply in DEMO). Stop is hidden (no worker-side run to interrupt).
+
+**Scenario IDs.**
+- `S-build-demo` — reload, → IDLE.
+- `S-step-demo-{off,on}` — cold-start Step. Worker arms `initialState.debug.after = true`, runs, → RUNNING_PAUSED. Per §7.
+- `S-run-demo-{off,on}-{auto,cont}` — cold-start Run. → RUNNING_AUTO or RUNNING_CONTINUOUS by withPause. Per §7.
+- `S-takectl-demo` — `userTookControl = true`, → MANUAL.
+
+DEMO is entered only on initial page load. After any of the exits above, the user never returns to DEMO.
+```
+
+- [ ] **Step 2: Scenario-ID grep + render check**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): DEMO mode (§4)"
+```
+
+---
+
+## Task 5: IDLE mode (§5)
+
+**Files:**
+- Modify: `docs/execution-model.md`
+
+- [ ] **Step 1: Append the IDLE section**
+
+Append this content to `docs/execution-model.md`:
+
+```markdown
+## 5. IDLE mode
+
+IDLE is the post-interaction, pre-Take-Control resting state. The user has clicked Build / Step / Run (from DEMO or after a previous run) but hasn't committed to the manual track. The auto-loop is dead; the worker is built; the panel mirrors the worker's state but is read-only.
+
+IDLE differs from MANUAL only by the `userTookControl` latch — once Take Control fires, IDLE → MANUAL and never returns.
+
+**Exits.** Build (→ IDLE, reload — same code, fresh worker); Step / Run (→ RUNNING_*; cold-start path); Take Control (→ MANUAL, latch flips). Errors during cold-start lead → HALTED via the cold-start error branch.
+
+**Visible controls.** Build, Step, Run, Take Control. Apply is hidden (Apply is MANUAL-only). Stop is hidden (no run in flight).
+
+**Scenario IDs.**
+- `S-build-idle` — reload, → IDLE.
+- `S-step-idle-{off,on}` — cold-start Step. Per §7.
+- `S-run-idle-{off,on}-{auto,cont}` — cold-start Run. Per §7.
+- `S-takectl-idle` — `userTookControl = true`, → MANUAL.
+
+A user who has run a machine to completion without ever clicking Take Control returns to IDLE — the spec preserves the IDLE track until the user explicitly opts in to MANUAL.
+```
+
+- [ ] **Step 2: Render check**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): IDLE mode (§5)"
+```
+
+---
+
+## Task 6: MANUAL mode (§6) with Apply scenarios
+
+**Files:**
+- Modify: `docs/execution-model.md`
+
+- [ ] **Step 1: Append the MANUAL section**
+
+Append this content to `docs/execution-model.md`:
+
+```markdown
+## 6. MANUAL mode
+
+MANUAL is the committed resting state. `userTookControl = true`; the user is driving the machine via Apply. The panel is enabled and the user composes a `Command` (movement + symbol) which writes to the mirror via the same `ifOtherSymbol` one-step state used internally by Step.
+
+Once entered, MANUAL is sticky: subsequent Build / Step / Run / completion all return to MANUAL.
+
+**Exits.** Build (→ MANUAL, reload); Step / Run (→ RUNNING_*; cold-start); Apply (stays MANUAL, in-place mirror write). Errors during cold-start lead → HALTED.
+
+**Visible controls.** Build, Step, Run, Apply. Take Control is hidden (already taken). Stop is hidden (no run in flight).
+
+**Apply scenario.**
+- `S-apply-manual` — main thread applies the user-composed `Command` to `mirrorMachine` via the `ifOtherSymbol` one-step state. No worker round-trip; the worker stays idle. Mode stays MANUAL. The log gets a single command entry per Apply.
+
+The Apply button is **hidden** in DEMO, IDLE, and HALTED — it's MANUAL-only. Earlier code variants displayed a flashing "next random command" Apply button in DEMO; the spec drops that affordance and lets the DEMO loop render its commands inline on the panel.
+
+**Cold-start scenarios from MANUAL.** See §7.
+- `S-build-manual` — reload, → MANUAL.
+- `S-step-manual-{off,on}` — cold-start Step.
+- `S-run-manual-{off,on}-{auto,cont}` — cold-start Run.
+```
+
+- [ ] **Step 2: Render check + scenario-ID grep**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): MANUAL mode + Apply scenarios (§6)"
+```
+
+---
+
+## Task 7: Cold-start (§7) with flowchart
+
+**Files:**
+- Modify: `docs/execution-model.md`
+
+- [ ] **Step 1: Append §7 opening, cold-start sub-section, and the flowchart**
+
+Append this content to `docs/execution-model.md`:
+
+````markdown
+## 7. Starting and resuming runs
+
+The cold-start path (Build / Step / Run from IDLE, MANUAL, or HALTED — and DEMO's user-clicked equivalent) is unified: reload the worker, then either land back in a resting mode (Build) or enter `machine.run()` (Step / Run). The Resume sub-section covers Continue from RUNNING_PAUSED, which uses the same in-flight `run()` rather than reloading.
+
+### Cold-start
+
+The path is identical from IDLE, MANUAL, and HALTED. Each Build / Step / Run reloads the worker, builds a fresh mirror, then routes by action:
+
+- **Build** — reload only. → IDLE if `!userTookControl`, → MANUAL if `userTookControl`.
+- **Step** — reload, arm `initialState.debug.after = true` (preserving any user-authored `state.debug.before`), call `runner.run({ debug: debugMode, step: true })`. Worker pauses at iter 1's after-fire → RUNNING_PAUSED. With `debug=on` and a user-authored `state.debug.before` on `initialState`, the before-fire interposes first; same target mode.
+- **Run** — reload, call `runner.run({ debug: debugMode })`. → RUNNING_AUTO (`withPause=on`, with throttled `onStep`) or RUNNING_CONTINUOUS (`withPause=off`, no throttle). Debug breaks during the run land → RUNNING_PAUSED.
+
+If the reload itself fails (build error in user code), → HALTED with an error log; covered by walk-through 7.
+
+```mermaid
+flowchart TD
+    Start([User clicks Build, Step, or Run from IDLE / MANUAL / HALTED])
+    Start --> Reload[reload worker — build, mirror, alphabets]
+    Reload --> Action{which action?}
+    Reload -. build error .-> ErrorOut[→ HALTED with error log]
+    Action -->|Build| Resolve1{userTookControl?}
+    Resolve1 -->|true| ManualOut[→ MANUAL]
+    Resolve1 -->|false| IdleOut[→ IDLE]
+    Action -->|Step| ArmAfter[arm initialState.debug.after = true; preserve user-authored .before]
+    ArmAfter --> RunStep[runner.run debug=debugMode, step=true]
+    RunStep --> PauseOut[→ RUNNING_PAUSED at iter 1 after-fire]
+    Action -->|Run| WithPause{withPause?}
+    WithPause -->|true| RunAuto[runner.run debug=debugMode, with throttled onStep]
+    RunAuto --> AutoOut[→ RUNNING_AUTO]
+    WithPause -->|false| RunCont[runner.run debug=debugMode, no throttle]
+    RunCont --> ContOut[→ RUNNING_CONTINUOUS]
+    AutoOut -. user-authored break .-> PauseOut
+    ContOut -. user-authored break .-> PauseOut
+    RunStep -. user-authored .before fires before iter 1 after .-> PauseOut
+```
+
+**Cold-start scenario IDs.** Each origin (IDLE / MANUAL / HALTED) gets the same set:
+
+- `S-build-{idle,manual,halted}` — reload, → IDLE / MANUAL by `userTookControl`.
+- `S-step-{idle,manual,halted}-{off,on}` — Step cold-start. Off / on selects `debug` flag.
+- `S-run-{idle,manual,halted}-{off,on}-{auto,cont}` — Run cold-start. Off / on selects `debug`; auto / cont selects `withPause`.
+
+**DEMO origin.** Build / Step / Run from DEMO uses the same cold-start path; the click signals intent (kills the auto-loop) but doesn't flip `userTookControl`, so post-RUNNING_* completion and Build resolution land IDLE. Scenario IDs `S-build-demo`, `S-step-demo-{off,on}`, `S-run-demo-{off,on}-{auto,cont}` mirror the IDLE entries.
+
+**Post-RUNNING_* completion** — when a run reaches halt naturally (or via Stop), the resolution is HALTED. The next Build / Step / Run from HALTED then resolves to IDLE or MANUAL by `userTookControl`. The track is preserved across the run.
+````
+
+- [ ] **Step 2: Render check**
+
+Verify the flowchart renders. Confirm the dotted "build error" and "user-authored break" edges appear distinct from the solid main flow.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): cold-start sub-section + flowchart (§7)"
+```
+
+---
+
+## Task 8: Resume from PAUSED (§7 cont'd)
+
+**Files:**
+- Modify: `docs/execution-model.md`
+
+- [ ] **Step 1: Append the Resume sub-section**
+
+Append this content to `docs/execution-model.md`:
+
+```markdown
+### Resume from PAUSED
+
+The Run / Continue button (Run while in RUNNING_PAUSED) doesn't reload — it sends `runner.resume({ step: false })` and the worker continues inside the same in-flight `machine.run()` invocation. Two outcomes by `debug`:
+
+- `S-continue-paused-off` — `runner.resume({ step: false })`. Debug breaks are not honored (worker-side `debugEnabled = false`), so the run continues to halt → HALTED on completion. Stop / error / timeout still terminate the worker normally.
+- `S-continue-paused-on` — `runner.resume({ step: false })`. Debug breaks fire as encountered → next RUNNING_PAUSED. The user can click Continue again, repeating across multiple paused / resume cycles until halt or Stop.
+
+The button's label changes by mode: "Run" in non-PAUSED modes (cold-start), "Continue" in RUNNING_PAUSED. Same underlying action class; the label just clarifies intent.
+
+Walk-through 3 expands these scenarios with per-segment timer behavior, log replay, and edge cases.
+```
+
+- [ ] **Step 2: Render check + scenario-ID grep**
+
+```bash
+grep -oE 'S-[a-z-]+' docs/execution-model.md | sort -u
+```
+
+Expected: `S-continue-paused-off` and `S-continue-paused-on` newly present.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): resume from PAUSED sub-section (§7 cont'd)"
+```
+
+---
+
+## Task 9: Action matrix (§8)
+
+**Files:**
+- Modify: `docs/execution-model.md`
+
+- [ ] **Step 1: Append the Action matrix section**
+
+Append this content to `docs/execution-model.md`:
+
+```markdown
+## 8. Action matrix
+
+Mode-transition outcomes for user actions across the three running / paused modes. Each cell is a scenario ID + one-line outcome, or `—` for hidden / disabled.
+
+**Matrix scope.** The matrix lists *user-action* exits only. Event-driven transitions — debug break firing, run completion, error, timeout, truncation — are not matrix rows. They appear in three other places: §1's master state diagram (edges), each mode's "Exit" line in §2 Mode reference, and walk-throughs 2 and 7-9. A reader looking only at the matrix should not conclude that, e.g., RUNNING_CONTINUOUS exits only via Stop or Take Control.
+
+| Action | RUNNING_AUTO | RUNNING_CONTINUOUS | RUNNING_PAUSED |
+|---|---|---|---|
+| **Step (debug=off)** | `S-step-auto-off`: pause label — suspend run loop, → PAUSED | — | `S-step-paused-off`: arm `.after` on next state, resume(step), → PAUSED |
+| **Step (debug=on)** | `S-step-auto-on`: pause label — suspend, → PAUSED | — | `S-step-paused-on`: arm `.after`, resume(step), → PAUSED (a user break may interpose first) |
+| **Stop** | `S-stop-auto`: terminate, → HALTED | `S-stop-cont`: terminate, → HALTED | `S-stop-paused`: terminate, suppress failHalted, → HALTED |
+| **Take Control** | `S-takectl-auto`: latch userTookControl=true, terminate, → MANUAL | `S-takectl-cont`: latch, terminate, → MANUAL | `S-takectl-paused`: latch, terminate, → MANUAL |
+
+Notes:
+- Every cell is a mode transition (or `—` for hidden / disabled). Flag-change actions (debug toggle, withPause toggle) live in §3 — they don't cause mode transitions.
+- **Build is hidden in RUNNING_AUTO / RUNNING_CONTINUOUS / RUNNING_PAUSED** — a pending worker request blocks Build. To rebuild, the user clicks Stop or Take Control first (terminate the worker), then Build is available from HALTED / MANUAL.
+- All RUNNING_* paths use `run()`. "Pause" from RUNNING_AUTO suspends inside run-mode (the throttle's setTimeout) and lands in PAUSED — the same paused state used by debug breaks.
+- **RUNNING_CONTINUOUS has the same control surface as RUNNING_AUTO** — Stop, Take Control, debug toggle all available. The modes differ only in throttle / animation; the control surface does not become a third axis of difference. Take Control mid-CONTINUOUS can lose the race to completion, but no race produces a broken state — terminate-or-complete are both clean exits.
+- Run / Continue is a single-column action (only meaningful from RUNNING_PAUSED). It's documented in §7 Resume from PAUSED rather than in the matrix.
+- DEMO, IDLE, MANUAL, HALTED are not matrix columns — they have their own sections (§4, §5, §6, §9).
+```
+
+- [ ] **Step 2: Render check + scenario-ID grep**
+
+Confirm the table renders with all 4 columns and the matrix cells contain scenario IDs in monospace.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): action matrix (§8)"
+```
+
+---
+
+## Task 10: HALTED mode (§9)
+
+**Files:**
+- Modify: `docs/execution-model.md`
+
+- [ ] **Step 1: Append the HALTED section**
+
+Append this content to `docs/execution-model.md`:
+
+```markdown
+## 9. HALTED mode
+
+HALTED is the terminal state — the machine reached its halt state, was stopped, or hit an error / timeout / `MAX_STEPS` truncation. The tape is frozen at the final state; the worker is alive but idle (no run in flight). Build / Step / Run reload-from-code; Take Control flips the latch.
+
+**Exits.** Build (→ IDLE if `!userTookControl`, → MANUAL if `userTookControl`), Step / Run (→ RUNNING_* via cold-start, see §7), Take Control (→ MANUAL, only when `!userTookControl` — otherwise the button is hidden).
+
+**Visible controls.** Build, Step, Run. Take Control if `!userTookControl`. Apply hidden (Apply is MANUAL-only). Stop hidden (nothing to stop).
+
+**Scenario IDs.**
+- `S-build-halted` — reload, → IDLE / MANUAL by `userTookControl`. See §7.
+- `S-step-halted-{off,on}` — cold-start Step. See §7.
+- `S-run-halted-{off,on}-{auto,cont}` — cold-start Run. See §7.
+- `S-takectl-halted` — `userTookControl = true`, → MANUAL. Available only when `!userTookControl`.
+
+HALTED can be reached from any non-resting state. Build / Step / Run from HALTED, plus error and timeout handling, are walk-throughs in §10.
+```
+
+- [ ] **Step 2: Render check + scenario-ID grep**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): HALTED mode (§9)"
+```
+
+---
+
+## Task 11: Walk-throughs §10 part 1 — Step from PAUSED, Run with breakpoints, Continue (with sequence diagram)
+
+**Files:**
+- Modify: `docs/execution-model.md`
+
+- [ ] **Step 1: Append the §10 opening + walk-throughs 1–3**
+
+Append this content to `docs/execution-model.md`:
+
+````markdown
+## 10. Scenario walk-throughs
+
+Each walk-through expands a contested or non-obvious path with sequence, log entries, worker calls, and edge cases. Boundary cases only — straightforward paths (Build, Apply, cold-start Run with no breaks) are sufficiently covered by the matrix and §7.
+
+### `S-step-paused-off` / `S-step-paused-on` — Step from break
+
+**Sequence**
+1. User clicks Step while in RUNNING_PAUSED.
+2. Main thread arms `.after` on the relevant state — `m.state` if the current pause was a `before`-fire, `m.nextState` if it was an `after`-fire. The mutation is captured in `pendingRestore` for later un-application.
+3. `runner.resume({ step: true })` resolves the worker's pending Promise with the step intent.
+4. Worker un-applies any prior `pendingRestore`, then runs until the armed `.after` fire (or until a user-authored break interposes when `debug=on`).
+5. Worker sends `paused`; main thread enters RUNNING_PAUSED with the new break info, runs `pendingRestore` for the new arm.
+
+**Log entries**
+- `paused at state <X> after applying command for symbols: [<syms>]`
+
+**Worker calls**
+- `resume({ step: true })`
+
+**Edge cases**
+- `debug=on`: a user-authored `.before` may interpose before the armed `.after` fires. Both produce a normal `paused` response; the long-format log line distinguishes them by `before` vs `after`.
+- The halting iter's armed `.after` never fires (engine quirk). If the next iter halts the machine, the worker sends `ran` instead of a final `paused` — the run lands in HALTED. Tracked in [turing-machine-js#108](https://github.com/mellonis/turing-machine-js/issues/108).
+
+The sequence diagram below shows the complete cycle: Run (debug=on) → break → Step → re-pause → Continue → halt or further breaks.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Main as Main thread (MachineView)
+    participant Worker
+    participant Engine as machine.run()
+
+    User->>Main: click Run [debug=on]
+    Main->>Worker: postMessage { type: 'run', debug: true }
+    Worker->>Engine: machine.run({ onDebugBreak })
+    Engine-->>Worker: yield N, state.debug.before fires
+    Worker-->>Main: { type: 'paused', state, currentSymbols, debugBreak: { before: true } }
+    Note over Worker: timer suspended
+    Note over Main: → RUNNING_PAUSED — log paused at state X before applying ...
+
+    User->>Main: click Step
+    Main->>Main: arm m.state.debug.after = true (pendingRestore captured)
+    Main->>Worker: postMessage { type: 'resume', step: true }
+    Note over Worker: timer restarted
+    Worker->>Engine: resolve onDebugBreak Promise
+    Engine-->>Worker: yield N+1, state.debug.after fires (armed)
+    Worker->>Worker: pendingRestore() — undo arm
+    Worker-->>Main: { type: 'paused', debugBreak: { after: true } }
+    Note over Worker: timer suspended
+    Note over Main: → RUNNING_PAUSED — log paused at state X after applying ...
+
+    User->>Main: click Run (Continue)
+    Main->>Worker: postMessage { type: 'resume', step: false }
+    Note over Worker: timer restarted
+    Worker->>Engine: resolve
+    alt run completes naturally
+        Engine-->>Worker: ... runs to halt
+        Worker-->>Main: { type: 'ran', tapes, commands }
+        Note over Main: → HALTED — log halted after N step(s)
+    else another debug break fires (debug=on)
+        Engine-->>Worker: yield M, state.debug.before fires
+        Worker-->>Main: { type: 'paused', state, currentSymbols, debugBreak: { before: true } }
+        Note over Main: → RUNNING_PAUSED — back to the break-cycle above
+    end
+```
+
+### Walk-through 2 — Run with breakpoints (multi-paused cycle)
+
+A Run with `debug=on` and user-authored `state.debug` triggers a sequence of paused / resume cycles. Each `paused` includes the current state, current symbols, and the `debugBreak` shape (`{ before: true }` or `{ after: true }`).
+
+**Per-segment timer.** The worker's per-segment `WORKER_TIMEOUT_MS` (5 s) suspends on every `paused` and restarts on every `resume`-send. A user inspecting a paused state for minutes does not trigger the timeout; only worker-side execution time counts.
+
+**Log replay.** Each `paused` carries a `commands` array — the per-step commands buffered between this `paused` and the previous one. The main thread appends them to the log in order, so the trace is preserved across pauses without the worker re-sending the full history.
+
+**Edge case — Stop while paused.** Worker is terminated; `runner.run()` rejects; `failHalted` is suppressed via `stopRequested`. Mode → HALTED with a `stopped` log entry. See walk-through 4.
+
+### Walk-through 3 — Continue from break (`S-continue-paused-{off,on}`)
+
+**Sequence (debug=off).**
+1. User clicks Run while in RUNNING_PAUSED. The button reads "Continue".
+2. Main thread sends `resume({ step: false })`.
+3. Worker resolves the pending Promise. `debugEnabled = false` so `onDebugBreak` returns immediately on subsequent breaks.
+4. Run continues to halt; worker sends `ran` → HALTED.
+
+**Sequence (debug=on).**
+1. Same start.
+2. Worker resolves; `debugEnabled = true` so subsequent breaks pause normally.
+3. Run continues until next break (→ another `paused` → RUNNING_PAUSED again), Stop, or halt (→ HALTED).
+
+**Log entries**
+- (debug=off, halt) `halted after N step(s)`
+- (debug=on, next break) — same long-format line as walk-through 1's log: `paused at state <X> {before|after} applying command for symbols: [<syms>]`
+
+**Worker calls**
+- `resume({ step: false })`
+````
+
+- [ ] **Step 2: Render check**
+
+Verify the sequence diagram renders. Confirm the `alt`/`else` branch shows two outcomes for the Continue path.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): walk-throughs 1–3 + sequence diagram (§10)"
+```
+
+---
+
+## Task 12: Walk-throughs §10 part 2 — Stop, debug toggle, Take Control
+
+**Files:**
+- Modify: `docs/execution-model.md`
+
+- [ ] **Step 1: Append walk-throughs 4–6**
+
+Append this content to `docs/execution-model.md`:
+
+```markdown
+### Walk-through 4 — Stop from each running mode
+
+Stop is visible while in RUNNING_AUTO, RUNNING_CONTINUOUS, and RUNNING_PAUSED.
+
+- `S-stop-auto` / `S-stop-cont` — main thread calls `runner.terminate()`. Worker is killed; `runner.run()` rejects with `runner terminated`. `failHalted` runs: rebuild mirror from worker's last-known tape state (or zeroed state if none), → HALTED with `stopped` log entry.
+- `S-stop-paused` — same as above, but `stopRequested` is set on the runner first so `failHalted` is **suppressed** when the rejected Promise surfaces (the rejection is the expected outcome of Stop, not an error). → HALTED with `stopped` log entry only — no error log.
+
+**Log entries**
+- `stopped`
+- (state mirror snapshot in matrix view)
+
+**Edge case.** A Stop click that races with run completion: worker may have already sent `ran` when `terminate()` is called. The runner's `runPending` slot has been cleared; `terminate()` is a no-op on the runner side. The HALTED transition still happens via the normal completion path, with a `halted after N step(s)` log entry instead of `stopped`. No user-visible bug.
+
+### Walk-through 5 — debug toggle mid-run
+
+The `debugMode` UI checkbox is reactive across mode transitions. A change while in any RUNNING_* mode pushes `setDebug(on)` to the worker.
+
+- `S-debug-toggle-auto` / `S-debug-toggle-cont` — `runner.setDebug(on)` posts a fire-and-forget message. Worker flips an internal `debugEnabled` flag. Subsequent `onDebugBreak` calls honor the new value (no run restart).
+- `S-debug-toggle-paused` — same `setDebug()` send. The current paused state is unaffected; the next break (after Continue) is gated by the new flag value.
+- In DEMO / IDLE / MANUAL / HALTED — flag flip only; no worker call (the worker is idle, the flag is read at the next `run()`).
+
+**Log entries**
+- (none — toggle is silent)
+
+**Edge case.** Toggling debug=on while paused doesn't cause an immediate break — the user is already paused. After Continue, breaks fire normally.
+
+### Walk-through 6 — Take Control mid-run
+
+Take Control is visible in DEMO, IDLE (visible during cold-start RUNNING_*), HALTED (when `!userTookControl`), and any RUNNING_* mode.
+
+- `S-takectl-auto` / `S-takectl-cont` / `S-takectl-paused` — main thread calls `runner.terminate()`. Worker is killed; `runner.run()` rejects via `rejectAll`. `userTookControl = true`. `failHalted` is suppressed via the same path as `S-stop-paused`. Mode → MANUAL.
+- `S-takectl-demo` / `S-takectl-idle` — no run in flight, just latch + mode change. → MANUAL.
+- `S-takectl-halted` — `userTookControl = true`, → MANUAL. Available only when `!userTookControl`.
+
+**Log entries**
+- `took control`
+
+**Edge case.** Take Control from RUNNING_PAUSED is functionally identical to from RUNNING_AUTO / RUNNING_CONTINUOUS — the worker is paused, but `terminate()` kills it the same way. `runPending`'s onPaused callback is never called again because the runner's pending slot is cleared on terminate.
+```
+
+- [ ] **Step 2: Render check + scenario-ID grep**
+
+```bash
+grep -oE 'S-[a-z-]+' docs/execution-model.md | sort -u
+```
+
+Expected new IDs: `S-stop-auto`, `S-stop-cont`, `S-stop-paused`, `S-debug-toggle-{auto,cont,paused}`, `S-takectl-{auto,cont,paused,demo,idle,halted}`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): walk-throughs 4–6 (Stop / debug toggle / Take Control) (§10)"
+```
+
+---
+
+## Task 13: Walk-throughs §10 part 3 — Error, Truncation, Timeout
+
+**Files:**
+- Modify: `docs/execution-model.md`
+
+- [ ] **Step 1: Append walk-throughs 7–9**
+
+Append this content to `docs/execution-model.md`:
+
+```markdown
+### Walk-through 7 — Error mid-run (and cold-start build error)
+
+Errors come from two sources:
+
+1. **Build error** — the worker's user-code build (cold-start) throws (parse error, runtime exception during initial setup). Worker sends `error` with no `tapes`. → HALTED with error log.
+2. **Mid-run error** — the worker's `machine.run()` throws (typically: no edge in the state graph for the current symbol). Worker sends `error` with partial `tapes` (the snapshot at throw-time). → HALTED with error log.
+
+Both surface as `WorkerError` in the runner; main thread's `failHalted` rebuilds the mirror from the partial `tapes` (when present) so the user sees the state where execution actually stuck — not the loaded tape with no record of the steps that ran.
+
+- `S-error-{auto,cont,paused}` — mid-run error from each running mode. Same flow.
+
+**Log entries**
+- `error: <message>`
+
+**Edge case.** Cold-start build errors don't have running-mode-specific scenario IDs in the matrix because they happen before any RUNNING_* mode is entered. Tested against from each cold-start origin (IDLE / MANUAL / HALTED / DEMO) — see §7's flowchart error branch.
+
+### Walk-through 8 — Truncation (`S-truncate-{auto,cont}`)
+
+A run that doesn't halt naturally hits `MAX_STEPS = 100_000` inside the worker's `runToEnd` cap. Worker sends `ran` with `truncated: true`.
+
+- `S-truncate-auto` / `S-truncate-cont` — main thread receives `ran`. → HALTED with `truncated: did not halt within MAX_STEPS steps` log entry. Per-step entries are **suppressed** when `truncated: true` (band-aid until [#45](https://github.com/mellonis/machines-demo/issues/45) lands; rendering 100k log entries freezes the main thread for seconds).
+
+**Log entries**
+- `truncated: did not halt within MAX_STEPS steps`
+
+**Edge case.** A debug-paused run that's then continued without `debug=off` won't truncate at the same point — the per-segment cap accrues across resume cycles, so a long-paused-then-resumed run could still hit MAX_STEPS in a later segment.
+
+### Walk-through 9 — Worker timeout per segment (`S-timeout-{auto,cont,paused}`)
+
+`WORKER_TIMEOUT_MS = 5_000` caps wall-clock time on each worker request **segment**. For `build` / `step` / `run`-without-pause it's a round-trip cap; for `run` with paused / resume cycles it's per-segment (suspends on `paused`, restarts on `resume`-send).
+
+- `S-timeout-auto` / `S-timeout-cont` — segment exceeds 5 s. Runner kills the worker (terminate) and rejects with `timeout after 5000ms — worker terminated (likely infinite loop)`. → HALTED with timeout log.
+- `S-timeout-paused` — only fires if the user clicks Continue or Step and the **resumed** segment exceeds 5 s. A paused state is not subject to timeout.
+
+**Log entries**
+- `timeout after 5000ms — worker terminated (likely infinite loop)`
+
+**Edge case.** A user code that uses `setTimeout` / async patterns inside `state.debug.before` / `state.debug.after` callbacks (if any) could ostensibly stall a segment indefinitely; the per-segment cap protects the demo from such cases.
+```
+
+- [ ] **Step 2: Render check + scenario-ID grep**
+
+Expected new IDs: `S-error-{auto,cont,paused}`, `S-truncate-{auto,cont}`, `S-timeout-{auto,cont,paused}`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): walk-throughs 7–9 (Error / Truncation / Timeout) (§10)"
+```
+
+---
+
+## Task 14: Tail sections §11 §12 §13
+
+**Files:**
+- Modify: `docs/execution-model.md`
+
+- [ ] **Step 1: Append §§11–13**
+
+Append this content to `docs/execution-model.md`:
+
+```markdown
+## 11. Current divergences from spec
+
+A punchlist of where today's code differs from the spec, each with a tracking-issue link. Acts as a TODO list for follow-up PRs; #47 cites scenario IDs and `it.skip` divergent ones until they close.
+
+- **IDLE mode does not exist.** Today's code encodes the post-Build, pre-Take-Control resting state via `(executionMode = DEMO, demoEnabled = false)`. Affects all `S-*-idle-*` IDs — they're served by `S-*-demo-*` paths today. Step from DEMO completes back to a still-running auto-loop that overwrites the result. Implementation tracked alongside [#46](https://github.com/mellonis/machines-demo/issues/46) (this spec); follow-up PR introduces IDLE and drops `demoEnabled`.
+- **RUNNING_STEP exists as a separate paused state.** Affects `S-step-auto-{off,on}` (today: → RUNNING_STEP, not PAUSED) and any `S-step-step-*` / `S-run-step-*` IDs that exist only as legacy citations. Tracked in [#43](https://github.com/mellonis/machines-demo/issues/43).
+- **Today's code names the paused-mode `RUNNING_PAUSED_AT_BREAK`.** The spec uses the shorter `RUNNING_PAUSED` (consistent with `RUNNING_AUTO` / `RUNNING_CONTINUOUS`). Cosmetic rename folded into the same alignment work as the RUNNING_STEP collapse ([#43](https://github.com/mellonis/machines-demo/issues/43)).
+- **Auto-step path uses `runner.step()`, not `run()`.** Affects all `S-step-auto-*`, `S-debug-toggle-auto` (today: flag only, no `setDebug()` call). Tracked in [#43](https://github.com/mellonis/machines-demo/issues/43).
+- **Step (debug=on) on auto-step path doesn't honor breaks.** Affects `S-step-auto-on`. Tracked in [#43](https://github.com/mellonis/machines-demo/issues/43).
+- **Halting iter's `state.debug.after` never fires.** Affects walk-through 1 edge case. Tracked in [turing-machine-js#108](https://github.com/mellonis/turing-machine-js/issues/108).
+- **`haltState.debug.after` silently ignored; `haltState.debug.before` IS honored.** Tracked in [turing-machine-js#108](https://github.com/mellonis/turing-machine-js/issues/108).
+
+## 12. Engine quirks
+
+Upstream behaviors the spec encodes (won't change without a major upstream version, so the spec works around them):
+
+- `onDebugBreak` after-fire payload substitutes `m` to `prevYield` — the un-substituted `machineState` is not exposed. Affects step-over-from-after implementations. Cross-ref [turing-machine-js#107](https://github.com/mellonis/turing-machine-js/issues/107).
+- `onStep` and `onDebugBreak` after-fire payloads carry semantically identical `MachineState`. Both hooks are documented; the demo wires both for orthogonal reasons (per-step buffer vs. pause cycle). Cross-ref [turing-machine-js#109](https://github.com/mellonis/turing-machine-js/issues/109).
+
+§11 vs §12: §11 lists demo-side gaps to be closed; §12 lists engine semantics that won't change. Items can move from §12 to §11 if the upstream issue lands and a corresponding demo-side simplification becomes possible.
+
+## 13. Cross-references
+
+- [`CLAUDE.md`](../CLAUDE.md) — working conventions, file structure, build commands. Runtime-behavior content moved here.
+- [`docs/superpowers/specs/2026-05-08-worker-run-mode-design.md`](superpowers/specs/2026-05-08-worker-run-mode-design.md) — the [#40](https://github.com/mellonis/machines-demo/issues/40) design; gives the *why* behind RUNNING_PAUSED and the worker contract.
+- [#47](https://github.com/mellonis/machines-demo/issues/47) — test infrastructure that consumes the scenario IDs defined in this doc.
+- [#46](https://github.com/mellonis/machines-demo/issues/46) — issue this spec resolves.
+```
+
+- [ ] **Step 2: Render check + final scenario-ID grep**
+
+```bash
+grep -oE 'S-[a-z-]+' docs/execution-model.md | sort -u | wc -l
+```
+
+Expected count: roughly 35–45 unique scenario IDs across all the sections.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): divergences, engine quirks, cross-refs (§§11–13)"
+```
+
+---
+
+## Task 15: CLAUDE.md edits
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Locate sections to remove**
+
+In `CLAUDE.md`:
+
+- **"## Execution modes"** section: a heading + paragraph + `ExecutionMode = ...` type line + a markdown table with rows for each of 7 modes + the paragraph "Take control is the only entry into MANUAL..." + the auto-step `$effect` paragraph. ~30 lines total.
+- **"## Debugger UX (debug mode + breakpoints)"** section: a heading + 4 paragraphs about `debugMode`, Step semantics, the `pendingRestore` pattern, and the halt-iter quirks. ~15 lines.
+
+Verify against `git log -p CLAUDE.md | head -200` if the section boundaries are unclear.
+
+- [ ] **Step 2: Replace both with a one-line link**
+
+Remove the two sections entirely. In their place, add this one line at the same location (after the section that originally precedes "## Execution modes"):
+
+```markdown
+**Execution model and debugger semantics:** see [`docs/execution-model.md`](docs/execution-model.md).
+```
+
+The remaining `CLAUDE.md` content (build commands, file structure, architectural diagram, conventions) is untouched.
+
+- [ ] **Step 3: Verify**
+
+```bash
+git diff CLAUDE.md
+```
+
+Expected: ~45 lines removed, 1 line added. No changes outside the two stripped sections.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude-md): replace runtime-behavior sections with link to execution-model.md"
+```
+
+---
+
+## Task 16: Final review
+
+**Files:**
+- Read: `docs/execution-model.md`, `CLAUDE.md`, `docs/superpowers/specs/2026-05-08-execution-model-spec-design.md`
+
+- [ ] **Step 1: Spec-coverage check**
+
+For each `## N. <section>` in the spec design's deliverable outline, confirm a section exists in `docs/execution-model.md`:
+
+```bash
+grep -E '^## [0-9]+\.' docs/execution-model.md
+```
+
+Expected: 13 numbered headings (`## 1. Overview` through `## 13. Cross-references`).
+
+- [ ] **Step 2: Scenario-ID dedup**
+
+```bash
+grep -oE 'S-[a-z-]+' docs/execution-model.md | sort | uniq -c | sort -rn | head -20
+```
+
+Each ID should appear at least once (definition) and possibly multiple times (cross-references). No typos like `S-stop-pasued` or `S-takectl-pasued`. Compare against the §Scenario ID grammar's `<from-state>` allowlist (`demo`, `idle`, `manual`, `auto`, `cont`, `paused`, `halted`).
+
+- [ ] **Step 3: Cross-section reference check**
+
+```bash
+grep -oE '§[0-9]+' docs/execution-model.md | sort -u
+```
+
+Each `§N` reference should point to a real section. Manually skim 5–10 references to confirm the linked section makes sense in context.
+
+- [ ] **Step 4: Mermaid render check on GitHub**
+
+Push the branch and view the file on GitHub. Confirm:
+- Master state diagram (§1) renders all 7 mode nodes and labeled edges
+- Cold-start flowchart (§7) renders the decision tree with dotted error / break edges
+- Paused-cycle sequence diagram (§10 walk-through 1) renders with the `alt` / `else` branch on the Continue path
+
+If any diagram falls back to raw text, check the `<br/>` / YAML-frontmatter / classDef-color constraints documented in the spec design's §Diagram shapes.
+
+- [ ] **Step 5: Final commit (if any fixes)**
+
+If the review surfaces small fixes:
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): review-pass fixes"
+```
+
+If no fixes needed, skip this step.
+
+---
+
+## Self-review
+
+**Spec coverage.** Each of the 13 sections in the spec design's deliverable outline has a corresponding task: §1 (Task 1), §2 (Task 2), §3 (Task 3), §4 (Task 4), §5 (Task 5), §6 (Task 6), §7 (Tasks 7-8), §8 (Task 9), §9 (Task 10), §10 (Tasks 11-13), §11 (Task 14), §12 (Task 14), §13 (Task 14). Tasks 15-16 cover the CLAUDE.md edit and the final review.
+
+**Placeholder scan.** No "TBD" / "TODO" / "implement later" / "similar to Task N" — every task has its content inlined. Mermaid blocks copied verbatim from the spec design where they exist.
+
+**Type / vocabulary consistency.** Mode names (`DEMO`, `IDLE`, `MANUAL`, `RUNNING_AUTO`, `RUNNING_CONTINUOUS`, `RUNNING_PAUSED`, `HALTED`) appear identically across all tasks. Flag names (`debugMode`, `withPause`, `halted`, `userTookControl`) are consistent. Scenario IDs follow the `S-<action>-<from-state>-<flags?>` grammar throughout.
+
+**No code changes.** No source files (`src/**`, `tests/**`) are modified. The PR is pure documentation. Tests (#47) are blocked on this and follow as a separate PR.

--- a/docs/superpowers/specs/2026-05-08-execution-model-spec-design.md
+++ b/docs/superpowers/specs/2026-05-08-execution-model-spec-design.md
@@ -1,0 +1,377 @@
+# Execution-model behavioral spec — design
+
+Tracks: [#46](https://github.com/mellonis/machines-demo/issues/46). Blocks [#47](https://github.com/mellonis/machines-demo/issues/47) (test infrastructure).
+
+## Problem
+
+After [#40](https://github.com/mellonis/machines-demo/issues/40) the demo has 7 execution modes (DEMO, MANUAL, RUNNING_STEP, RUNNING_AUTO, RUNNING_CONTINUOUS, RUNNING_PAUSED_AT_BREAK, HALTED) and several user actions interacting with two flags (`debugMode`, `withPause`) plus a halted state and two sticky latches. The Step-semantics churn during #40 happened because the expected behavior was not written down — discussion oscillated through several interpretations across multiple PR revisions.
+
+The spec proposes a 7-mode ideal model — same count, but a different lineup (RUNNING_STEP collapses, IDLE replaces the `demoEnabled` flag). See §Modes for the substitution.
+
+This spec design captures *what the behavioral reference doc will look like* — its location, structure, scope, and conventions — so the implementation produces a single canonical reference that #47's tests can cite.
+
+The deliverable is the reference doc itself: `docs/execution-model.md`. This design captures the decisions about that doc.
+
+## Decisions
+
+- **Location: `docs/execution-model.md`.** Standalone reference, neutral name, room for sibling `docs/*.md` files later. Not under `docs/superpowers/specs/` — that's design history, not durable reference.
+- **`CLAUDE.md` loses the runtime-behavior sections.** The "Execution modes" table and "Debugger UX (debug mode + breakpoints)" section move to `docs/execution-model.md`. CLAUDE.md keeps build commands, file structure, architectural conventions, and gets a one-line link. Single source of truth; the recent #40 churn would have been worse with two unsynced sources.
+- **Write to the ideal model, not today's code.** The spec describes what the system *should* do once known follow-ups land. Today's divergences live in §11 (Current divergences) with tracking-issue links; tests in #47 cite ideal scenario IDs and `it.skip` the divergent ones until they close. A descriptive spec ages poorly: every PR fixing a known bug forces a spec edit, and tests written against today's quirks bake them in.
+- **Walk-throughs are boundary cases only; the matrix is exhaustive.** Per [#46 (b)](https://github.com/mellonis/machines-demo/issues/46) — but the matrix table must give every realistic `(action, mode)` cell a stable ID so #47 has full-coverage citations. Walk-throughs add prose only where the path was confusing or contested.
+- **Stable scenario IDs.** Format `S-<action>-<from-state>-<flags?>` (lowercase, hyphenated). Each matrix cell and each walk-through carries one. Tests grep `\bS-[a-z-]+` to find every spec citation. Renames break test-to-spec links, so prefer adding new IDs over renaming.
+- **DEMO, IDLE, and MANUAL get dedicated sections, not matrix columns.** All three are non-running resting states; their action sets differ (Apply is MANUAL-only; Take Control hides once `userTookControl` is true; the auto-loop runs only in DEMO). These differences read more naturally as prose than matrix columns. The matrix focuses on in-motion behavior; idle/halted paths live in their own sections.
+- **`IDLE` mode replaces the `demoEnabled` flag.** "DEMO with `demoEnabled=false`" is functionally a different state — no auto-loop, user is uncommitted (hasn't clicked Take Control), but they've signaled intent. Encoding it as a mode name (IDLE) eliminates the flag and fixes a latent quirk where Step from DEMO completes back to a still-running auto-loop that overwrites the user's result.
+
+## Deliverable outline (`docs/execution-model.md`)
+
+```
+1. Overview                — includes master mode-transition diagram
+2. Mode reference          — vocabulary cards for all 7 modes
+3. Flag reference          — debugMode, withPause, halted, userTookControl
+4. DEMO mode               — auto-loop, single exit-on-intent, exits to IDLE / MANUAL
+5. IDLE mode               — uncommitted resting state; Apply hidden; cold-start origin
+6. MANUAL mode             — committed resting state; Apply enabled; cold-start origin
+7. Cold-start and resume   — Build / Step / Run from IDLE/MANUAL/HALTED (cold-start, includes flowchart); Continue from PAUSED (resume)
+8. Action matrix           — RUNNING_AUTO, RUNNING_CONTINUOUS, RUNNING_PAUSED
+9. HALTED mode             — Build/Step/Run = §7; Take Control → MANUAL [!userTookControl]
+10. Scenario walk-throughs — boundary cases; walk-through 1 or 2 includes paused-cycle sequence diagram
+11. Current divergences from spec — punchlist with tracking-issue links
+12. Engine quirks          — appendix; upstream behaviors the spec encodes
+13. Cross-references
+```
+
+Three Mermaid diagrams orient the reader: a master state diagram in §1, a cold-start flowchart in §7, a paused-cycle sequence diagram in §10. The matrix remains the canonical detail; diagrams are for shape, not lookup. Concrete Mermaid blocks are below in §Diagram shapes.
+
+## Modes (ideal model — 7 modes)
+
+`DEMO`, `IDLE`, `MANUAL`, `RUNNING_AUTO`, `RUNNING_CONTINUOUS`, `RUNNING_PAUSED`, `HALTED`.
+
+Two collapses / introductions vs today's code:
+
+- **`RUNNING_STEP` collapses into `RUNNING_PAUSED`.** All running modes use `run()`, so a click-pause from `RUNNING_AUTO` suspends inside run-mode (the throttled `setTimeout`) and lands in the same paused state used by debug breaks. The button label stays "Pause" vs "Step" depending on context, but there is one paused state. (Today RUNNING_STEP exists because RUNNING_AUTO uses the legacy `runner.step()` path; tracked in #43.)
+- **`IDLE` is introduced** as the post-interaction, pre-take-control resting state. Today encoded as `(DEMO mode, demoEnabled=false)`. The mode name encodes the latch directly, removes the flag, and absorbs the latent-quirk fix described above. Implementation tracked alongside #46.
+
+## Mode reference shape
+
+Each mode gets a short card:
+
+```markdown
+### MANUAL
+The user is driving the machine via Apply. Worker is built but idle (no run/step pending). `userTookControl` is true.
+Entry: Take Control from DEMO / IDLE / any RUNNING_* / HALTED; post-RUNNING_* completion or Build from HALTED lands MANUAL when userTookControl is true.
+Exit: Step / Run via §7 cold-start (→ RUNNING_AUTO / RUNNING_CONTINUOUS / RUNNING_PAUSED), Build (→ MANUAL, reload), Apply (stays MANUAL).
+```
+
+Three lines per mode: **what it means**, **how it's entered**, **how it's exited**. UI / log detail belongs in the matrix or walk-throughs. The 7 cards together fit on roughly one screen.
+
+## Flag reference shape
+
+Each flag gets one line:
+
+```markdown
+- **debugMode** — `boolean`. UI checkbox, persisted to `localStorage:<engine>:debugMode`. Gates whether user-authored `state.debug` / `haltState.debug` breaks pause execution. Mid-run toggle pushes `setDebug(on)` to the worker.
+- **withPause** — `boolean`. UI checkbox + interval input. Selects RUNNING_AUTO (with throttle) vs RUNNING_CONTINUOUS (snap-to-final) on the next Run. The toggle itself (`S-withpause-toggle`) has no immediate runtime effect; it's read at Run-click time.
+- **halted** — `boolean`. Derived from worker `built` / `ran` / `error` responses. Drives the HALTED mode transition.
+- **userTookControl** — `boolean`. Sticky latch, starts `false`, set `true` on Take Control click, never re-enables. Marks the "manual track": after RUNNING_*/HALTED, post-action mode resolution lands MANUAL when true, IDLE when false.
+```
+
+The `demoEnabled` flag from today's code is dropped — the DEMO ↔ IDLE mode distinction encodes it. `userTookControl` remains because both IDLE and MANUAL can host RUNNING_* and HALTED, so the spec needs to remember which track HALTED resolves to.
+
+## Action matrix shape
+
+Flat table, one row per `(action, flag-context)` pair, columns are the in-motion / paused modes. Cells show `<scenario-id>: <terse outcome>` or `—` for hidden/disabled.
+
+**Matrix scope.** The matrix lists *user-action* exits only. Event-driven transitions — debug break firing, run completion, error, timeout, truncation — are not matrix rows. They appear in three other places: §1's master state diagram (edges), each mode's "Exit" line in §2 Mode reference, and walk-throughs 2 and 7-9. A reader looking only at the matrix should not conclude that, e.g., RUNNING_CONTINUOUS exits only via Stop or Take Control.
+
+| Action | RUNNING_AUTO | RUNNING_CONTINUOUS | RUNNING_PAUSED |
+|---|---|---|---|
+| **Step (debug=off)** | `S-step-auto-off`: pause label — suspend run loop, → PAUSED | — | `S-step-paused-off`: arm `.after` on next state, resume(step), → PAUSED |
+| **Step (debug=on)** | `S-step-auto-on`: pause label — suspend, → PAUSED | — | `S-step-paused-on`: arm `.after`, resume(step), → PAUSED (a user break may interpose first) |
+| **Stop** | `S-stop-auto`: terminate, → HALTED | `S-stop-cont`: terminate, → HALTED | `S-stop-paused`: terminate, suppress failHalted, → HALTED |
+| **Take Control** | `S-takectl-auto`: latch userTookControl=true, terminate, → MANUAL | `S-takectl-cont`: latch, terminate, → MANUAL | `S-takectl-paused`: latch, terminate, → MANUAL |
+
+Notes:
+- Every cell is a mode transition (or `—` for hidden/disabled). Flag-change actions (debug toggle, withPause toggle) live in §3 Flag reference — they don't cause mode transitions, so they don't belong in the matrix.
+- **Build is hidden in RUNNING_AUTO / RUNNING_CONTINUOUS / RUNNING_PAUSED** — a pending worker request blocks Build. To rebuild, the user clicks Stop or Take Control first (terminate the worker), then Build is available from HALTED / MANUAL.
+- All RUNNING_* paths use `run()`. "Pause" from RUNNING_AUTO suspends inside run-mode (the throttle's setTimeout) and lands in PAUSED — the same paused state used by debug breaks.
+- **RUNNING_CONTINUOUS has the same control surface as RUNNING_AUTO** — Stop, Take Control, debug toggle all available. The modes differ only in throttle / animation; the control surface does not become a third axis of difference. Take Control mid-CONTINUOUS can lose the race to completion, but no race produces a broken state: terminate-or-complete are both clean exits.
+- Cells stay terse (1 line). The *why* lives in walk-throughs for the cells that need it.
+- DEMO, IDLE, MANUAL, HALTED are not matrix columns — they have their own sections (§4, §5, §6, §9).
+
+## Diagram shapes
+
+Three diagrams, each placed in a specific section. They orient the reader; the matrix and walk-throughs remain canonical.
+
+**Constraint: plain Mermaid syntax only.** Do not use the YAML frontmatter `--- config: ... ---` block — GitHub's Mermaid renderer does not support it, and the diagram silently fails to render. Each diagram starts directly with its type declaration (`stateDiagram-v2`, `flowchart TD`, `sequenceDiagram`).
+
+**Avoid `/` in transition labels.** In stateDiagram-v2, `/` is the event/action separator — `Stop / completion` parses as event="Stop", action="completion" and renders the two halves with different styling (the action looks "highlighted"). For alternations (where the slash means "or"), use the literal word `or` (`Stop or completion`). For sequences (where one thing follows another), use an arrow (`Continue→halt`). Reserve `/` for cases where the event/action split is actually intended.
+
+**No HTML tags inside diagrams.** GitHub's renderer is stricter than the Mermaid Live Editor and unreliably supports HTML — most notably `<br/>` inside `participant ... as ...` declarations, `Note over ...` blocks, and (sometimes) edge labels. Keep labels and notes on a single line. If a label is long, prefer breaking the diagram into smaller pieces or using punctuation (`—`, `;`, `,`) inline. Don't depend on HTML rendering anywhere in the diagram source.
+
+**No `classDef` colors with light fills.** GitHub renders Mermaid diagrams against the user's chosen theme (light/dark) but does not adapt custom node fills. Light pastel fills (e.g. `#f0fdf4`) become unreadable on dark mode — node text disappears against the near-white background. Either use Mermaid's default (theme-adaptive) styling — which is what we do — or, if a class-based color scheme is necessary, use medium-saturation colors that have enough contrast against both light and dark themes (and verify on both before committing).
+
+### 1. Master mode-transition diagram (§1 Overview, deliverable)
+
+All 7 modes; every action labeled, conditions inline. Reader sees the whole shape on one screen.
+
+```mermaid
+stateDiagram-v2
+    [*] --> DEMO
+
+    DEMO --> IDLE : Build
+    DEMO --> RUNNING_PAUSED : Step (cold-start)
+    DEMO --> RUNNING_AUTO : Run [withPause=on]
+    DEMO --> RUNNING_CONTINUOUS : Run [withPause=off]
+    DEMO --> MANUAL : Take Control
+
+    IDLE --> IDLE : Build
+    IDLE --> RUNNING_PAUSED : Step (cold-start)
+    IDLE --> RUNNING_AUTO : Run [withPause=on]
+    IDLE --> RUNNING_CONTINUOUS : Run [withPause=off]
+    IDLE --> MANUAL : Take Control
+
+    MANUAL --> MANUAL : Build or Apply
+    MANUAL --> RUNNING_PAUSED : Step (cold-start)
+    MANUAL --> RUNNING_AUTO : Run [withPause=on]
+    MANUAL --> RUNNING_CONTINUOUS : Run [withPause=off]
+
+    RUNNING_AUTO --> RUNNING_PAUSED : Pause
+    RUNNING_AUTO --> RUNNING_PAUSED : break [debug=on]
+    RUNNING_AUTO --> HALTED : Stop or completion
+    RUNNING_AUTO --> MANUAL : Take Control
+
+    RUNNING_CONTINUOUS --> RUNNING_PAUSED : break [debug=on]
+    RUNNING_CONTINUOUS --> HALTED : Stop or completion
+    RUNNING_CONTINUOUS --> MANUAL : Take Control
+
+    RUNNING_PAUSED --> RUNNING_PAUSED : Step or next break
+    RUNNING_PAUSED --> RUNNING_AUTO : Continue [withPause=on]
+    RUNNING_PAUSED --> RUNNING_CONTINUOUS : Continue [withPause=off]
+    RUNNING_PAUSED --> HALTED : Stop or Continue→halt
+    RUNNING_PAUSED --> MANUAL : Take Control
+
+    HALTED --> IDLE : Build [!userTookControl]
+    HALTED --> MANUAL : Build [userTookControl]
+    HALTED --> RUNNING_PAUSED : Step (cold-start)
+    HALTED --> RUNNING_AUTO : Run [withPause=on]
+    HALTED --> RUNNING_CONTINUOUS : Run [withPause=off]
+    HALTED --> MANUAL : Take Control [!userTookControl]
+
+    note right of HALTED : Error, timeout, truncation, or cold-start build error from any non-resting state lands HALTED.
+```
+
+### 2. Cold-start flowchart (§7)
+
+Captures the branching when user clicks Build / Step / Run from IDLE, MANUAL, or HALTED (and DEMO, which uses the same paths but with `userTookControl=false`). The "Build" branch resolves to IDLE or MANUAL by `userTookControl`. If `Reload` fails (build error in user code), → HALTED with error logged; covered by walk-through 7.
+
+```mermaid
+flowchart TD
+    Start([User clicks Build, Step, or Run from IDLE / MANUAL / HALTED])
+    Start --> Reload[reload worker — build, mirror, alphabets]
+    Reload --> Action{which action?}
+    Reload -. build error .-> ErrorOut[→ HALTED with error log]
+    Action -->|Build| Resolve1{userTookControl?}
+    Resolve1 -->|true| ManualOut[→ MANUAL]
+    Resolve1 -->|false| IdleOut[→ IDLE]
+    Action -->|Step| ArmAfter[arm initialState.debug.after = true; preserve user-authored .before]
+    ArmAfter --> RunStep[runner.run debug=debugMode, step=true]
+    RunStep --> PauseOut[→ RUNNING_PAUSED at iter 1 after-fire]
+    Action -->|Run| WithPause{withPause?}
+    WithPause -->|true| RunAuto[runner.run debug=debugMode, with throttled onStep]
+    RunAuto --> AutoOut[→ RUNNING_AUTO]
+    WithPause -->|false| RunCont[runner.run debug=debugMode, no throttle]
+    RunCont --> ContOut[→ RUNNING_CONTINUOUS]
+    AutoOut -. user-authored break .-> PauseOut
+    ContOut -. user-authored break .-> PauseOut
+    RunStep -. user-authored .before fires before iter 1 after .-> PauseOut
+```
+
+### 3. Paused-state cycle sequence diagram (§10, walk-through 1 or 2)
+
+Main thread ↔ worker messages across a Step then Continue cycle. Per-segment timer behavior is annotated.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Main as Main thread (MachineView)
+    participant Worker
+    participant Engine as machine.run()
+
+    User->>Main: click Run [debug=on]
+    Main->>Worker: postMessage { type: 'run', debug: true }
+    Worker->>Engine: machine.run({ onDebugBreak })
+    Engine-->>Worker: yield N, state.debug.before fires
+    Worker-->>Main: { type: 'paused', state, currentSymbols, debugBreak: { before: true } }
+    Note over Worker: timer suspended
+    Note over Main: → RUNNING_PAUSED — log paused at state X before applying ...
+
+    User->>Main: click Step
+    Main->>Main: arm m.state.debug.after = true (pendingRestore captured)
+    Main->>Worker: postMessage { type: 'resume', step: true }
+    Note over Worker: timer restarted
+    Worker->>Engine: resolve onDebugBreak Promise
+    Engine-->>Worker: yield N+1, state.debug.after fires (armed)
+    Worker->>Worker: pendingRestore() — undo arm
+    Worker-->>Main: { type: 'paused', debugBreak: { after: true } }
+    Note over Worker: timer suspended
+    Note over Main: → RUNNING_PAUSED — log paused at state X after applying ...
+
+    User->>Main: click Run (Continue)
+    Main->>Worker: postMessage { type: 'resume', step: false }
+    Note over Worker: timer restarted
+    Worker->>Engine: resolve
+    alt run completes naturally
+        Engine-->>Worker: ... runs to halt
+        Worker-->>Main: { type: 'ran', tapes, commands }
+        Note over Main: → HALTED — log halted after N step(s)
+    else another debug break fires (debug=on)
+        Engine-->>Worker: yield M, state.debug.before fires
+        Worker-->>Main: { type: 'paused', state, currentSymbols, debugBreak: { before: true } }
+        Note over Main: → RUNNING_PAUSED — back to the break-cycle above
+    end
+```
+
+## Cold-start (§7)
+
+Build / Step / Run from IDLE, MANUAL, or HALTED. The path is identical across all three origins, so it's documented once and cited from each. Each entry carries an ID:
+
+- `S-build-idle` / `S-build-manual` / `S-build-halted` — reload, build worker, → IDLE (origin IDLE; HALTED with `!userTookControl`) or MANUAL (origin MANUAL; HALTED with `userTookControl`).
+- `S-step-idle-{off,on}` / `S-step-manual-{off,on}` / `S-step-halted-{off,on}` — reload, arm `initialState.debug.after = true` (preserving any user-authored `state.debug.before`), enter run-mode, → RUNNING_PAUSED at iter 1's after-fire.
+- `S-run-idle-{off,on}-{cont,auto}` / `S-run-manual-{off,on}-{cont,auto}` / `S-run-halted-{off,on}-{cont,auto}` — reload, run-mode, → RUNNING_AUTO (withPause=on) or RUNNING_CONTINUOUS (withPause=off). Debug=on may pause at user breaks, → RUNNING_PAUSED.
+
+**Post-RUNNING_* completion** lands `IDLE` when `!userTookControl`, `MANUAL` when `userTookControl` — the track is preserved across the run.
+
+**DEMO → cold-start** uses the same paths but lands IDLE post-action (since `userTookControl` is false in DEMO and the click itself doesn't set it). Scenario IDs `S-build-demo`, `S-step-demo-{off,on}`, `S-run-demo-{off,on}-{cont,auto}` mirror the IDLE entries.
+
+## Apply scenarios (§6)
+
+Apply is meaningful only in MANUAL — the only mode where the panel is enabled and a click writes to the mirror. One scenario:
+
+- `S-apply-manual` — main thread applies the user-composed `Command` to `mirrorMachine` via the `ifOtherSymbol` one-step state. No worker round-trip; the worker stays idle. Mode stays MANUAL.
+
+The Apply button is **hidden** in DEMO, IDLE, and HALTED (no `S-apply-*` scenario IDs exist for those modes). The DEMO loop generates commands internally and renders them on the panel without any user-facing Apply button — `S-apply-demo` does not exist.
+
+## Resume from PAUSED (§7, cont'd)
+
+The Run / Continue button (Run while in RUNNING_PAUSED) is the only action with a single-column relevance — it has meaning only from PAUSED. Pulled out of the matrix to keep the matrix focused on multi-column actions:
+
+- `S-continue-paused-off` — `runner.resume({ step: false })`. Worker resumes inside `run()`. Debug breaks are not honored (debug=off), so the run continues to halt → HALTED on completion (or to the run-mode end via Stop / error / timeout).
+- `S-continue-paused-on` — `runner.resume({ step: false })`. Debug breaks fire as encountered, → next PAUSED. Continues across multiple paused/resume cycles until halt or the user clicks Stop.
+
+The button label is "Run" when entering from non-PAUSED modes (cold-start) and "Continue" when in PAUSED — same underlying action class, different label for clarity. Walk-through 3 expands these scenarios with per-segment timer behavior, log replay, and edge cases; this sub-section is the canonical scenario-ID list, walk-through 3 is the prose.
+
+## Walk-through shape
+
+Each walk-through opens with a heading using its scenario ID(s) as the anchor:
+
+```markdown
+### `S-step-paused-off` / `S-step-paused-on` — Step from break
+
+**Sequence**
+1. User clicks Step while in RUNNING_PAUSED.
+2. Main thread arms `.after` on the relevant state — `m.state` if paused at before, `m.nextState` if paused at after.
+3. `runner.resume({ step: true })` resolves the worker's pending Promise.
+4. Worker un-applies `pendingRestore` from the previous arm (if any), runs until the next `.after` fire.
+5. Worker sends `paused`; main thread enters RUNNING_PAUSED with the new break info.
+
+**Log entries**
+- `paused at state <X> after applying command for symbols: [<syms>]`
+
+**Worker calls**
+- `resume({ step: true })`
+
+**Edge cases**
+- debug=on: a user-authored `.before` may interpose before the armed `.after` fires. Both produce a normal `paused` response; the long-format log line distinguishes them by `before` vs `after`.
+- The halting iter's armed `.after` never fires — see §11 (current divergences) / turing-machine-js#108.
+```
+
+Standard sub-sections: **Sequence** (numbered steps), **Log entries** (verbatim text), **Worker calls** (request types), **Edge cases** (variants and quirks).
+
+The 9 walk-throughs:
+
+1. Step from PAUSED (`S-step-paused-{off,on}`)
+2. Run with breakpoints — multiple paused/resume cycles, per-segment timer behavior
+3. Continue from break (`S-continue-paused-{off,on}`)
+4. Stop from each running mode (`S-stop-{auto,cont,paused}`)
+5. debug toggle mid-run (`S-debug-toggle-{auto,cont,paused}`)
+6. Take Control from any RUNNING_* (`S-takectl-{auto,cont,paused}`)
+7. Error mid-run (`S-error-{auto,cont,paused}`)
+8. Truncation (`S-truncate-{auto,cont}`)
+9. Worker timeout per segment (`S-timeout-{auto,cont,paused}`)
+
+## Current divergences from spec (§11)
+
+A punchlist of where today's code differs from the spec, each with a tracking-issue link. Acts as a TODO list for future PRs:
+
+- **IDLE mode does not exist.** Today's code encodes the post-Build, pre-Take-Control resting state via `(executionMode = DEMO, demoEnabled = false)`. Affects all `S-*-idle-*` IDs — they're served by `S-*-demo-*` paths today. Also: Step from DEMO completes back to a still-running auto-loop that overwrites the result. Implementation tracked alongside #46 (this spec); follow-up PR aligns code by introducing the IDLE mode and dropping the `demoEnabled` flag.
+- **RUNNING_STEP exists as a separate paused state.** Affects `S-step-auto-{off,on}` (today: → RUNNING_STEP, not PAUSED), and any `S-step-step-*` / `S-run-step-*` IDs that exist only as legacy citations. Tracked in [#43](https://github.com/mellonis/machines-demo/issues/43).
+- **Today's code names the paused-mode `RUNNING_PAUSED_AT_BREAK`.** The spec uses the shorter `RUNNING_PAUSED` (consistent with `RUNNING_AUTO` / `RUNNING_CONTINUOUS`, and accurate when PAUSED arises from a click-pause rather than a debug break). Cosmetic rename, folded into the same alignment work as the RUNNING_STEP collapse (#43).
+- **Auto-step path uses `runner.step()`, not `run()`.** Affects all `S-step-auto-*`, `S-debug-toggle-auto` (today: flag only, no `setDebug()` call). Tracked in [#43](https://github.com/mellonis/machines-demo/issues/43).
+- **Step (debug=on) on auto-step path doesn't honor breaks.** Affects `S-step-auto-on`. Tracked in [#43](https://github.com/mellonis/machines-demo/issues/43).
+- **Halting iter's `state.debug.after` never fires.** Affects walk-through 1 edge case. Tracked in [turing-machine-js#108](https://github.com/mellonis/turing-machine-js/issues/108).
+- **`haltState.debug.after` silently ignored; `haltState.debug.before` IS honored.** Tracked in [turing-machine-js#108](https://github.com/mellonis/turing-machine-js/issues/108).
+
+## Engine quirks (§12)
+
+Upstream behaviors the spec *encodes* (won't change without an upstream major version, so the spec works with them):
+
+- `onDebugBreak` after-fire payload substitutes `m` to `prevYield` — the un-substituted `machineState` is not exposed. Affects step-over-from-after implementations (cross-ref [turing-machine-js#107](https://github.com/mellonis/turing-machine-js/issues/107)).
+- `onStep` and `onDebugBreak` after-fire payloads carry semantically identical `MachineState`. Both hooks are documented; the demo wires both for orthogonal reasons (per-step buffer vs pause cycle). Cross-ref [turing-machine-js#109](https://github.com/mellonis/turing-machine-js/issues/109).
+
+§11 vs §12: §11 lists demo-side gaps to be closed; §12 lists engine semantics that won't change. Items can move from §12 to §11 if the upstream issue lands and a corresponding demo-side simplification becomes possible.
+
+## Cross-references (§13)
+
+- `CLAUDE.md` — working conventions, file structure, build commands. Runtime behavior moved here.
+- `docs/superpowers/specs/2026-05-08-worker-run-mode-design.md` — the #40 design; gives the *why* behind RUNNING_PAUSED and the worker contract.
+- [#47](https://github.com/mellonis/machines-demo/issues/47) — test infrastructure that consumes the scenario IDs.
+- [#46](https://github.com/mellonis/machines-demo/issues/46) — issue this spec resolves.
+
+## CLAUDE.md change (same PR)
+
+- Strip the "Execution modes" table (~30 lines).
+- Strip the "Debugger UX (debug mode + breakpoints)" section.
+- Replace both with a one-liner: `**Execution model and debugger semantics:** see [`docs/execution-model.md`](docs/execution-model.md).`
+- Keep build commands, file structure, the architecture/conventions sections.
+
+## Scenario ID grammar
+
+`S-<action>-<from-state>-<flags?>`
+
+| Slot | Values |
+|---|---|
+| `S-` | literal prefix; marks the token as a scenario reference |
+| `<action>` | `build`, `step`, `run`, `continue`, `stop`, `takectl`, `apply`, `debug-toggle`, `withpause-toggle`, `error`, `truncate`, `timeout` |
+| `<from-state>` | `demo`, `idle`, `manual`, `auto`, `cont`, `paused`, `halted` (and `step` only in §11 for legacy RUNNING_STEP citations) |
+| `<flags?>` | optional flag suffix(es); `on` / `off` (debug), `auto` / `cont` (withPause when ambiguous), or compound like `off-auto` |
+
+Conventions:
+- Lowercase + hyphen throughout. No shift key, easy to grep.
+- One token per slot. Don't run flags together.
+- Drop slots that don't matter — uniform behavior across flags ⇒ no flag suffix.
+- Stable across spec edits — prefer adding new IDs over renaming.
+- `S-` prefix is fixed. Tests grep for `\bS-[a-z-]+`.
+
+Where IDs live:
+- **Matrix cells:** `S-step-paused-off: arm .after, resume(step), → PAUSED`. Text after `:` is the one-line outcome.
+- **Walk-throughs:** each opens with `### `S-step-paused-off` / `S-step-paused-on` — Step from break` so the ID is the section anchor.
+- **Tests (#47):** each `it()` cites at least one ID via a comment or string token. Failing tests point straight at the spec rule they broke.
+- **§11 entries:** cite the IDs they affect.
+
+## Out of scope
+
+- Changing behavior. This is documentation of what the code should do; demo-side changes to align today's code with the spec are tracked separately (#43, etc.).
+- Tests — tracked in #47, blocked on this spec.
+- Visual representation of the state graph (#9, #10) — Wave 4 deferred.
+- Click-to-toggle breakpoints UI (#37) — Wave 4 deferred.
+
+## Self-review
+
+Run after writing the deliverable:
+
+1. **Placeholder scan.** No "TBD", "TODO", incomplete sections.
+2. **Internal consistency.** Mode reference vocabulary matches matrix column headers; walk-through scenario IDs match matrix cells.
+3. **Scope check.** Single deliverable, single implementation plan.
+4. **Ambiguity check.** Each cell's outcome and each walk-through's sequence is unambiguous.
+
+Fix inline; no second review pass.


### PR DESCRIPTION
## Summary

- Add `docs/execution-model.md` (459 lines) — canonical reference for the demo's runtime behavior: 7 modes, 4 flags, action matrix, 9 walk-throughs, 3 Mermaid diagrams (master state, cold-start flowchart, paused-cycle sequence).
- Strip duplicated runtime-behavior sections from `CLAUDE.md` (`## Execution modes`, `## Debugger UX`) and replace with a one-line link.
- Document the **ideal** model: known divergences from today's code live in §11 with tracking-issue links (`#43`, `turing-machine-js#108`, IDLE-mode introduction), so #47's tests can cite ideal scenario IDs and `it.skip` divergent ones until follow-up PRs land.

Notable model decisions captured here:
- `IDLE` introduced as a distinct mode replacing today's `(DEMO, demoEnabled=false)` flag-based encoding — fixes a latent quirk where Step from DEMO completes back into a still-running auto-loop.
- `RUNNING_PAUSED_AT_BREAK` renamed to `RUNNING_PAUSED` (consistent with `RUNNING_AUTO` / `RUNNING_CONTINUOUS`; reachable by click-pause too, not only break).
- Stable scenario-ID grammar `S-<action>-<from-state>-<flags?>` for #47 to cite.

Closes #46. Unblocks #47.

## Test plan

- [ ] Open `docs/execution-model.md` on GitHub; verify all 3 Mermaid diagrams render (state, flowchart, sequence)
- [ ] Verify `CLAUDE.md` no longer has `## Execution modes` or `## Debugger UX` sections; the link line is in their place
- [ ] Skim §10 walk-throughs for clarity; confirm sequence diagram's `alt` / `else` branch on Continue path renders
- [ ] Spot-check a few `S-...` scenario IDs and §N cross-references for accuracy
- [ ] Confirm spec design (`docs/superpowers/specs/2026-05-08-execution-model-spec-design.md`) and plan (`docs/superpowers/plans/2026-05-09-execution-model-spec.md`) are committed alongside