### PR TITLE
test: Vitest setup + machineRunner protocol-shape tests (PR1 of #47)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+coverage
 .DS_Store
 .vite
 *.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-`mellonis/machines-demo` is a **Vite + Svelte 5 (runes) + TypeScript** interactive demo for the upstream Turing and Post machine libraries. Single-page app with two tabs (Turing, Post). User code runs in a Web Worker. Deployed at `demo.machines.mellonis.ru` via the `mellonis/vps` repo (manual rsync of `dist/` into `vps/static/demo.machines.mellonis.ru/`; no CI yet).
+`mellonis/machines-demo` is a **Vite + Svelte 5 (runes) + TypeScript** interactive demo for the upstream Turing and Post machine libraries. Single-page app with two tabs (Turing, Post). User code runs in a Web Worker. Deployed at `demo.machines.mellonis.ru` via GitHub Actions on push to `master` (`.github/workflows/main.yml`: build + rsync straight to the VPS; matches the `mellonis/contacts` CI pattern). Doc-only changes are skipped via `paths-ignore`.
 
 ## Commands
 
@@ -11,6 +11,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm run preview` — preview the built bundle
 - `npm run check` — `svelte-check` + `tsc --noEmit`
 - `npm run lint` — ESLint flat config (typescript-eslint + eslint-plugin-svelte)
+- `npm test` — Vitest one-shot (runner / helper tests; node environment, no DOM)
+- `npm run test:watch` — Vitest watch mode
+- `npm run test:coverage` — Vitest with v8 coverage; output in `coverage/` (gitignored)
 
 ## Architecture
 
@@ -29,18 +32,22 @@ src/
 │   ├── Log.svelte           log entries (desktop)
 │   └── IconButton.svelte    shared corner-overlay icon button (reset / clear)
 └── lib/
-    ├── types.ts             Engine, Command, Alphabets, WorkerRequest/Response, TapeSnapshot
-    ├── caps.ts              numeric caps: VIEWPORT_WIDTH, MAX_STEPS, WORKER_TIMEOUT_MS, MAX_TAPES
-    ├── machineRunner.ts     main-thread worker wrapper; WORKER_TIMEOUT_MS round-trip cap
-    ├── machineWorker.ts     spawns user code via new Function inside worker
-    ├── demoLoop.ts          idle-mode random-command loop
-    ├── autoStep.ts          paused-auto-step controller + parseInterval
-    ├── completions.ts       CodeMirror autocomplete: machine namespace + locals
-    ├── syntaxLinter.ts      Lezer-based syntax-error markers
-    ├── persist.ts           localStorage helpers per engine — code, example, snippets (UUID-keyed)
-    ├── defaultCode.ts       starter Turing / Post snippets
-    ├── format.ts            describeAppliedCommand / formatTape / commandsEntry / tapesEntry
-    └── icons.ts             Tabler icon namespace (?raw imports)
+    ├── types.ts                Engine, Command, Alphabets, WorkerRequest/Response, TapeSnapshot
+    ├── caps.ts                 numeric caps: VIEWPORT_WIDTH, MAX_STEPS, WORKER_TIMEOUT_MS, MAX_TAPES
+    ├── machineRunner.ts        main-thread worker wrapper; WORKER_TIMEOUT_MS per-segment cap; injected workerFactory
+    ├── machineRunner.test.ts   Vitest protocol-shape suite (cites R-... / S-... scenario IDs)
+    ├── machineWorker.ts        spawns user code via new Function inside worker
+    ├── testUtils.ts            FakeWorker + makeFakeFactory test helpers
+    ├── log.ts                  log-entry types + helpers shared by Log.svelte
+    ├── demoLoop.ts             idle-mode random-command loop
+    ├── autoStep.ts             paused-auto-step controller + parseInterval
+    ├── completions.ts          CodeMirror autocomplete: machine namespace + locals
+    ├── syntaxLinter.ts         Lezer-based syntax-error markers
+    ├── persist.ts              localStorage helpers per engine — code, example, snippets (UUID-keyed)
+    ├── defaultCode.ts          starter Turing / Post snippets
+    ├── format.ts               describeAppliedCommand / formatTape / commandsEntry / tapesEntry
+    ├── icons.ts                Tabler icon namespace (?raw imports)
+    └── theme.svelte.ts         theme (light / dark) state + matchMedia watcher (Svelte 5 .svelte.ts module)
 ```
 
 **`App.svelte`** picks the active engine from the URL pathname (`/turing`, `/post`) and renders one `<MachineView engine={...}>` keyed by engine — switching engines unmounts and remounts the tab (kills CodeMirror undo, cheap CPU). Legacy `?machine=<engine>` URLs are rewritten to the path form on first load. SPA-fallback routing is required (nginx `try_files $uri $uri/ /index.html;` in `vps/nginx/sites/demo.machines.mellonis.ru`; Vite default in dev).
@@ -54,7 +61,7 @@ src/
 - `panelEnabled` / `applyVisible` / `takeControlVisible` / `loadDisabled` / `stepDisabled` / `runDisabled` / `tapeCount` — all `$derived` (single source of truth for UI state)
 - `mirrorMachine` / `mirrorTapeBlock` — a real `TuringMachine` instance on the main thread that mirrors the worker's tape state. Built by `_buildMirrorMachine` after each `reloadWorker`; advanced one step at a time by `_runMirrorStep` (uses an `ifOtherSymbol` one-step `State` so the upstream library's transitions drive the visualization, not bespoke UI code). `renderFromMirror` hands each `mirrorTapeBlock.tapes[i]` to the matching `<Tape>` via `TapesStack.setFromTape(i, tape, …)`.
 - `$effect`s for the demo loop, auto-step loop, belt-transitions toggle, and a code-changed warning (debounced via `codeChangedWarned` flag — fires once per running session)
-- `runner = new MachineRunner(engine)` and the `doLoad` / `doStep` / `doRun` / `takeControl` / `stopMachine` / `resetCodeToSelected` handlers; `reloadWorker(source?)` is the shared "build worker + rebuild mirrorMachine" helper, taking optional source code (defaults to current `code`) so DEMO can run the canonical `selectedExample.code` regardless of editor state
+- `runner = new MachineRunner(engine, () => new MachineWorker())` and the `doLoad` / `doStep` / `doRun` / `takeControl` / `stopMachine` / `resetCodeToSelected` handlers; `reloadWorker(source?)` is the shared "build worker + rebuild mirrorMachine" helper, taking optional source code (defaults to current `code`) so DEMO can run the canonical `selectedExample.code` regardless of editor state. The factory argument keeps the Vite-specific `?worker` import in `MachineView.svelte`; `machineRunner.ts` is plain TypeScript and accepts any `MachineWorkerLike` (real `Worker` or `FakeWorker` from `testUtils.ts`).
 
 **Execution model and debugger semantics:** see [`docs/execution-model.md`](docs/execution-model.md).
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,14 @@ The dev server prints a URL; open it in a browser.
 ## Scripts
 
 ```sh
-npm run dev        # Vite dev server
-npm run build      # type-check + production build into dist/
-npm run preview    # preview the built bundle
-npm run check      # svelte-check + tsc (no emit)
-npm run lint       # ESLint flat config
+npm run dev            # Vite dev server
+npm run build          # type-check + production build into dist/
+npm run preview        # preview the built bundle
+npm run check          # svelte-check + tsc (no emit)
+npm run lint           # ESLint flat config
+npm test               # Vitest one-shot (runner / helper tests)
+npm run test:watch     # Vitest watch mode
+npm run test:coverage  # Vitest with v8 coverage; output in coverage/
 ```
 
 Static bundle emitted to `dist/`. Serve with any static host. The build references hashed assets, so far-future caching is safe.
