### PR TITLE
ci: skip CD on docs-only changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,13 @@ name: CD
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - 'CLAUDE.md'
+      - 'README.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.editorconfig'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

Add `paths-ignore` to the CD workflow's `push` trigger so doc-only and meta-only changes don't run a full build + rsync.

Closes #52.

The list of ignored paths covers what's currently in the repo plus a couple of common future additions:

- `docs/**` — all in-repo docs (specs, plans, this-repo-only references)
- `CLAUDE.md`, `README.md`, `LICENSE`, `.gitignore`, `.editorconfig`

`workflow_dispatch` is preserved so we can still kick off a manual redeploy when needed (e.g., when only the VPS-side config changed and we want to re-rsync the same artifact).

## Test plan

- [ ] Merge this PR. CD should not run on the merge commit (the only changed file is `.github/workflows/main.yml`, which is **not** ignored — actually it WILL run, see note below).
- [ ] Push a docs-only follow-up commit to master (e.g., a typo fix in `docs/execution-model.md`). Confirm CD does not trigger.
- [ ] Push a source change (e.g., touch `src/lib/types.ts`). Confirm CD triggers.
- [ ] Trigger a manual run via Actions UI ("Run workflow"). Confirm `workflow_dispatch` still works.

> **Note:** the workflow file itself (`.github/workflows/main.yml`) is not in the ignore list. So this PR's merge will trigger one final CD run — which is fine; the artifact is unchanged but the workflow change validates that the rest of the pipeline still works.