@@ -74,28 +77,35 @@ User code and the engine live inside a Web Worker. The main thread holds the UI 
 
 ```
 src/
-├── App.svelte               # header + tab nav + popstate routing
-├── app.ts                   # entry; mounts <App>
-├── app.css                  # global tokens + base styles
+├── App.svelte                  # header + tab nav + popstate routing
+├── app.ts                      # entry; mounts <App>
+├── app.css                     # global tokens + base styles
 ├── components/
-│   ├── MachineView.svelte   # per-engine orchestrator (one $state, derived disabled flags)
-│   ├── Tape.svelte          # virtualized belt with prep-shift slide trick
-│   ├── ControlPanel.svelte  # L/S/R + alphabet chips + Apply
-│   ├── Editor.svelte        # CodeMirror wrapper + localStorage persist
-│   ├── Log.svelte           # entries list (desktop) / latest line (mobile)
-│   └── IconButton.svelte    # icon + optional label
+│   ├── MachineView.svelte      # per-engine orchestrator (one $state, derived disabled flags)
+│   ├── TapesStack.svelte       # multi-tape stack with shared head-thread
+│   ├── Tape.svelte             # virtualized belt with prep-shift slide trick
+│   ├── ControlPanel.svelte     # L/S/R + alphabet chips + Apply
+│   ├── Toolbar.svelte          # Build/Step/Run/Stop + with-pause + examples menu
+│   ├── Editor.svelte           # CodeMirror wrapper + localStorage persist
+│   ├── Log.svelte              # entries list (desktop) / latest line (mobile)
+│   └── IconButton.svelte       # icon + optional label
 └── lib/
-    ├── types.ts             # Engine, Command, WorkerRequest/Response, ...
-    ├── runner.ts            # main-thread worker wrapper, 5s timeout
-    ├── worker.ts            # spawns user code via new Function inside worker
-    ├── demoLoop.ts          # idle-mode random-command loop
-    ├── autoStep.ts          # paused-auto-step controller
-    ├── completions.ts       # CodeMirror autocomplete from machine namespace
-    ├── syntaxLinter.ts      # Lezer-based syntax-error markers
-    ├── persist.ts           # localStorage helpers per engine
-    ├── defaultCode.ts       # starter Turing / Post snippets
-    ├── format.ts            # describeCommand / formatTape / formatAlphabet
-    └── icons.ts             # Tabler icon namespace
+    ├── types.ts                # Engine, Command, WorkerRequest/Response, TapeSnapshot, ...
+    ├── caps.ts                 # numeric caps: VIEWPORT_WIDTH, MAX_STEPS, WORKER_TIMEOUT_MS, MAX_TAPES
+    ├── machineRunner.ts        # main-thread worker wrapper; per-segment timeout; injected workerFactory
+    ├── machineRunner.test.ts   # Vitest protocol-shape suite
+    ├── machineWorker.ts        # spawns user code via new Function inside worker
+    ├── testUtils.ts            # FakeWorker + makeFakeFactory test helpers
+    ├── log.ts                  # log-entry types + helpers
+    ├── demoLoop.ts             # idle-mode random-command loop
+    ├── autoStep.ts             # paused-auto-step controller
+    ├── completions.ts          # CodeMirror autocomplete from machine namespace
+    ├── syntaxLinter.ts         # Lezer-based syntax-error markers
+    ├── persist.ts              # localStorage helpers per engine
+    ├── defaultCode.ts          # starter Turing / Post snippets
+    ├── format.ts               # describeAppliedCommand / formatTape / commandsEntry / tapesEntry
+    ├── icons.ts                # Tabler icon namespace
+    └── theme.svelte.ts         # theme (light / dark) state + matchMedia watcher
 ```
 
 ## License

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -454,3 +454,30 @@ Upstream behaviors the spec encodes (won't change without a major upstream versi
 - [`docs/superpowers/specs/2026-05-08-worker-run-mode-design.md`](superpowers/specs/2026-05-08-worker-run-mode-design.md) — the [#40](https://github.com/mellonis/machines-demo/issues/40) design; gives the *why* behind RUNNING_PAUSED and the worker contract.
 - [#47](https://github.com/mellonis/machines-demo/issues/47) — test infrastructure that consumes the scenario IDs defined in this doc.
 - [#46](https://github.com/mellonis/machines-demo/issues/46) — issue this spec resolves.
+
+## 14. Scenario ID grammar
+
+`<prefix>-<action-or-topic>-<context-or-facet>-<flags?>`
+
+| Slot | Values |
+|---|---|
+| `S-` | literal prefix; marks the token as a UI-scenario reference. Used throughout §§4–10. |
+| `R-` | runner / worker / helper internal scenarios (no UI counterpart). Format `R-<topic>-<facet>`, e.g. `R-protocol-build`, `R-timer-suspend-on-paused`. Used in `*.test.ts` files alongside `S-...` IDs. |
+| `<action>` (S only) | `build`, `step`, `run`, `continue`, `stop`, `takectl`, `apply`, `debug-toggle`, `withpause-toggle`, `error`, `truncate`, `timeout` |
+| `<from-state>` (S only) | `demo`, `idle`, `manual`, `auto`, `cont`, `paused`, `halted` (and `step` only in §11 for legacy RUNNING_STEP citations) |
+| `<topic>` (R only) | `protocol`, `timer`, `pending`, `error`, plus equivalents for the worker / helper test scopes added by future PRs |
+| `<facet>` (R only) | short descriptor — `build`, `step-cycle`, `suspend-on-paused`, `reject-overlap`, `wraps-error-with-tapes`, etc. |
+| `<flags?>` (S only) | optional flag suffix(es); `on` / `off` (debug), `auto` / `cont` (withPause when ambiguous), or compound like `off-auto` |
+
+Conventions:
+- Lowercase + hyphen throughout. No shift key, easy to grep.
+- One token per slot. Don't run flags together.
+- Drop slots that don't matter — uniform behavior across flags ⇒ no flag suffix.
+- Stable across spec edits — prefer adding new IDs over renaming.
+- Both prefixes follow the regex `\b[SR]-[a-z-]+`. Tests / CI grep this to find every cited scenario.
+
+Where IDs live:
+- **Matrix cells** (§8): `S-step-paused-off: arm .after, resume(step), → PAUSED`. Text after `:` is the one-line outcome.
+- **Walk-throughs** (§10): each opens with `### \`S-step-paused-off\` / \`S-step-paused-on\` — Step from break` so the ID is the section anchor.
+- **Tests** ([#47](https://github.com/mellonis/machines-demo/issues/47)): each `it()` cites at least one ID. UI-flow tests cite `S-...` (component / E2E layers); runner / worker / helper tests cite `R-...`. Failing tests point straight at the spec rule they broke.
+- **§11 entries**: cite the IDs they affect when describing today's divergences.

--- a/docs/superpowers/plans/2026-05-09-test-infra-pr1.md
+++ b/docs/superpowers/plans/2026-05-09-test-infra-pr1.md
@@ -1,0 +1,978 @@
+# Test infrastructure PR1 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land Vitest + the first 7 `machineRunner` protocol-shape tests, plus the production refactor (factory injection) and test helpers (`FakeWorker`, `makeFakeFactory`) that subsequent test PRs build on. PR1 of [#47](https://github.com/mellonis/machines-demo/issues/47).
+
+**Architecture:** `MachineRunner` accepts a required `workerFactory: () => MachineWorkerLike` arg, removing the Vite `?worker` import from the runner module. Tests use a `FakeWorker` test double that captures `postMessage` calls and lets tests trigger synthetic responses. Each test asserts a single request/response shape from #47's protocol category.
+
+**Tech Stack:** Vitest 2.x, Vite 5.x, TypeScript 5.x, Svelte 5.x. No DOM environment needed for runner tests (`environment: 'node'`).
+
+**Spec:** `docs/superpowers/specs/2026-05-09-test-infra-pr1-design.md`
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `vitest.config.ts` | **Create** — minimal Vitest config (node env, explicit imports, v8 coverage). |
+| `package.json` | **Modify** — add `vitest` + `@vitest/coverage-v8` to devDependencies; add `test`, `test:watch`, `test:coverage` scripts. |
+| `src/lib/machineRunner.ts` | **Modify** — add `MachineWorkerLike` interface + `WorkerFactory` type, drop `MachineWorker` import, constructor takes required `workerFactory` arg. |
+| `src/components/MachineView.svelte` | **Modify** — single callsite update: import `MachineWorker`, pass `() => new MachineWorker()` to `new MachineRunner(...)`. |
+| `src/lib/testUtils.ts` | **Create** — `FakeWorker` class + `makeFakeFactory()` helper. |
+| `src/lib/machineRunner.test.ts` | **Create** — 7 protocol-shape tests. |
+| `docs/execution-model.md` | **Modify** — append §14 Scenario ID grammar (lifts grammar from the meta-spec, includes both `S-` and `R-` prefixes). |
+
+---
+
+## Verification model
+
+Each task ends with one or more of these checks:
+
+1. `npm run check` — `svelte-check` + `tsc --noEmit`. Must exit 0.
+2. `npm run lint` — ESLint flat config. Must exit 0.
+3. `npm test` — Vitest one-shot mode. After T2 lands the harness, every subsequent task runs this and expects a PASSING test count that grows by 1.
+
+The production refactor in T3 is a structural change with no behavior delta; T3's verification is `npm run check` only (TypeScript types must agree across `machineRunner.ts` and `MachineView.svelte`). Tests get added one at a time from T5 onward.
+
+---
+
+## Task 1: Add §14 Scenario ID grammar to the deliverable
+
+**Files:**
+- Modify: `docs/execution-model.md`
+
+- [ ] **Step 1: Append §14 at the end of the file**
+
+Append the following section after the existing §13 Cross-references. Single blank-line separator before the new heading.
+
+````markdown
+## 14. Scenario ID grammar
+
+`<prefix>-<action-or-topic>-<context-or-facet>-<flags?>`
+
+| Slot | Values |
+|---|---|
+| `S-` | literal prefix; marks the token as a UI-scenario reference. Used throughout §§4–10. |
+| `R-` | runner / worker / helper internal scenarios (no UI counterpart). Format `R-<topic>-<facet>`, e.g. `R-protocol-build`, `R-timer-suspend-on-paused`. Used in `*.test.ts` files alongside `S-...` IDs. |
+| `<action>` (S only) | `build`, `step`, `run`, `continue`, `stop`, `takectl`, `apply`, `debug-toggle`, `withpause-toggle`, `error`, `truncate`, `timeout` |
+| `<from-state>` (S only) | `demo`, `idle`, `manual`, `auto`, `cont`, `paused`, `halted` (and `step` only in §11 for legacy RUNNING_STEP citations) |
+| `<topic>` (R only) | `protocol`, `timer`, `pending`, `error`, plus equivalents for the worker / helper test scopes added by future PRs |
+| `<facet>` (R only) | short descriptor — `build`, `step-cycle`, `suspend-on-paused`, `reject-overlap`, `wraps-error-with-tapes`, etc. |
+| `<flags?>` (S only) | optional flag suffix(es); `on` / `off` (debug), `auto` / `cont` (withPause when ambiguous), or compound like `off-auto` |
+
+Conventions:
+- Lowercase + hyphen throughout. No shift key, easy to grep.
+- One token per slot. Don't run flags together.
+- Drop slots that don't matter — uniform behavior across flags ⇒ no flag suffix.
+- Stable across spec edits — prefer adding new IDs over renaming.
+- Both prefixes follow the regex `\b[SR]-[a-z-]+`. Tests / CI grep this to find every cited scenario.
+
+Where IDs live:
+- **Matrix cells** (§8): `S-step-paused-off: arm .after, resume(step), → PAUSED`. Text after `:` is the one-line outcome.
+- **Walk-throughs** (§10): each opens with `### \`S-step-paused-off\` / \`S-step-paused-on\` — Step from break` so the ID is the section anchor.
+- **Tests** ([#47](https://github.com/mellonis/machines-demo/issues/47)): each `it()` cites at least one ID. UI-flow tests cite `S-...` (component / E2E layers); runner / worker / helper tests cite `R-...`. Failing tests point straight at the spec rule they broke.
+- **§11 entries**: cite the IDs they affect when describing today's divergences.
+````
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -E '^## ' docs/execution-model.md`
+
+Expected: 14 numbered headings, ending with `## 14. Scenario ID grammar`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs(execution-model): add §14 Scenario ID grammar (lifts from meta-spec)"
+```
+
+---
+
+## Task 2: Install Vitest + add scripts + create config
+
+**Files:**
+- Modify: `package.json`
+- Create: `vitest.config.ts`
+
+- [ ] **Step 1: Install Vitest and the v8 coverage provider**
+
+Run:
+
+```bash
+npm install --save-dev vitest @vitest/coverage-v8
+```
+
+Expected: `package.json` and `package-lock.json` updated; new entries in `devDependencies` for `vitest` and `@vitest/coverage-v8`. Both at v2.x or whatever's current; the major version is what matters.
+
+- [ ] **Step 2: Add npm scripts to `package.json`**
+
+In `package.json`, replace the existing `scripts` block:
+
+```json
+"scripts": {
+  "dev": "vite",
+  "build": "svelte-check --tsconfig ./tsconfig.json && vite build",
+  "preview": "vite preview",
+  "check": "svelte-check --tsconfig ./tsconfig.json",
+  "lint": "eslint ."
+},
+```
+
+with:
+
+```json
+"scripts": {
+  "dev": "vite",
+  "build": "svelte-check --tsconfig ./tsconfig.json && vite build",
+  "preview": "vite preview",
+  "check": "svelte-check --tsconfig ./tsconfig.json",
+  "lint": "eslint .",
+  "test": "vitest run",
+  "test:watch": "vitest",
+  "test:coverage": "vitest run --coverage"
+},
+```
+
+- [ ] **Step 3: Create `vitest.config.ts`**
+
+Create `vitest.config.ts` at the repo root:
+
+```ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/lib/**/*.ts'],
+      exclude: ['src/lib/**/*.test.ts', 'src/lib/testUtils.ts'],
+    },
+  },
+});
+```
+
+- [ ] **Step 4: Verify Vitest runs**
+
+Run: `npm test`
+
+Expected output (no test files exist yet):
+
+```
+No test files found, exiting with code 1
+include: src/**/*.test.ts
+```
+
+That's fine for now — the harness is wired up; tests follow in T5+. The exit code 1 isn't ideal but is Vitest's default when no tests exist; it'll flip to 0 once T5 lands the first test.
+
+Also run: `npm run check`
+
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json vitest.config.ts
+git commit -m "test(infra): install Vitest and configure node environment"
+```
+
+---
+
+## Task 3: Refactor `MachineRunner` for factory injection
+
+**Files:**
+- Modify: `src/lib/machineRunner.ts`
+- Modify: `src/components/MachineView.svelte`
+
+- [ ] **Step 1: Update `src/lib/machineRunner.ts`**
+
+Replace the imports block (top of file, lines starting with `import MachineWorker from './machineWorker.ts?worker';`) so it reads:
+
+```ts
+import { MAX_STEPS, WORKER_TIMEOUT_MS } from './caps.ts';
+import {
+  type BuiltResponse,
+  type Engine,
+  type PausedResponse,
+  type RanResponse,
+  type SteppedResponse,
+  type TapeSnapshot,
+  type WorkerRequest,
+  type WorkerResponse,
+} from './types.ts';
+```
+
+(Removed: `import MachineWorker from './machineWorker.ts?worker';`. Kept everything else.)
+
+After the `WorkerError` class declaration and before the `type SimplePending` line, add the new interface and type alias:
+
+```ts
+export interface MachineWorkerLike {
+  postMessage(msg: WorkerRequest): void;
+  terminate(): void;
+  onmessage: ((e: MessageEvent<WorkerResponse>) => void) | null;
+  onerror: ((e: ErrorEvent) => void) | null;
+}
+
+export type WorkerFactory = () => MachineWorkerLike;
+```
+
+Change the `private worker:` field declaration from:
+
+```ts
+private worker: Worker | null = null;
+```
+
+to:
+
+```ts
+private worker: MachineWorkerLike | null = null;
+```
+
+Add a `private workerFactory: WorkerFactory;` field declaration alongside. Update the constructor from:
+
+```ts
+constructor(engine: Engine) {
+  this.engine = engine;
+}
+```
+
+to:
+
+```ts
+constructor(engine: Engine, workerFactory: WorkerFactory) {
+  this.engine = engine;
+  this.workerFactory = workerFactory;
+}
+```
+
+Update `spawnWorker()` — change the line `this.worker = new MachineWorker();` to:
+
+```ts
+this.worker = this.workerFactory();
+```
+
+The `onmessage` and `onerror` assignments below it work as-is. The rest of the class is unchanged.
+
+- [ ] **Step 2: Update `src/components/MachineView.svelte`**
+
+Find the `import { MachineRunner }` import line (somewhere near the top of the `<script lang="ts">` block) and add a new import line directly above it:
+
+```ts
+import MachineWorker from '$lib/machineWorker.ts?worker';
+```
+
+Find the `runner = new MachineRunner(engine)` line (or `new MachineRunner(...)` wherever it's used). Update it to:
+
+```ts
+runner = new MachineRunner(engine, () => new MachineWorker());
+```
+
+If the import path uses a relative form (`'../lib/machineRunner'`) and not `$lib`, mirror the existing convention for the runner — do NOT introduce `$lib` if the codebase isn't already using path aliases. Inspect the existing `import { MachineRunner }` line first; use the same style for the new `MachineWorker` import.
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `npm run check`
+
+Expected: 0 errors, 0 warnings. The new types resolve, `MachineRunner`'s constructor now requires two args, and the `MachineView.svelte` callsite supplies both.
+
+- [ ] **Step 4: Verify lint passes**
+
+Run: `npm run lint`
+
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/machineRunner.ts src/components/MachineView.svelte
+git commit -m "refactor(machineRunner): inject worker factory; remove ?worker import"
+```
+
+---
+
+## Task 4: Add `FakeWorker` and `makeFakeFactory` to `testUtils.ts`
+
+**Files:**
+- Create: `src/lib/testUtils.ts`
+
+- [ ] **Step 1: Create the file**
+
+Create `src/lib/testUtils.ts`:
+
+```ts
+import type { MachineWorkerLike, WorkerFactory } from './machineRunner';
+import type { WorkerRequest, WorkerResponse } from './types';
+
+/**
+ * Test double for the Web Worker that `MachineRunner` posts to.
+ *
+ * - `postedMessages` captures every request sent by the runner.
+ * - Tests trigger inbound messages via `respond(...)` and `errorEvent(...)`.
+ * - Implements `MachineWorkerLike` structurally; can be passed wherever a
+ *   real `Worker` is expected on the runner side.
+ */
+export class FakeWorker implements MachineWorkerLike {
+  postedMessages: WorkerRequest[] = [];
+
+  onmessage: ((e: MessageEvent<WorkerResponse>) => void) | null = null;
+  onerror: ((e: ErrorEvent) => void) | null = null;
+
+  terminated = false;
+
+  postMessage(msg: WorkerRequest): void {
+    if (this.terminated) throw new Error('postMessage on terminated worker');
+    this.postedMessages.push(msg);
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  // -- Test helpers (not part of MachineWorkerLike) --
+
+  respond(data: WorkerResponse): void {
+    if (!this.onmessage) throw new Error('respond() before onmessage handler set');
+    this.onmessage({ data } as MessageEvent<WorkerResponse>);
+  }
+
+  errorEvent(message: string): void {
+    if (!this.onerror) throw new Error('errorEvent() before onerror handler set');
+    this.onerror({ message } as ErrorEvent);
+  }
+
+  get last(): WorkerRequest | undefined {
+    return this.postedMessages[this.postedMessages.length - 1];
+  }
+}
+
+/**
+ * Returns a factory that produces a fresh `FakeWorker` on each call, plus
+ * accessors for the most recent fake (`current()`) and every fake produced
+ * (`all()`). Mirrors `MachineRunner.spawnWorker` semantics: each `build()`
+ * invokes the factory once.
+ */
+export function makeFakeFactory(): {
+  factory: WorkerFactory;
+  current: () => FakeWorker;
+  all: () => FakeWorker[];
+} {
+  const fakes: FakeWorker[] = [];
+  return {
+    factory: () => {
+      const fake = new FakeWorker();
+      fakes.push(fake);
+      return fake;
+    },
+    current: () => {
+      const last = fakes[fakes.length - 1];
+      if (!last) throw new Error('makeFakeFactory: factory not yet called');
+      return last;
+    },
+    all: () => fakes.slice(),
+  };
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `npm run check`
+
+Expected: 0 errors, 0 warnings. (`testUtils.ts` is picked up by `svelte-check` because it's under `src/lib/`. The interface and type imports must resolve from the refactored `machineRunner.ts`.)
+
+- [ ] **Step 3: Verify lint passes**
+
+Run: `npm run lint`
+
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/testUtils.ts
+git commit -m "test(infra): add FakeWorker and makeFakeFactory test helpers"
+```
+
+---
+
+## Task 5: First test — `R-protocol-build`
+
+**Files:**
+- Create: `src/lib/machineRunner.test.ts`
+
+- [ ] **Step 1: Create the test file with the first test**
+
+Create `src/lib/machineRunner.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { MachineRunner } from './machineRunner';
+import { makeFakeFactory } from './testUtils';
+
+describe('MachineRunner', () => {
+  describe('protocol shape', () => {
+    it('R-protocol-build: posts {type:"build",engine,code} and resolves with BuiltResponse', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+
+      expect(current().last).toEqual({
+        type: 'build',
+        engine: 'turing',
+        code: '// user code',
+      });
+
+      const builtPayload = {
+        type: 'built' as const,
+        tapes: [],
+        alphabets: [],
+        halted: false,
+      };
+      current().respond(builtPayload);
+
+      await expect(buildPromise).resolves.toEqual(builtPayload);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `npm test`
+
+Expected:
+
+```
+ ✓ src/lib/machineRunner.test.ts (1 test)
+   ✓ MachineRunner > protocol shape > R-protocol-build: posts {type:"build",engine,code} and resolves with BuiltResponse
+
+ Test Files  1 passed (1)
+      Tests  1 passed (1)
+```
+
+If the test fails, the most likely cause is a typo in the request shape or response payload — fix and re-run before committing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/machineRunner.test.ts
+git commit -m "test(machineRunner): R-protocol-build (build request → BuiltResponse)"
+```
+
+---
+
+## Task 6: `R-protocol-step`
+
+**Files:**
+- Modify: `src/lib/machineRunner.test.ts`
+
+- [ ] **Step 1: Add the step test**
+
+Append a new `it(...)` block inside the existing `describe('protocol shape', ...)` after the `R-protocol-build` test. Inside `describe('protocol shape')`:
+
+```ts
+    it('R-protocol-step: posts {type:"step"} and resolves with SteppedResponse', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      // Build first to spawn the worker.
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const stepPromise = runner.step();
+
+      expect(current().last).toEqual({ type: 'step' });
+
+      const steppedPayload = {
+        type: 'stepped' as const,
+        halted: false,
+        commands: null,
+        nextCommands: null,
+        stepsApplied: 1,
+      };
+      current().respond(steppedPayload);
+
+      await expect(stepPromise).resolves.toEqual(steppedPayload);
+    });
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test`
+
+Expected: 2 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/machineRunner.test.ts
+git commit -m "test(machineRunner): R-protocol-step (step request → SteppedResponse)"
+```
+
+---
+
+## Task 7: `R-protocol-run`
+
+**Files:**
+- Modify: `src/lib/machineRunner.test.ts`
+
+- [ ] **Step 1: Add the run test**
+
+Append inside `describe('protocol shape')` after the `R-protocol-step` test. Add an import for `MAX_STEPS` at the top of the file (modifying the existing top-of-file imports to include `import { MAX_STEPS } from './caps';`):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { MAX_STEPS } from './caps';
+import { MachineRunner } from './machineRunner';
+import { makeFakeFactory } from './testUtils';
+```
+
+Then add the test:
+
+```ts
+    it('R-protocol-run: posts {type:"run",maxSteps,debug,step} and resolves with RanResponse', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      // Build first.
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      // Custom-arg run.
+      const runPromise = runner.run({ maxSteps: 100, debug: true, step: false });
+
+      expect(current().last).toEqual({
+        type: 'run',
+        maxSteps: 100,
+        debug: true,
+        step: false,
+      });
+
+      const ranPayload = {
+        type: 'ran' as const,
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 5,
+      };
+      current().respond(ranPayload);
+
+      await expect(runPromise).resolves.toEqual(ranPayload);
+    });
+
+    it('R-protocol-run-defaults: posts MAX_STEPS, debug=false, step=false on bare run()', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run();
+
+      expect(current().last).toEqual({
+        type: 'run',
+        maxSteps: MAX_STEPS,
+        debug: false,
+        step: false,
+      });
+
+      current().respond({
+        type: 'ran',
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 0,
+      });
+
+      await runPromise;
+    });
+```
+
+(Two `it(...)` calls in this task — one for explicit args, one for defaults. The defaults case is part of the protocol-shape contract since the runner adds `?? MAX_STEPS` etc., and tests should lock that behavior down.)
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test`
+
+Expected: 4 tests pass (R-protocol-build, R-protocol-step, R-protocol-run, R-protocol-run-defaults).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/machineRunner.test.ts
+git commit -m "test(machineRunner): R-protocol-run + run-defaults (run request shapes)"
+```
+
+---
+
+## Task 8: `R-protocol-resume`
+
+**Files:**
+- Modify: `src/lib/machineRunner.test.ts`
+
+- [ ] **Step 1: Add the resume test**
+
+Append inside `describe('protocol shape')` after the run tests:
+
+```ts
+    it('R-protocol-resume: posts {type:"resume",step} and does not resolve the run promise', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      // Build, then start a run with onPaused.
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      let pausedSeen = false;
+      const runPromise = runner.run({
+        onPaused: () => {
+          pausedSeen = true;
+        },
+      });
+
+      // Worker pauses.
+      current().respond({
+        type: 'paused',
+        tapes: [],
+        commands: [],
+        stepsApplied: 1,
+        state: 'q1',
+        currentSymbols: ['a'],
+        debugBreak: { before: true },
+      });
+      expect(pausedSeen).toBe(true);
+
+      // Now resume(step=true).
+      runner.resume(true);
+
+      expect(current().last).toEqual({ type: 'resume', step: true });
+
+      // Run promise still pending — resolves only on `ran`/`error`.
+      // Sanity check: settle a microtask, ensure no resolution yet.
+      let runResolved = false;
+      void runPromise.then(() => {
+        runResolved = true;
+      });
+      await Promise.resolve();
+      expect(runResolved).toBe(false);
+
+      // Default resume() posts step:false.
+      runner.resume();
+      expect(current().last).toEqual({ type: 'resume', step: false });
+
+      // Cleanly settle the pending run by responding with `ran`.
+      current().respond({
+        type: 'ran',
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 1,
+      });
+      await runPromise;
+    });
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test`
+
+Expected: 5 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/machineRunner.test.ts
+git commit -m "test(machineRunner): R-protocol-resume (resume request shape; run stays pending)"
+```
+
+---
+
+## Task 9: `R-protocol-set-debug`
+
+**Files:**
+- Modify: `src/lib/machineRunner.test.ts`
+
+- [ ] **Step 1: Add the setDebug test**
+
+Append inside `describe('protocol shape')`:
+
+```ts
+    it('R-protocol-set-debug: posts {type:"setDebug",on}', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      // Build first to spawn the worker (setDebug is a no-op without one).
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      runner.setDebug(true);
+      expect(current().last).toEqual({ type: 'setDebug', on: true });
+
+      runner.setDebug(false);
+      expect(current().last).toEqual({ type: 'setDebug', on: false });
+    });
+
+    it('R-protocol-set-debug-no-worker: setDebug before build is a silent no-op', () => {
+      const { factory } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      // No build yet, so no worker. setDebug must not throw.
+      expect(() => runner.setDebug(true)).not.toThrow();
+    });
+```
+
+(Two tests — happy path with the worker spawned, plus the documented no-op-before-build path.)
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test`
+
+Expected: 7 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/machineRunner.test.ts
+git commit -m "test(machineRunner): R-protocol-set-debug (worker-present and no-worker)"
+```
+
+---
+
+## Task 10: `R-protocol-paused-then-ran`
+
+**Files:**
+- Modify: `src/lib/machineRunner.test.ts`
+
+- [ ] **Step 1: Add the paused-cycle test**
+
+Append inside `describe('protocol shape')`:
+
+```ts
+    it('R-protocol-paused-then-ran: run() invokes onPaused on paused, resolves on ran', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const pausedPayloads: Parameters<NonNullable<Parameters<MachineRunner['run']>[0]>['onPaused']>[0][] = [];
+      const runPromise = runner.run({
+        debug: true,
+        onPaused: (p) => {
+          pausedPayloads.push(p);
+        },
+      });
+
+      const pausedPayload = {
+        type: 'paused' as const,
+        tapes: [],
+        commands: [],
+        stepsApplied: 1,
+        state: 'q1',
+        currentSymbols: ['a'],
+        debugBreak: { before: true },
+      };
+      current().respond(pausedPayload);
+
+      // onPaused fired with the payload.
+      expect(pausedPayloads).toHaveLength(1);
+      expect(pausedPayloads[0]).toEqual(pausedPayload);
+
+      // Run still pending.
+      let runSettled = false;
+      void runPromise.then(() => {
+        runSettled = true;
+      });
+      await Promise.resolve();
+      expect(runSettled).toBe(false);
+
+      // Now finish the run.
+      const ranPayload = {
+        type: 'ran' as const,
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 5,
+      };
+      current().respond(ranPayload);
+
+      await expect(runPromise).resolves.toEqual(ranPayload);
+    });
+```
+
+The unwieldy `Parameters<...>` chain at the top of the test extracts the type of `onPaused`'s argument from the runner's public signature without re-importing `PausedResponse`. Keeps the test surface minimal.
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test`
+
+Expected: 8 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/machineRunner.test.ts
+git commit -m "test(machineRunner): R-protocol-paused-then-ran (onPaused callback + run resolution)"
+```
+
+---
+
+## Task 11: `S-step-paused-off / R-protocol-step-arming`
+
+**Files:**
+- Modify: `src/lib/machineRunner.test.ts`
+
+- [ ] **Step 1: Add the cold-start step-arming test**
+
+Append inside `describe('protocol shape')`:
+
+```ts
+    it('S-step-paused-off / R-protocol-step-arming: run({step:true}) posts step=true', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run({ step: true, debug: false });
+
+      expect(current().last).toMatchObject({
+        type: 'run',
+        step: true,
+        debug: false,
+      });
+
+      // Wrap up cleanly so the pending run doesn't leak between tests.
+      current().respond({
+        type: 'ran',
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 0,
+      });
+      await runPromise;
+    });
+```
+
+This test uses `toMatchObject` (not `toEqual`) because the `maxSteps` field is included by the runner (set to `MAX_STEPS` by default) and we don't care about its specific value here — only that `step: true` and `debug: false` cross the wire.
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test`
+
+Expected: 9 tests pass.
+
+(Note: this is one more test than the spec's "7 tests" target — the run-defaults and setDebug-no-worker subtests in T7 / T9 each added one extra. The spec's 7-test count was the headline scenario count; the actual `it()` count is 9. Both are correct per the spec's intent — every protocol facet locked down.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/machineRunner.test.ts
+git commit -m "test(machineRunner): S-step-paused-off / R-protocol-step-arming (cold-start step wire shape)"
+```
+
+---
+
+## Task 12: Final verification
+
+**Files:** none modified
+
+- [ ] **Step 1: Type-check**
+
+Run: `npm run check`
+
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+
+Expected: exit 0.
+
+- [ ] **Step 3: Build (sanity check that runtime code wasn't broken)**
+
+Run: `npm run build`
+
+Expected: build succeeds; `dist/` produced. Tests aren't part of the build, so this only verifies the production refactor (T3) is clean.
+
+- [ ] **Step 4: Run all tests**
+
+Run: `npm test`
+
+Expected:
+
+```
+ Test Files  1 passed (1)
+      Tests  9 passed (9)
+```
+
+- [ ] **Step 5: Coverage spot-check**
+
+Run: `npm run test:coverage`
+
+Expected: `src/lib/machineRunner.ts` shows partial coverage (the protocol-shape paths exercised; the timer, pending-overlap, and error paths still uncovered — those land in PR2). No coverage threshold is enforced; this is informational.
+
+- [ ] **Step 6: Scenario-ID grep audit**
+
+Run:
+
+```bash
+grep -oE '\b[SR]-[a-z-]+' src/lib/machineRunner.test.ts | sort -u
+```
+
+Expected: every cited ID is one of:
+- `R-protocol-build`
+- `R-protocol-step`
+- `R-protocol-run`
+- `R-protocol-run-defaults`
+- `R-protocol-resume`
+- `R-protocol-set-debug`
+- `R-protocol-set-debug-no-worker`
+- `R-protocol-paused-then-ran`
+- `R-protocol-step-arming`
+- `S-step-paused-off`
+
+No typos, no orphans. Ten unique IDs across 9 tests (the cold-start test cites both `S-step-paused-off` and `R-protocol-step-arming`).
+
+- [ ] **Step 7: No further commit needed**
+
+If any of T1's grammar references or T11's compound ID didn't match, fix inline in the relevant file and amend that task's commit (don't create a "review fixes" commit — keep the per-task commit history clean).
+
+---
+
+## Self-review
+
+**Spec coverage.** Each spec section maps to tasks:
+
+- §Decisions and §Modes (ideal model) — captured in the plan's intro and file map.
+- §Production refactor — T3.
+- §FakeWorker and makeFakeFactory — T4.
+- §Test pattern + naming — every test in T5–T11 follows the `R-...` / `S-...:` naming format.
+- §The seven tests — covered across T5–T11 (with two split into sub-tests, hence 9 total).
+- §Spec edit (§14 Scenario ID grammar lift) — T1.
+- §Vitest config + §package.json updates — T2.
+- §Out of scope items — explicitly not in any task.
+
+**Placeholder scan.** No "TBD", "TODO", or "implement later". Every code step shows the actual code. Every command shows the expected output. No "similar to Task N" — code is repeated where helpful.
+
+**Type / vocabulary consistency.** `MachineRunner`, `MachineWorkerLike`, `WorkerFactory`, `FakeWorker`, `makeFakeFactory`, `current()`, `all()`, `respond()`, `errorEvent()`, `last` — all named identically across the plan and the spec. Scenario IDs match the spec design's grammar (lowercase, hyphenated, `S-` and `R-` prefixes).
+
+**Branch hygiene.** All commits land on the existing feature branch `47-test-infra-pr1` (which already has the spec design commit). Implementer must verify they're on that branch before T1; do not commit to master.

--- a/docs/superpowers/specs/2026-05-09-test-infra-pr1-design.md
+++ b/docs/superpowers/specs/2026-05-09-test-infra-pr1-design.md
@@ -1,0 +1,359 @@
+# Test infrastructure — PR1 (Vitest setup + machineRunner protocol tests) — design
+
+Tracks: [#47](https://github.com/mellonis/machines-demo/issues/47) (test infrastructure). PR1 of an expected 4-PR series. Cites scenario IDs from `docs/execution-model.md`.
+
+## Problem
+
+The demo has no automated tests — only `svelte-check` and `eslint`. The Step-semantics churn during #40 would have been caught by even minimal tests of the worker protocol. #47 specifies four scopes: Vitest setup, `machineRunner` tests, `machineWorker` logic tests, component tests, plus a handful of Playwright E2E flows. That's a lot for one PR.
+
+PR1 lands the **harness + the first test pattern** so the rest can be filled in mechanically by follow-up PRs. Specifically:
+
+- Vitest config, npm scripts, dev dependencies.
+- The seam that lets tests substitute the worker without invoking Vite's `?worker` plumbing (a small refactor of `MachineRunner`).
+- A `FakeWorker` test double + helper factory.
+- One category from #47's `machineRunner` test scope: **protocol shape** (request → response wire shapes).
+- A grammar update to `docs/execution-model.md` introducing the `R-` scenario ID prefix for runner-internal scenarios.
+
+The other three categories (timer, pending-slot, error wrapping) and the worker / component / E2E layers are explicitly out of scope here. Their patterns follow PR1's structure mechanically.
+
+## Decisions
+
+- **Scope: lean PR1.** Setup + harness + protocol-shape category only. Subsequent PRs (PR2/3/4) layer on the remaining categories. Choosing this over a single all-of-#47 PR because the harness/mock pattern is the contested part — getting it right with a small surface lets every follow-up be a copy-and-fill.
+- **Test runner: Vitest.** Per #47, Vite-native, no extra config. Mirrors the existing build's tooling. No alternatives (Jest/Mocha) were seriously considered — Vite-native test runner is the obvious fit.
+- **File layout: co-located.** Tests live next to the file under test (`src/lib/machineRunner.test.ts` next to `machineRunner.ts`). Vitest defaults pick these up. Co-located is the small-repo modern convention; keeps "open the dir, see code + tests together" ergonomics. A future `tests/` directory for E2E (PR4) doesn't conflict.
+- **Worker mocking: factory injection (production-side change).** `MachineRunner` accepts an explicit `workerFactory: () => MachineWorkerLike` constructor argument. Production callers pass `() => new MachineWorker()`; tests pass `() => new FakeWorker()`. Chosen over `vi.mock`-of-`?worker`-import (fragile, ties tests to Vite plumbing) and over real-Worker spawning (slow, and the test surface still has to define a stub's protocol). One existing call site in `MachineView.svelte` updates to pass the factory.
+- **Factory always returns a fresh fake.** Mirrors production: `MachineRunner.spawnWorker()` invokes the factory every `build()`. Sharing a single fake would conflate distinct worker sessions and break tests that exercise the supersede-on-rebuild path. Helper `makeFakeFactory()` exposes `current()` and `all()` for single-build and multi-build tests respectively.
+- **Scenario ID convention: hybrid.** Runner tests cite `S-...` IDs where they map to a UI scenario, `R-...` IDs for runner-internal mechanics with no UI counterpart. Format `R-<topic>-<facet>` (lowercase, hyphenated). Follows the same `\b[SR]-[a-z-]+` grep contract as the spec's existing `S-` prefix. Both prefixes are documented in the execution-model spec's §Scenario ID grammar.
+- **Test environment: `node`.** `MachineRunner` doesn't touch the DOM; runner tests don't need `happy-dom` or `jsdom`. Component tests (PR3) will need a DOM environment, but configuring it now is YAGNI.
+- **No CI integration in PR1.** `npm test` runs locally; wiring it into the CD workflow's pre-build step is a separate small PR after PR1 lands and the test pattern is validated.
+
+## File map
+
+| File | Change | Roughly |
+|---|---|---|
+| `vitest.config.ts` | **Create** — minimal Vitest config (node env, explicit imports). | ~10 lines |
+| `package.json` | **Modify** — add `vitest` + `@vitest/coverage-v8` to devDependencies; add `test`, `test:watch`, `test:coverage` scripts. | +2 deps, +3 scripts |
+| `src/lib/machineRunner.ts` | **Modify** — add `MachineWorkerLike` interface + `WorkerFactory` type; constructor takes required `workerFactory`; drop `MachineWorker` import; `private worker: MachineWorkerLike \| null`. | ~15 lines net |
+| `src/components/MachineView.svelte` | **Modify** — single callsite update: import `MachineWorker`, pass `() => new MachineWorker()` as second arg to `new MachineRunner(...)`. | ~3 lines |
+| `src/lib/testUtils.ts` | **Create** — `FakeWorker` class + `makeFakeFactory()` helper. | ~70 lines |
+| `src/lib/machineRunner.test.ts` | **Create** — 7 protocol-shape tests. | ~150 lines |
+| `docs/execution-model.md` | **Modify** — append new §14 Scenario ID grammar (lift from meta-spec, includes both `S-` and `R-` rows from the start, plus conventions and "where IDs live" bullets). | ~30 lines |
+
+## Production refactor — `MachineRunner` factory injection
+
+Constructor signature changes from `constructor(engine: Engine)` to `constructor(engine: Engine, workerFactory: WorkerFactory)`. The factory is required (not optional) — production and tests both supply one explicitly, no asymmetry.
+
+```ts
+// src/lib/machineRunner.ts (no MachineWorker import — moves to the caller)
+import { MAX_STEPS, WORKER_TIMEOUT_MS } from './caps.ts';
+import {
+  type BuiltResponse,
+  type Engine,
+  type PausedResponse,
+  type RanResponse,
+  type SteppedResponse,
+  type TapeSnapshot,
+  type WorkerRequest,
+  type WorkerResponse,
+} from './types.ts';
+
+export interface MachineWorkerLike {
+  postMessage(msg: WorkerRequest): void;
+  terminate(): void;
+  onmessage: ((e: MessageEvent<WorkerResponse>) => void) | null;
+  onerror: ((e: ErrorEvent) => void) | null;
+}
+
+export type WorkerFactory = () => MachineWorkerLike;
+
+export class WorkerError extends Error { /* unchanged */ }
+
+export class MachineRunner {
+  readonly engine: Engine;
+  private workerFactory: WorkerFactory;
+  private worker: MachineWorkerLike | null = null;
+  // ... existing private fields unchanged
+
+  constructor(engine: Engine, workerFactory: WorkerFactory) {
+    this.engine = engine;
+    this.workerFactory = workerFactory;
+  }
+
+  private spawnWorker(): void {
+    this.rejectAll(new Error('superseded by new worker'));
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+    }
+    this.worker = this.workerFactory(); // ← was `new MachineWorker()`
+    this.worker.onmessage = (e) => this.onMessage(e.data);
+    this.worker.onerror = (e) => this.onWorkerError(e);
+  }
+
+  // ... rest of the class is identical (build / step / run / resume / setDebug / terminate)
+}
+```
+
+Caller change in `MachineView.svelte` is one import + one constructor argument:
+
+```ts
+// before
+import { MachineRunner } from '$lib/machineRunner';
+const runner = new MachineRunner(engine);
+
+// after
+import MachineWorker from '$lib/machineWorker.ts?worker';
+import { MachineRunner } from '$lib/machineRunner';
+const runner = new MachineRunner(engine, () => new MachineWorker());
+```
+
+The Vite-specific `?worker` import suffix is now contained in `MachineView.svelte` (the only Svelte/Vite-specific module on the runner-construction path). `machineRunner.ts` becomes pure TypeScript with no build-tool dependency.
+
+## `FakeWorker` and `makeFakeFactory()`
+
+```ts
+// src/lib/testUtils.ts
+import type { MachineWorkerLike, WorkerFactory } from './machineRunner';
+import type { WorkerRequest, WorkerResponse } from './types';
+
+export class FakeWorker implements MachineWorkerLike {
+  /** Every postMessage call captured in order. Tests assert against this. */
+  postedMessages: WorkerRequest[] = [];
+
+  /** Set by MachineRunner.spawnWorker. Tests trigger via respond() / errorEvent(). */
+  onmessage: ((e: MessageEvent<WorkerResponse>) => void) | null = null;
+  onerror: ((e: ErrorEvent) => void) | null = null;
+
+  /** True after terminate() — postMessage on a terminated worker throws. */
+  terminated = false;
+
+  postMessage(msg: WorkerRequest): void {
+    if (this.terminated) throw new Error('postMessage on terminated worker');
+    this.postedMessages.push(msg);
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  // -- Test helpers (not part of the MachineWorkerLike interface) --
+
+  /** Simulate a worker→main message. */
+  respond(data: WorkerResponse): void {
+    if (!this.onmessage) throw new Error('respond() before onmessage handler set');
+    this.onmessage({ data } as MessageEvent<WorkerResponse>);
+  }
+
+  /** Simulate a worker-side error. */
+  errorEvent(message: string): void {
+    if (!this.onerror) throw new Error('errorEvent() before onerror handler set');
+    this.onerror({ message } as ErrorEvent);
+  }
+
+  /** Most recent posted message — convenience for assertions. */
+  get last(): WorkerRequest | undefined {
+    return this.postedMessages[this.postedMessages.length - 1];
+  }
+}
+
+export function makeFakeFactory(): {
+  factory: WorkerFactory;
+  current: () => FakeWorker;
+  all: () => FakeWorker[];
+} {
+  const fakes: FakeWorker[] = [];
+  return {
+    factory: () => {
+      const fake = new FakeWorker();
+      fakes.push(fake);
+      return fake;
+    },
+    current: () => {
+      const last = fakes[fakes.length - 1];
+      if (!last) throw new Error('makeFakeFactory: factory not yet called');
+      return last;
+    },
+    all: () => fakes.slice(),
+  };
+}
+```
+
+Test patterns:
+
+**Single-build test** — most common in the protocol-shape category:
+
+```ts
+const { factory, current } = makeFakeFactory();
+const runner = new MachineRunner('turing', factory);
+const buildPromise = runner.build('// user code');
+expect(current().last).toEqual({ type: 'build', engine: 'turing', code: '// user code' });
+current().respond({ type: 'built', tapes: [...], alphabets: [...], halted: false });
+await buildPromise;
+```
+
+**Multi-build test** — for supersede-on-rebuild assertions (deferred to PR2 but the helper supports it):
+
+```ts
+const { factory, all } = makeFakeFactory();
+const runner = new MachineRunner('turing', factory);
+await runFirstBuild(runner, all);
+const secondBuild = runner.build('// new code');
+expect(all()[0].terminated).toBe(true);
+all()[1].respond({ type: 'built', tapes: [...], ... });
+await secondBuild;
+```
+
+## Test pattern + naming
+
+**File**: `src/lib/machineRunner.test.ts`. Co-located with `machineRunner.ts`.
+
+**Top-level structure**: a single `describe('MachineRunner', ...)` with category-named nested blocks.
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { MachineRunner, WorkerError } from './machineRunner';
+import { makeFakeFactory } from './testUtils';
+
+describe('MachineRunner', () => {
+  describe('protocol shape', () => {
+    it('R-protocol-build: posts {type:"build",engine,code} and resolves with BuiltResponse', async () => {
+      // ...
+    });
+    // ...
+  });
+  // PR2/3 add `describe('timer', ...)`, `describe('pending', ...)`, `describe('error', ...)`.
+});
+```
+
+**`it()` naming**: `'<scenario-id>: <one-line behavior>'`. Two flavors:
+
+- **`R-...` ID** for runner-internal mechanics (most of PR1). Format `R-<topic>-<facet>`. Topic matches the `describe` block name (`protocol`, `timer`, `pending`, `error`); facet is a short descriptor.
+- **`S-...` ID** when the test directly maps to a UI scenario from §10 of `docs/execution-model.md`. Rare in PR1's protocol category; one example: a test verifying `runner.run({ step: true })` posts `step: true` cites `S-step-paused-off` because that scenario relies on the runner's correct posting.
+
+**Grep contract**: tests cite IDs via `\b[SR]-[a-z-]+`. CI / contributor docs grep this regex to find every cited scenario across `*.test.ts` files.
+
+## The seven tests in PR1
+
+Each test follows the single-build pattern above. Acceptance criteria are listed alongside.
+
+1. **`R-protocol-build`** — `runner.build(code)` posts `{ type: 'build', engine, code }` and resolves with the `BuiltResponse` payload the fake responds with. Asserts that the worker is spawned via the factory.
+2. **`R-protocol-step`** — after a build, `runner.step()` posts `{ type: 'step' }` and resolves with the `SteppedResponse` payload.
+3. **`R-protocol-run`** — `runner.run({ maxSteps: 100, debug: true, step: false })` posts `{ type: 'run', maxSteps: 100, debug: true, step: false }`. The default behavior (`runner.run()` with no args) posts `{ type: 'run', maxSteps: MAX_STEPS, debug: false, step: false }`. Resolves with `RanResponse`.
+4. **`R-protocol-resume`** — during a paused run, `runner.resume(true)` posts `{ type: 'resume', step: true }`; `runner.resume()` (default) posts `{ type: 'resume', step: false }`. The run Promise stays pending — resume is not directly resolving.
+5. **`R-protocol-set-debug`** — `runner.setDebug(true)` posts `{ type: 'setDebug', on: true }`. Fire-and-forget; no Promise / no return value.
+6. **`R-protocol-paused-then-ran`** — `runner.run({ onPaused })` invokes `onPaused(pausedPayload)` when the fake responds with a `paused` message, then resolves with `RanResponse` when the fake responds with a `ran` message. Asserts the onPaused payload matches what was sent.
+7. **`S-step-paused-off / R-protocol-step-arming`** — `runner.run({ step: true })` posts `step: true` on the wire. Confirms the cold-start Step path's request shape. Cited under both prefixes because this is the runner-side contract for the user-facing `S-step-{idle,manual,halted}-off` scenarios.
+
+Approximately 150 lines for the test file. ~20 lines per test on average (setup + send + assert + respond + assert).
+
+**What's NOT covered in PR1** (each is a `describe` block that follows-up PRs add):
+
+- `describe('timer')` — per-segment timeout fires after `WORKER_TIMEOUT_MS`; suspend on `paused`, restart on `resume`-send. **PR2.**
+- `describe('pending')` — `simplePending` and `runPending` slots reject on overlap; supersede-on-rebuild rejects existing pending requests; `terminate()` clears both. **PR2.**
+- `describe('error')` — worker-side `error` response wraps as `WorkerError` with `tapes` field; `error` during a `run` rejects the run Promise; `error` during a simple request rejects the simple Promise; `onerror` event invokes `rejectAll`. **PR2.**
+
+## Spec edit — create §14 Scenario ID grammar in `docs/execution-model.md`
+
+The deliverable currently has no scenario-ID grammar published — the grammar table from the meta-spec (`2026-05-08-execution-model-spec-design.md`) was never lifted across. PR1 lifts it as a new closing section §14, with both `S-` and `R-` prefixes documented from the start. Test authors hitting `S-...` or `R-...` IDs need a published reference; until now they had to read the meta-spec to find one.
+
+The new section appends after §13 Cross-references:
+
+````markdown
+## 14. Scenario ID grammar
+
+`<prefix>-<action-or-topic>-<context-or-facet>-<flags?>`
+
+| Slot | Values |
+|---|---|
+| `S-` | literal prefix; marks the token as a UI-scenario reference. Used throughout §§4–10. |
+| `R-` | runner / worker / helper internal scenarios (no UI counterpart). Format `R-<topic>-<facet>`, e.g. `R-protocol-build`, `R-timer-suspend-on-paused`. Used in `*.test.ts` files alongside `S-...` IDs. |
+| `<action>` (S only) | `build`, `step`, `run`, `continue`, `stop`, `takectl`, `apply`, `debug-toggle`, `withpause-toggle`, `error`, `truncate`, `timeout` |
+| `<from-state>` (S only) | `demo`, `idle`, `manual`, `auto`, `cont`, `paused`, `halted` (and `step` only in §11 for legacy RUNNING_STEP citations) |
+| `<topic>` (R only) | `protocol`, `timer`, `pending`, `error`, plus equivalents for the worker / helper test scopes added by future PRs |
+| `<facet>` (R only) | short descriptor — `build`, `step-cycle`, `suspend-on-paused`, `reject-overlap`, `wraps-error-with-tapes`, etc. |
+| `<flags?>` (S only) | optional flag suffix(es); `on` / `off` (debug), `auto` / `cont` (withPause when ambiguous), or compound like `off-auto` |
+
+Conventions:
+- Lowercase + hyphen throughout. No shift key, easy to grep.
+- One token per slot. Don't run flags together.
+- Drop slots that don't matter — uniform behavior across flags ⇒ no flag suffix.
+- Stable across spec edits — prefer adding new IDs over renaming.
+- Both prefixes follow the regex `\b[SR]-[a-z-]+`. Tests / CI grep this to find every cited scenario.
+
+Where IDs live:
+- **Matrix cells** (§8): `S-step-paused-off: arm .after, resume(step), → PAUSED`. Text after `:` is the one-line outcome.
+- **Walk-throughs** (§10): each opens with `### \`S-step-paused-off\` / \`S-step-paused-on\` — Step from break` so the ID is the section anchor.
+- **Tests** ([#47](https://github.com/mellonis/machines-demo/issues/47)): each `it()` cites at least one ID. UI-flow tests cite `S-...` (component / E2E layers); runner / worker / helper tests cite `R-...`. Failing tests point straight at the spec rule they broke.
+- **§11 entries**: cite the IDs they affect when describing today's divergences.
+````
+
+Notes for the implementer:
+
+- The lift is largely verbatim from the meta-spec's §Scenario ID grammar, with two updates: the `R-` prefix is included in the table from the start (no `+` diff), and the "Tests" bullet's wording mentions both prefixes.
+- The grammar table grows two extra rows (`<topic>` and `<facet>`) over the meta-spec version to document `R-`'s structure. The `(S only)` / `(R only)` annotations clarify which slots apply to which prefix.
+- After this section lands, the meta-spec's grammar block can be deleted in a follow-up cleanup (the deliverable now owns the canonical version), but PR1 leaves the meta-spec untouched to keep the diff focused.
+
+## Vitest config
+
+```ts
+// vitest.config.ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/lib/**/*.ts'],
+      exclude: ['src/lib/**/*.test.ts', 'src/lib/testUtils.ts'],
+    },
+  },
+});
+```
+
+`globals: false` keeps tests free of magic globals — every test file imports `describe`, `it`, `expect` explicitly. `environment: 'node'` is sufficient for runner tests; component tests in PR3 will need to switch to `happy-dom` or `jsdom` (a future config split, not a PR1 concern).
+
+## `package.json` updates
+
+Add to `devDependencies` (entries to merge into the existing object):
+
+```json
+"vitest": "^2.1.0",
+"@vitest/coverage-v8": "^2.1.0"
+```
+
+(Pin the major; minor/patch float. Vitest 2.x is current at time of writing; 3.x will likely require minor config changes when adopted.)
+
+Add to `scripts` (entries to merge into the existing object):
+
+```json
+"test": "vitest run",
+"test:watch": "vitest",
+"test:coverage": "vitest run --coverage"
+```
+
+`vitest run` is the one-shot mode used in CI; `vitest` (no args) is watch mode for development.
+
+## Out of scope (deferred)
+
+- **Other `machineRunner` test categories** (timer, pending, error wrapping). PR2.
+- **Worker-side logic tests.** PR2 of #47 — extracts pure helpers from `machineWorker.ts` and unit-tests those.
+- **Component tests.** PR3 of #47 — `@testing-library/svelte` for Toolbar's `runLabel` derivation, button-disabled states, debug-toggle wiring.
+- **Playwright E2E.** PR4 of #47 — happy paths through the full UI stack.
+- **CI integration.** `npm test` is local-only in PR1. Wiring it into the CD workflow as a pre-build gate is a separate small PR after PR1 validates the harness.
+- **Coverage thresholds.** No floor enforced in PR1. After PR2 lands the rest of `machineRunner` tests, threshold can be set realistically.
+- **The `S-step-step-*` / `S-run-step-*` legacy IDs** mentioned in §11 of the execution-model spec — those describe today's RUNNING_STEP code path; tests for them would be skipped under #43's tracking and aren't worth writing in PR1.
+
+## Self-review
+
+After writing tests in implementation:
+
+1. **Each `it()` name matches the `\b[SR]-[a-z-]+: <text>` pattern.** `grep -E 'it\(.*[SR]-' src/lib/machineRunner.test.ts` should match every test.
+2. **Every cited scenario ID exists somewhere it's defined** — `S-` IDs in `docs/execution-model.md`'s matrix / cold-start / walk-throughs; `R-` IDs introduced by this PR follow the `R-<topic>-<facet>` format.
+3. **No test depends on a real Worker.** `grep -n 'new Worker\|new MachineWorker' src/lib/machineRunner.test.ts` should match nothing.
+4. **`MachineView.svelte` callsite still type-checks.** `npm run check` passes.
+5. **All 7 tests pass.** `npm test` exits zero.
+
+Fix any issues inline before declaring done.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@sveltejs/vite-plugin-svelte": "^4.0.0",
         "@tsconfig/svelte": "^5.0.4",
         "@types/node": "^24.12.2",
+        "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^9.0.0",
         "eslint-plugin-svelte": "^2.46.0",
         "svelte": "^5.0.0",
@@ -30,7 +31,68 @@
         "tslib": "^2.8.0",
         "typescript": "^5.6.0",
         "typescript-eslint": "^8.0.0",
-        "vite": "^5.4.0"
+        "vite": "^5.4.0",
+        "vitest": "^4.1.5"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -139,6 +201,40 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -828,6 +924,35 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
+      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@post-machine-js/machine": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@post-machine-js/machine/-/machine-4.0.0.tgz",
@@ -839,6 +964,270 @@
       "peerDependencies": {
         "@turing-machine-js/machine": "^4.0.0"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
+      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
+      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
+      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
@@ -1190,6 +1579,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
@@ -1264,6 +1660,35 @@
       "engines": {
         "npm": ">=7.0.0"
       }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1576,6 +2001,123 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1647,6 +2189,28 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1682,6 +2246,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1768,6 +2342,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -1837,10 +2418,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/devalue": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.0.tgz",
       "integrity": "sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==",
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -2113,6 +2711,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2121,6 +2729,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2264,6 +2882,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2340,6 +2965,52 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -2415,6 +3086,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -2461,6 +3393,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -2517,6 +3477,17 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -2602,6 +3573,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2623,9 +3601,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -2783,6 +3761,40 @@
         "node": ">=4"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
+      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.128.0",
+        "@rolldown/pluginutils": "1.0.0-rc.18"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -2877,6 +3889,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2886,6 +3905,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3056,6 +4089,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -3071,6 +4121,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3248,6 +4308,201 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
+      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0-rc.18",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -3268,6 +4523,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "build": "svelte-check --tsconfig ./tsconfig.json && vite build",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.0",
@@ -25,6 +28,7 @@
     "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "@tsconfig/svelte": "^5.0.4",
     "@types/node": "^24.12.2",
+    "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^9.0.0",
     "eslint-plugin-svelte": "^2.46.0",
     "svelte": "^5.0.0",
@@ -33,6 +37,7 @@
     "tslib": "^2.8.0",
     "typescript": "^5.6.0",
     "typescript-eslint": "^8.0.0",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -5,6 +5,7 @@
   import ControlPanel from './ControlPanel.svelte';
   import Log from './Log.svelte';
   import type { LogEntry, LogKind } from '../lib/log.ts';
+  import MachineWorker from '../lib/machineWorker.ts?worker';
   import { MachineRunner, WorkerError } from '../lib/machineRunner.ts';
   import * as turing from '@turing-machine-js/machine';
   import { VIEWPORT_WIDTH } from '../lib/caps.ts';
@@ -130,7 +131,7 @@
   // the editor chunk loads in parallel and slots in once ready.
   const editorPromise = import('./Editor.svelte').then((m) => m.default);
 
-  const runner = new MachineRunner(untrack(() => engine));
+  const runner = new MachineRunner(untrack(() => engine), () => new MachineWorker());
 
   /* ───── derived ─────
    * Single source of truth for button-disabled state and panel visibility.

--- a/src/lib/machineRunner.test.ts
+++ b/src/lib/machineRunner.test.ts
@@ -248,5 +248,33 @@ describe('MachineRunner', () => {
 
       await expect(runPromise).resolves.toEqual(ranPayload);
     });
+
+    it('S-step-paused-off / R-protocol-step-arming: run({step:true}) posts step=true', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run({ step: true, debug: false });
+
+      expect(current().last).toMatchObject({
+        type: 'run',
+        step: true,
+        debug: false,
+      });
+
+      // Wrap up cleanly so the pending run doesn't leak between tests.
+      current().respond({
+        type: 'ran',
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 0,
+      });
+      await runPromise;
+    });
   });
 });

--- a/src/lib/machineRunner.test.ts
+++ b/src/lib/machineRunner.test.ts
@@ -26,5 +26,30 @@ describe('MachineRunner', () => {
 
       await expect(buildPromise).resolves.toEqual(builtPayload);
     });
+
+    it('R-protocol-step: posts {type:"step"} and resolves with SteppedResponse', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      // Build first to spawn the worker.
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const stepPromise = runner.step();
+
+      expect(current().last).toEqual({ type: 'step' });
+
+      const steppedPayload = {
+        type: 'stepped' as const,
+        halted: false,
+        commands: null,
+        nextCommands: null,
+        stepsApplied: 1,
+      };
+      current().respond(steppedPayload);
+
+      await expect(stepPromise).resolves.toEqual(steppedPayload);
+    });
   });
 });

--- a/src/lib/machineRunner.test.ts
+++ b/src/lib/machineRunner.test.ts
@@ -195,5 +195,58 @@ describe('MachineRunner', () => {
       // No build yet, so no worker. setDebug must not throw.
       expect(() => runner.setDebug(true)).not.toThrow();
     });
+
+    it('R-protocol-paused-then-ran: run() invokes onPaused on paused, resolves on ran', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const pausedPayloads: Parameters<NonNullable<Parameters<MachineRunner['run']>[0]>['onPaused']>[0][] = [];
+      const runPromise = runner.run({
+        debug: true,
+        onPaused: (p) => {
+          pausedPayloads.push(p);
+        },
+      });
+
+      const pausedPayload = {
+        type: 'paused' as const,
+        tapes: [],
+        commands: [],
+        stepsApplied: 1,
+        state: 'q1',
+        currentSymbols: ['a'],
+        debugBreak: { before: true },
+      };
+      current().respond(pausedPayload);
+
+      // onPaused fired with the payload.
+      expect(pausedPayloads).toHaveLength(1);
+      expect(pausedPayloads[0]).toEqual(pausedPayload);
+
+      // Run still pending.
+      let runSettled = false;
+      void runPromise.then(() => {
+        runSettled = true;
+      });
+      await Promise.resolve();
+      expect(runSettled).toBe(false);
+
+      // Now finish the run.
+      const ranPayload = {
+        type: 'ran' as const,
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 5,
+      };
+      current().respond(ranPayload);
+
+      await expect(runPromise).resolves.toEqual(ranPayload);
+    });
   });
 });

--- a/src/lib/machineRunner.test.ts
+++ b/src/lib/machineRunner.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { MAX_STEPS } from './caps';
 import { MachineRunner } from './machineRunner';
+import { type PausedResponse } from './types';
 import { makeFakeFactory } from './testUtils';
 
 describe('MachineRunner', () => {
@@ -138,7 +139,7 @@ describe('MachineRunner', () => {
         stepsApplied: 1,
         state: 'q1',
         currentSymbols: ['a'],
-        debugBreak: { before: true },
+        debugBreak: { before: true as const },
       });
       expect(pausedSeen).toBe(true);
 
@@ -204,7 +205,7 @@ describe('MachineRunner', () => {
       current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
       await buildPromise;
 
-      const pausedPayloads: Parameters<NonNullable<Parameters<MachineRunner['run']>[0]>['onPaused']>[0][] = [];
+      const pausedPayloads: PausedResponse[] = [];
       const runPromise = runner.run({
         debug: true,
         onPaused: (p) => {
@@ -219,7 +220,7 @@ describe('MachineRunner', () => {
         stepsApplied: 1,
         state: 'q1',
         currentSymbols: ['a'],
-        debugBreak: { before: true },
+        debugBreak: { before: true as const },
       };
       current().respond(pausedPayload);
 

--- a/src/lib/machineRunner.test.ts
+++ b/src/lib/machineRunner.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { MAX_STEPS } from './caps';
 import { MachineRunner } from './machineRunner';
 import { makeFakeFactory } from './testUtils';
 
@@ -50,6 +51,67 @@ describe('MachineRunner', () => {
       current().respond(steppedPayload);
 
       await expect(stepPromise).resolves.toEqual(steppedPayload);
+    });
+
+    it('R-protocol-run: posts {type:"run",maxSteps,debug,step} and resolves with RanResponse', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      // Build first.
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      // Custom-arg run.
+      const runPromise = runner.run({ maxSteps: 100, debug: true, step: false });
+
+      expect(current().last).toEqual({
+        type: 'run',
+        maxSteps: 100,
+        debug: true,
+        step: false,
+      });
+
+      const ranPayload = {
+        type: 'ran' as const,
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 5,
+      };
+      current().respond(ranPayload);
+
+      await expect(runPromise).resolves.toEqual(ranPayload);
+    });
+
+    it('R-protocol-run-defaults: posts MAX_STEPS, debug=false, step=false on bare run()', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run();
+
+      expect(current().last).toEqual({
+        type: 'run',
+        maxSteps: MAX_STEPS,
+        debug: false,
+        step: false,
+      });
+
+      current().respond({
+        type: 'ran',
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 0,
+      });
+
+      await runPromise;
     });
   });
 });

--- a/src/lib/machineRunner.test.ts
+++ b/src/lib/machineRunner.test.ts
@@ -113,5 +113,63 @@ describe('MachineRunner', () => {
 
       await runPromise;
     });
+
+    it('R-protocol-resume: posts {type:"resume",step} and does not resolve the run promise', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      // Build, then start a run with onPaused.
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      let pausedSeen = false;
+      const runPromise = runner.run({
+        onPaused: () => {
+          pausedSeen = true;
+        },
+      });
+
+      // Worker pauses.
+      current().respond({
+        type: 'paused',
+        tapes: [],
+        commands: [],
+        stepsApplied: 1,
+        state: 'q1',
+        currentSymbols: ['a'],
+        debugBreak: { before: true },
+      });
+      expect(pausedSeen).toBe(true);
+
+      // Now resume(step=true).
+      runner.resume(true);
+
+      expect(current().last).toEqual({ type: 'resume', step: true });
+
+      // Run promise still pending — resolves only on `ran`/`error`.
+      // Sanity check: settle a microtask, ensure no resolution yet.
+      let runResolved = false;
+      void runPromise.then(() => {
+        runResolved = true;
+      });
+      await Promise.resolve();
+      expect(runResolved).toBe(false);
+
+      // Default resume() posts step:false.
+      runner.resume();
+      expect(current().last).toEqual({ type: 'resume', step: false });
+
+      // Cleanly settle the pending run by responding with `ran`.
+      current().respond({
+        type: 'ran',
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 1,
+      });
+      await runPromise;
+    });
   });
 });

--- a/src/lib/machineRunner.test.ts
+++ b/src/lib/machineRunner.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { MachineRunner } from './machineRunner';
+import { makeFakeFactory } from './testUtils';
+
+describe('MachineRunner', () => {
+  describe('protocol shape', () => {
+    it('R-protocol-build: posts {type:"build",engine,code} and resolves with BuiltResponse', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+
+      expect(current().last).toEqual({
+        type: 'build',
+        engine: 'turing',
+        code: '// user code',
+      });
+
+      const builtPayload = {
+        type: 'built' as const,
+        tapes: [],
+        alphabets: [],
+        halted: false,
+      };
+      current().respond(builtPayload);
+
+      await expect(buildPromise).resolves.toEqual(builtPayload);
+    });
+  });
+});

--- a/src/lib/machineRunner.test.ts
+++ b/src/lib/machineRunner.test.ts
@@ -171,5 +171,29 @@ describe('MachineRunner', () => {
       });
       await runPromise;
     });
+
+    it('R-protocol-set-debug: posts {type:"setDebug",on}', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      // Build first to spawn the worker (setDebug is a no-op without one).
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      runner.setDebug(true);
+      expect(current().last).toEqual({ type: 'setDebug', on: true });
+
+      runner.setDebug(false);
+      expect(current().last).toEqual({ type: 'setDebug', on: false });
+    });
+
+    it('R-protocol-set-debug-no-worker: setDebug before build is a silent no-op', () => {
+      const { factory } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      // No build yet, so no worker. setDebug must not throw.
+      expect(() => runner.setDebug(true)).not.toThrow();
+    });
   });
 });

--- a/src/lib/machineRunner.ts
+++ b/src/lib/machineRunner.ts
@@ -1,4 +1,3 @@
-import MachineWorker from './machineWorker.ts?worker';
 import { MAX_STEPS, WORKER_TIMEOUT_MS } from './caps.ts';
 import {
   type BuiltResponse,
@@ -27,6 +26,15 @@ export class WorkerError extends Error {
   }
 }
 
+export interface MachineWorkerLike {
+  postMessage(msg: WorkerRequest): void;
+  terminate(): void;
+  onmessage: ((e: MessageEvent<WorkerResponse>) => void) | null;
+  onerror: ((e: ErrorEvent) => void) | null;
+}
+
+export type WorkerFactory = () => MachineWorkerLike;
+
 type SimplePending = {
   resolve: (data: WorkerResponse) => void;
   reject: (err: Error) => void;
@@ -42,12 +50,14 @@ type RunPending = {
 
 export class MachineRunner {
   readonly engine: Engine;
-  private worker: Worker | null = null;
+  private worker: MachineWorkerLike | null = null;
+  private workerFactory: WorkerFactory;
   private simplePending: SimplePending | null = null;
   private runPending: RunPending | null = null;
 
-  constructor(engine: Engine) {
+  constructor(engine: Engine, workerFactory: WorkerFactory) {
     this.engine = engine;
+    this.workerFactory = workerFactory;
   }
 
   private rejectAll(err: Error): void {
@@ -69,7 +79,7 @@ export class MachineRunner {
       this.worker.terminate();
       this.worker = null;
     }
-    this.worker = new MachineWorker();
+    this.worker = this.workerFactory();
     this.worker.onmessage = (e: MessageEvent<WorkerResponse>) => this.onMessage(e.data);
     this.worker.onerror = (e) => this.onWorkerError(e);
   }

--- a/src/lib/testUtils.ts
+++ b/src/lib/testUtils.ts
@@ -1,0 +1,71 @@
+import type { MachineWorkerLike, WorkerFactory } from './machineRunner';
+import type { WorkerRequest, WorkerResponse } from './types';
+
+/**
+ * Test double for the Web Worker that `MachineRunner` posts to.
+ *
+ * - `postedMessages` captures every request sent by the runner.
+ * - Tests trigger inbound messages via `respond(...)` and `errorEvent(...)`.
+ * - Implements `MachineWorkerLike` structurally; can be passed wherever a
+ *   real `Worker` is expected on the runner side.
+ */
+export class FakeWorker implements MachineWorkerLike {
+  postedMessages: WorkerRequest[] = [];
+
+  onmessage: ((e: MessageEvent<WorkerResponse>) => void) | null = null;
+  onerror: ((e: ErrorEvent) => void) | null = null;
+
+  terminated = false;
+
+  postMessage(msg: WorkerRequest): void {
+    if (this.terminated) throw new Error('postMessage on terminated worker');
+    this.postedMessages.push(msg);
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  // -- Test helpers (not part of MachineWorkerLike) --
+
+  respond(data: WorkerResponse): void {
+    if (!this.onmessage) throw new Error('respond() before onmessage handler set');
+    this.onmessage({ data } as MessageEvent<WorkerResponse>);
+  }
+
+  errorEvent(message: string): void {
+    if (!this.onerror) throw new Error('errorEvent() before onerror handler set');
+    this.onerror({ message } as ErrorEvent);
+  }
+
+  get last(): WorkerRequest | undefined {
+    return this.postedMessages[this.postedMessages.length - 1];
+  }
+}
+
+/**
+ * Returns a factory that produces a fresh `FakeWorker` on each call, plus
+ * accessors for the most recent fake (`current()`) and every fake produced
+ * (`all()`). Mirrors `MachineRunner.spawnWorker` semantics: each `build()`
+ * invokes the factory once.
+ */
+export function makeFakeFactory(): {
+  factory: WorkerFactory;
+  current: () => FakeWorker;
+  all: () => FakeWorker[];
+} {
+  const fakes: FakeWorker[] = [];
+  return {
+    factory: () => {
+      const fake = new FakeWorker();
+      fakes.push(fake);
+      return fake;
+    },
+    current: () => {
+      const last = fakes[fakes.length - 1];
+      if (!last) throw new Error('makeFakeFactory: factory not yet called');
+      return last;
+    },
+    all: () => fakes.slice(),
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/lib/**/*.ts'],
+      exclude: ['src/lib/**/*.test.ts', 'src/lib/testUtils.ts'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

PR1 of [#47](https://github.com/mellonis/machines-demo/issues/47). Lands the test harness plus the first 9 tests covering `MachineRunner`'s protocol-shape contract — the request/response wire shapes for `build` / `step` / `run` / `resume` / `setDebug`. Subsequent PRs (PR2/3/4) layer on the timer / pending / error categories, then the worker-side helpers, component tests, and Playwright E2E.

What's in this PR:

- **Vitest harness** — `vitest.config.ts` (node env, no DOM needed for runner tests), v8 coverage, `npm test` / `test:watch` / `test:coverage` scripts.
- **`MachineRunner` factory injection** (production refactor) — constructor now takes `(engine, workerFactory)` instead of `(engine)`. The Vite-specific `?worker` import moves out of `machineRunner.ts` (now pure TS) and into `MachineView.svelte` (the only Svelte/Vite-specific module on the runner-construction path). Tests inject a `FakeWorker` directly without Vite mocking.
- **`FakeWorker` + `makeFakeFactory()`** in `src/lib/testUtils.ts` — test double capturing `postMessage` calls and providing `respond(...)` / `errorEvent(...)` to push synthetic responses back. Factory returns a fresh fake per call (mirroring `MachineRunner.spawnWorker`'s once-per-build semantics) with `current()` and `all()` accessors.
- **9 protocol-shape tests** in `src/lib/machineRunner.test.ts` — every request type's wire shape + Promise resolution, plus the paused/ran callback interleave and the cold-start step-arming path.
- **`docs/execution-model.md` §14 Scenario ID grammar** — lifts the grammar from the meta-spec into the deliverable. Adds the `R-` prefix for runner / worker / helper internal scenarios alongside the existing `S-` UI-scenario prefix.
- **Spec design + plan** committed under `docs/superpowers/specs/` and `docs/superpowers/plans/` for the implementation history.

Two type errors in T10's test (the spec design's `Parameters<NonNullable<...>>[0][]` chain and a `debugBreak: { before: true }` literal-vs-`boolean` widening) were caught during the final-review pass and fixed inline (`fix(machineRunner.test): resolve two type errors in paused-then-ran test`).

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — exit 0
- `npm run build` — succeeds
- `npm test` — 9 / 9 pass (132ms)
- `npm run test:coverage` — `machineRunner.ts` at 54% statements / 71% functions (timer / pending / error paths uncovered; deferred to PR2)

Scenario IDs cited (10 unique across 9 tests; one test cites both an `S-` and an `R-` ID since it covers a UI-scenario's underlying runner mechanic):

- `R-protocol-build`
- `R-protocol-step`
- `R-protocol-run`, `R-protocol-run-defaults`
- `R-protocol-resume`
- `R-protocol-set-debug`, `R-protocol-set-debug-no-worker`
- `R-protocol-paused-then-ran`
- `R-protocol-step-arming` / `S-step-paused-off` (cold-start step wire shape)

## Out of scope (deferred to follow-up PRs)

- `machineRunner` timer / pending-slot / error-wrapping tests — PR2 of #47 (extends `describe('protocol shape')` with sibling `describe('timer')` / `describe('pending')` / `describe('error')` blocks in the same file).
- Worker-side logic tests — PR2 of #47 (separate scope; extracts pure helpers from `machineWorker.ts`).
- Component tests (Toolbar, MachineView) — PR3 of #47.
- Playwright E2E — PR4 of #47.
- CI integration (running `npm test` as a pre-build gate in `.github/workflows/main.yml`) — separate small PR after PR1 lands.

## Test plan

- [ ] PR review of `MachineRunner` factory-injection refactor (the only production code change)
- [ ] PR review of `FakeWorker` shape and `makeFakeFactory` ergonomics
- [ ] Spot-check 1-2 tests for clarity and assertion strength
- [ ] Confirm scenario IDs cited in tests appear in `docs/execution-model.md` §14 grammar
- [ ] Run `npm test` locally to verify reproducibility