### PR TITLE
test: machineRunner timer / pending / error tests (PR2 of #47)

### DIFF
--- a/docs/superpowers/plans/2026-05-09-test-infra-pr2.md
+++ b/docs/superpowers/plans/2026-05-09-test-infra-pr2.md
@@ -1,0 +1,600 @@
+# Test infrastructure PR2 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the remaining `machineRunner` test categories — timer behavior, pending-slot model, and error wrapping — as 16 new tests across three sibling `describe` blocks in `src/lib/machineRunner.test.ts`. PR2 of [#47](https://github.com/mellonis/machines-demo/issues/47).
+
+**Architecture:** No production code changes. Append three new `describe` blocks (`timer`, `pending`, `error`) inside the existing outer `describe('MachineRunner')`. Timer block uses `vi.useFakeTimers()` per-test (via `beforeEach` / `afterEach`); pending and error blocks use real timers. Same `FakeWorker` + `makeFakeFactory()` harness from PR1.
+
+**Tech Stack:** Vitest 4.x (`vi.useFakeTimers`, `vi.advanceTimersByTimeAsync`), TypeScript 5.x.
+
+**Spec:** `docs/superpowers/specs/2026-05-09-test-infra-pr2-design.md`
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `src/lib/machineRunner.test.ts` | **Modify** — extend imports (add `vi`, `beforeEach`, `afterEach`, `WORKER_TIMEOUT_MS`, `WorkerError`); append three sibling `describe` blocks. |
+
+No other files modified. No new dependencies.
+
+---
+
+## Verification model
+
+After each task:
+
+1. `npm test` — Vitest one-shot. Total test count grows by the number added in the task (T1: +6 → 15 total; T2: +5 → 20; T3: +5 → 25).
+2. `npm run check` — exits 0.
+3. `npm run lint` — exits 0.
+
+Final task (T4) re-runs all four checks plus `npm run build` and `npm run test:coverage`.
+
+---
+
+## Task 1: Append `describe('timer')` block
+
+**Files:**
+- Modify: `src/lib/machineRunner.test.ts`
+
+- [ ] **Step 1: Update imports**
+
+Replace the current import block at the top of `src/lib/machineRunner.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { MAX_STEPS } from './caps';
+import { MachineRunner } from './machineRunner';
+import { makeFakeFactory } from './testUtils';
+```
+
+with:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MAX_STEPS, WORKER_TIMEOUT_MS } from './caps';
+import { MachineRunner, WorkerError } from './machineRunner';
+import { makeFakeFactory } from './testUtils';
+```
+
+(Adds `vi`, `beforeEach`, `afterEach` from vitest; `WORKER_TIMEOUT_MS` from caps; `WorkerError` from machineRunner.)
+
+- [ ] **Step 2: Append `describe('timer')` block**
+
+After the closing `});` of the existing `describe('protocol shape', ...)` block (still inside the outer `describe('MachineRunner', ...)`), append:
+
+```ts
+  describe('timer', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('R-timer-build-timeout: build with no response rejects with timeout error and terminates worker', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS);
+
+      await expect(buildPromise).rejects.toThrow(
+        `timeout after ${WORKER_TIMEOUT_MS}ms — worker terminated (likely infinite loop)`,
+      );
+      expect(current().terminated).toBe(true);
+    });
+
+    it('R-timer-step-timeout: step with no response rejects with timeout error and terminates worker', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const stepPromise = runner.step();
+      await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS);
+
+      await expect(stepPromise).rejects.toThrow(/timeout after/);
+      expect(current().terminated).toBe(true);
+    });
+
+    it('R-timer-run-timeout-no-paused: run with no paused/ran rejects with timeout error and terminates worker', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run({ debug: true, onPaused: () => {} });
+      await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS);
+
+      await expect(runPromise).rejects.toThrow(/timeout after/);
+      expect(current().terminated).toBe(true);
+    });
+
+    it('R-timer-suspend-on-paused: paused clears the timer; advancing past WORKER_TIMEOUT_MS does not reject', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run({ debug: true, onPaused: () => {} });
+      current().respond({
+        type: 'paused',
+        tapes: [],
+        commands: [],
+        stepsApplied: 1,
+        state: 'q1',
+        currentSymbols: ['a'],
+        debugBreak: { before: true as const },
+      });
+
+      // Advance time well past the timeout — paused should have cleared it.
+      await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS * 2);
+
+      // Run should still be pending.
+      let runSettled = false;
+      void runPromise.then(
+        () => { runSettled = true; },
+        () => { runSettled = true; },
+      );
+      await Promise.resolve();
+      expect(runSettled).toBe(false);
+
+      // Settle cleanly so the test doesn't leak a pending Promise.
+      current().respond({
+        type: 'ran',
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 1,
+      });
+      await runPromise;
+    });
+
+    it('R-timer-restart-on-resume: resume re-arms the timer; advancing past WORKER_TIMEOUT_MS rejects', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run({ debug: true, onPaused: () => {} });
+      current().respond({
+        type: 'paused',
+        tapes: [],
+        commands: [],
+        stepsApplied: 1,
+        state: 'q1',
+        currentSymbols: ['a'],
+        debugBreak: { before: true as const },
+      });
+
+      runner.resume(false);
+      await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS);
+
+      await expect(runPromise).rejects.toThrow(/timeout after/);
+    });
+
+    it('R-timer-cleared-on-ran: ran response clears the timer; subsequent time advance has no effect', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run();
+      current().respond({
+        type: 'ran',
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 0,
+      });
+      await runPromise;
+
+      // Advance time past WORKER_TIMEOUT_MS — should be a no-op since the timer was cleared on ran.
+      await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS * 2);
+
+      // If the timer had still been alive, it would have called terminate().
+      expect(current().terminated).toBe(false);
+    });
+  });
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `npm test`
+
+Expected: 15 tests pass (PR1's 9 + PR2's 6 timer tests).
+
+- [ ] **Step 4: Run check + lint**
+
+Run: `npm run check && npm run lint`
+
+Expected: both exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/machineRunner.test.ts
+git commit -m "test(machineRunner): timer category — 6 tests for per-segment WORKER_TIMEOUT_MS"
+```
+
+---
+
+## Task 2: Append `describe('pending')` block
+
+**Files:**
+- Modify: `src/lib/machineRunner.test.ts`
+
+- [ ] **Step 1: Append `describe('pending')` block**
+
+After the closing `});` of the `describe('timer', ...)` block from T1, append:
+
+```ts
+  describe('pending', () => {
+    it('R-pending-simple-overlap: build then step before built rejects step', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      await expect(runner.step()).rejects.toThrow('previous request still pending');
+
+      // Settle the build.
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+    });
+
+    it('R-pending-run-overlap: run then run synchronously throws', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run();
+
+      // run() is NOT async — overlap throws synchronously.
+      expect(() => runner.run()).toThrow('previous request still pending');
+
+      // Settle the first run.
+      current().respond({
+        type: 'ran',
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 0,
+      });
+      await runPromise;
+    });
+
+    it('R-pending-simple-during-run: step during pending run rejects step', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run();
+      await expect(runner.step()).rejects.toThrow('previous request still pending');
+
+      // Settle.
+      current().respond({
+        type: 'ran',
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 0,
+      });
+      await runPromise;
+    });
+
+    it('R-pending-rebuild-rejects-pending: second build rejects the first with "superseded by new worker"', async () => {
+      const { factory, all } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const firstBuild = runner.build('// first');
+      expect(all()).toHaveLength(1);
+
+      const secondBuild = runner.build('// second');
+      expect(all()).toHaveLength(2);
+
+      await expect(firstBuild).rejects.toThrow('superseded by new worker');
+      expect(all()[0].terminated).toBe(true);
+
+      // Second build proceeds normally.
+      all()[1].respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await secondBuild;
+    });
+
+    it('R-pending-terminate-rejects-all: terminate rejects pending run; then rejects pending build on a fresh build', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      // Pending run case.
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run();
+      runner.terminate();
+
+      await expect(runPromise).rejects.toThrow('runner terminated');
+      expect(current().terminated).toBe(true);
+
+      // Pending build case (fresh build via spawnWorker, then terminate before built response).
+      const buildAgain = runner.build('// user code');
+      runner.terminate();
+
+      await expect(buildAgain).rejects.toThrow('runner terminated');
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test`
+
+Expected: 20 tests pass (15 from before + 5 pending tests).
+
+- [ ] **Step 3: Run check + lint**
+
+Run: `npm run check && npm run lint`
+
+Expected: both exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/machineRunner.test.ts
+git commit -m "test(machineRunner): pending category — 5 tests for two-slot model + supersede"
+```
+
+---
+
+## Task 3: Append `describe('error')` block
+
+**Files:**
+- Modify: `src/lib/machineRunner.test.ts`
+
+- [ ] **Step 1: Append `describe('error')` block**
+
+After the closing `});` of the `describe('pending', ...)` block from T2, append:
+
+```ts
+  describe('error', () => {
+    it('R-error-wraps-as-worker-error: error response with tapes wraps as WorkerError', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      const tapes = [{ symbols: ['a', 'b'], position: 0 }];
+      current().respond({ type: 'error', message: 'parse error', tapes });
+
+      let caught: unknown;
+      try {
+        await buildPromise;
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBeInstanceOf(WorkerError);
+      expect((caught as WorkerError).message).toBe('parse error');
+      expect((caught as WorkerError).tapes).toEqual(tapes);
+    });
+
+    it('R-error-tapes-default-null: error response without tapes field → tapes is null (not undefined)', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'error', message: 'no edge for symbol' });
+
+      let caught: unknown;
+      try {
+        await buildPromise;
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBeInstanceOf(WorkerError);
+      expect((caught as WorkerError).tapes).toBeNull();
+    });
+
+    it('R-error-during-step: error response during pending step rejects step with WorkerError', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const stepPromise = runner.step();
+      current().respond({ type: 'error', message: 'mid-step error' });
+
+      await expect(stepPromise).rejects.toBeInstanceOf(WorkerError);
+    });
+
+    it('R-error-during-run: error response during pending run rejects run with WorkerError; worker not terminated', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run();
+      current().respond({ type: 'error', message: 'mid-run error' });
+
+      await expect(runPromise).rejects.toBeInstanceOf(WorkerError);
+      expect(current().terminated).toBe(false);
+    });
+
+    it('R-error-onerror-event: worker.onerror fires; pending request rejects with plain Error and "worker error:" prefix', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const stepPromise = runner.step();
+      current().errorEvent('worker crashed');
+
+      let caught: unknown;
+      try {
+        await stepPromise;
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      expect(caught).not.toBeInstanceOf(WorkerError);
+      expect((caught as Error).message).toMatch(/^worker error: worker crashed/);
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test`
+
+Expected: 25 tests pass (20 from before + 5 error tests).
+
+- [ ] **Step 3: Run check + lint**
+
+Run: `npm run check && npm run lint`
+
+Expected: both exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/machineRunner.test.ts
+git commit -m "test(machineRunner): error category — 5 tests for WorkerError wrapping + onerror"
+```
+
+---
+
+## Task 4: Final verification
+
+**Files:** none modified
+
+- [ ] **Step 1: Type-check**
+
+Run: `npm run check`
+
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+
+Expected: exit 0.
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+
+Expected: build succeeds; `dist/` produced.
+
+- [ ] **Step 4: Run all tests**
+
+Run: `npm test`
+
+Expected:
+
+```
+ Test Files  1 passed (1)
+      Tests  25 passed (25)
+```
+
+- [ ] **Step 5: Coverage check**
+
+Run: `npm run test:coverage`
+
+Expected: `src/lib/machineRunner.ts` shows ≥80% statement coverage (PR1 baseline was ~54%; PR2's 16 tests should push it well above 80%). No threshold enforced; this is informational. Capture the per-file coverage % in your report.
+
+- [ ] **Step 6: Scenario-ID grep audit**
+
+Run:
+
+```bash
+grep -oE '\b[SR]-[a-z-]+' src/lib/machineRunner.test.ts | sort -u
+```
+
+Expected: 26 unique IDs total (25 `R-` + 1 `S-`):
+
+```
+R-error-during-run
+R-error-during-step
+R-error-onerror-event
+R-error-tapes-default-null
+R-error-wraps-as-worker-error
+R-pending-rebuild-rejects-pending
+R-pending-run-overlap
+R-pending-simple-during-run
+R-pending-simple-overlap
+R-pending-terminate-rejects-all
+R-protocol-build
+R-protocol-paused-then-ran
+R-protocol-resume
+R-protocol-run
+R-protocol-run-defaults
+R-protocol-set-debug
+R-protocol-set-debug-no-worker
+R-protocol-step
+R-protocol-step-arming
+R-timer-build-timeout
+R-timer-cleared-on-ran
+R-timer-restart-on-resume
+R-timer-run-timeout-no-paused
+R-timer-step-timeout
+R-timer-suspend-on-paused
+S-step-paused-off
+```
+
+If the count or list differs, investigate — likely a typo in one of the new test names.
+
+- [ ] **Step 7: No fix commit if all checks pass**
+
+If steps 1–6 reveal real issues (broken test, type error, lint fail), fix inline in `src/lib/machineRunner.test.ts` and amend the relevant task's commit. Don't create a "review-pass" commit.
+
+If no fixes needed, T4 has no commit.
+
+---
+
+## Self-review
+
+**Spec coverage.** Each spec section maps to tasks:
+
+- §Decisions and §File map — captured in plan intro and the file map.
+- §Test layout (sibling structure) — T1 sets the import block + first describe; T2/T3 append siblings.
+- §`describe('timer')` 6 tests — T1.
+- §`describe('pending')` 5 tests — T2.
+- §`describe('error')` 5 tests — T3.
+- §Out of scope — explicitly not in any task.
+- §Self-review (5 verifications) — T4.
+
+**Placeholder scan.** No "TBD", "TODO", or "implement later". Every code step shows the actual test code. Every command shows the expected output.
+
+**Type / vocabulary consistency.** All tests use `MachineRunner`, `WorkerError`, `WORKER_TIMEOUT_MS`, `MAX_STEPS`, `FakeWorker` (via `makeFakeFactory`'s `current()` / `all()`), and the `vi.useFakeTimers` / `vi.advanceTimersByTimeAsync` Vitest API consistently. Scenario IDs match the spec design's `R-<topic>-<facet>` grammar.
+
+**Branch hygiene.** All commits land on the existing `47-test-infra-pr2` branch (which already has the spec design commit `be92e95`). Do not commit to master.

--- a/docs/superpowers/specs/2026-05-09-test-infra-pr2-design.md
+++ b/docs/superpowers/specs/2026-05-09-test-infra-pr2-design.md
@@ -1,0 +1,132 @@
+# Test infrastructure — PR2 (machineRunner timer / pending / error tests) — design
+
+Tracks: [#47](https://github.com/mellonis/machines-demo/issues/47) (test infrastructure). PR2 of an expected 4-PR series. Builds on PR1 (merged in #55).
+
+## Problem
+
+PR1 landed the test harness (Vitest + `FakeWorker` + `makeFakeFactory`) plus 9 protocol-shape tests covering each worker request's wire shape. The remaining three `machineRunner` test categories from #47's scope — timer behavior, pending-slot model, error wrapping — are still uncovered. Coverage on `src/lib/machineRunner.ts` sits around 54% statements / 71% functions; the lines that fail are the ones PR2 covers (timer paths in `sendSimple` / `startRunTimer` / `stopRunTimer`, `rejectAll` invariants, `onMessage`'s error branch, `onWorkerError`).
+
+PR2 closes those gaps. No production refactor — the runner's surface stays exactly as PR1 left it.
+
+## Decisions
+
+- **Scope: `machineRunner` test categories only.** Worker-side helper extraction (a separate concern, requires designing what counts as a "pure helper" inside `machineWorker.ts`) is deferred to PR3. Component tests are PR4. Playwright E2E is PR5.
+- **Test layout: append three sibling `describe` blocks** to `src/lib/machineRunner.test.ts`. Same file, same `describe('MachineRunner')` outer block, no new files.
+- **Timer mocking: `vi.useFakeTimers()` per-test in the timer block.** Wrapped in `beforeEach` / `afterEach` of `describe('timer')` so a failure mid-test doesn't leak fake timers into subsequent describe blocks. Other blocks stay on real timers (real timers don't fire because none of those tests wait long enough for `WORKER_TIMEOUT_MS`).
+- **Use `vi.advanceTimersByTimeAsync`** (the `Async` variant), not `vi.advanceTimersByTime`. The `Async` variant flushes pending Promise microtasks, which the runner's timeout-callback rejection chain depends on.
+- **Preserve the runner's async/sync asymmetry.** `runner.build(...)` and `.step()` are `async` (synchronous throws become rejections); `runner.run(...)` is **not** `async` and synchronously throws on overlap. Tests use the appropriate `.rejects.toThrow(...)` vs `() => runner.run(...).toThrow(...)` matcher per call. Production-side fix is out of scope.
+- **Plain `Error` for `onerror` rejections, `WorkerError` for `error` responses.** The runner distinguishes these intentionally — `onerror` is a Worker-environment event (e.g., script-level crash), the `error` response is in-protocol. Tests verify both shapes match the runner's existing distinction.
+- **Scenario IDs all `R-`-prefixed.** No `S-` IDs — these are runner-internal mechanics with no UI counterpart. Format `R-<topic>-<facet>` per the §14 grammar in `docs/execution-model.md`.
+
+## File map
+
+| File | Change |
+|---|---|
+| `src/lib/machineRunner.test.ts` | **Modify** — append three `describe` blocks (`timer`, `pending`, `error`) inside the existing outer `describe('MachineRunner')`. ~16 tests, ~250 added lines. |
+
+No other files modified.
+
+## Test layout (sibling structure)
+
+```ts
+describe('MachineRunner', () => {
+  describe('protocol shape', () => { /* PR1 — 9 tests, untouched */ });
+
+  describe('timer', () => {
+    beforeEach(() => { vi.useFakeTimers(); });
+    afterEach(() => { vi.useRealTimers(); });
+    // 6 tests
+  });
+
+  describe('pending', () => {
+    // real timers; 5 tests
+  });
+
+  describe('error', () => {
+    // real timers; 5 tests
+  });
+});
+```
+
+Imports updated at the top of the file:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MAX_STEPS, WORKER_TIMEOUT_MS } from './caps';
+import { MachineRunner, WorkerError } from './machineRunner';
+import { makeFakeFactory } from './testUtils';
+```
+
+(Adds `vi`, `beforeEach`, `afterEach` from `vitest`; adds `WORKER_TIMEOUT_MS` from `caps`; adds `WorkerError` from `machineRunner`. The existing PR1 imports stay.)
+
+## `describe('timer')` — 6 tests
+
+Each test follows the shape: `setup → exercise → advance time → assert`.
+
+1. **`R-timer-build-timeout`** — `runner.build(...)`; `await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS)`; assert build Promise rejects with `'timeout after 5000ms — worker terminated (likely infinite loop)'` and `current().terminated === true`.
+2. **`R-timer-step-timeout`** — successful build, then `runner.step()`; advance time; assert step Promise rejects with the same message; worker terminated.
+3. **`R-timer-run-timeout-no-paused`** — successful build, then `runner.run({ debug: true, onPaused })`; no `paused` arrives; advance time; assert run rejects with timeout message; worker terminated.
+4. **`R-timer-suspend-on-paused`** — successful build, `runner.run(...)`; fake responds with `paused`; advance time **past** `WORKER_TIMEOUT_MS`; assert run Promise still pending (microtask probe); settle with a `ran` response; assert run resolved cleanly. Verifies `stopRunTimer` cleared the timeout.
+5. **`R-timer-restart-on-resume`** — paused (as in test 4), then `runner.resume(false)`; no further response; advance time past `WORKER_TIMEOUT_MS`; assert run Promise rejects with timeout. Confirms `startRunTimer` re-armed the timeout for the resumed segment.
+6. **`R-timer-cleared-on-ran`** — successful build, `runner.run(...)`; fake responds with `ran` immediately; advance time well past `WORKER_TIMEOUT_MS`; assert run already resolved, no spurious second rejection. Verifies the `clearTimeout` path on the success branch of `onMessage`.
+
+The microtask-probe pattern (used in tests 4 and 6) follows PR1's resume test:
+
+```ts
+let runSettled = false;
+void runPromise.then(() => { runSettled = true; }, () => { runSettled = true; });
+await Promise.resolve();
+expect(runSettled).toBe(false);  // or true, depending on the assertion
+```
+
+## `describe('pending')` — 5 tests
+
+Real timers. Tests assert how the runner enforces its two-slot pending model.
+
+**Async/sync asymmetry note (preserved in tests):**
+
+- `runner.build(...)` and `.step()` are async — overlap throws become rejections; assert via `await expect(promise).rejects.toThrow(...)`.
+- `runner.run(...)` is sync (returns a Promise but throws synchronously on overlap); assert via `expect(() => runner.run(...)).toThrow(...)`.
+
+Tests:
+
+1. **`R-pending-simple-overlap`** — `runner.build(...)` (no response yet), then `runner.step()`. Assert step rejects with `'previous request still pending'`. Settle the build cleanly with a `built` response so it doesn't leak into the next test.
+2. **`R-pending-run-overlap`** — `runner.run(...)` (no response), then `runner.run(...)` again. Assert second call **synchronously throws** `'previous request still pending'`. Settle the first run cleanly.
+3. **`R-pending-simple-during-run`** — `runner.run(...)` (no response), then `runner.step()`. Assert step rejects (same message). Settle the run.
+4. **`R-pending-rebuild-rejects-pending`** — `runner.build(code1)` (no response), then `runner.build(code2)`. Assert: first build's Promise rejects with `'superseded by new worker'`; `all()[0].terminated === true`; `all()[1]` exists and is fresh. Settle the second build.
+5. **`R-pending-terminate-rejects-all`** — successful build; start a `runner.run(...)`; `runner.terminate()`. Assert: run Promise rejects with `'runner terminated'`; `current().terminated === true`. Then start a fresh build (forced to spawn a new worker via the supersede path), call `runner.terminate()` mid-build, assert that build also rejects. (One test exercises both pending slots in sequence.)
+
+## `describe('error')` — 5 tests
+
+Real timers. Tests assert error wrapping (worker → `WorkerError`), pending-slot routing, and the `onerror` event path.
+
+1. **`R-error-wraps-as-worker-error`** — pending build; `current().respond({ type: 'error', message: 'parse error', tapes: [{ symbols: ['a', 'b'], position: 0 }] })`. Assert: build Promise rejects with a `WorkerError` instance (`err instanceof WorkerError`); `err.message === 'parse error'`; `err.tapes` deep-equals the payload's `tapes` array.
+2. **`R-error-tapes-default-null`** — pending build; `current().respond({ type: 'error', message: 'no edge for symbol' })` (no `tapes` field). Assert: rejects with `WorkerError`; `err.tapes === null` (literally null, not `undefined`). Confirms the `data.tapes ?? null` defaulting.
+3. **`R-error-during-step`** — successful build, then pending step; `current().respond({ type: 'error', ... })`. Assert: step Promise rejects with `WorkerError`. Verifies the `simplePending` branch of `onMessage`'s error handler.
+4. **`R-error-during-run`** — successful build, then pending `runner.run(...)`; `current().respond({ type: 'error', ... })`. Assert: run Promise rejects with `WorkerError`; `current().terminated === false` (errors don't auto-terminate; that's a Stop/Take Control/supersede concern). Verifies the `runPending` branch.
+5. **`R-error-onerror-event`** — successful build, pending `runner.step()`; `current().errorEvent('worker crashed')`. Assert: step Promise rejects with a **plain `Error`** (not a `WorkerError`); message starts with `'worker error: worker crashed'`. Verifies the `onWorkerError` path that calls `rejectAll(new Error(...))`. The plain-Error vs WorkerError distinction is intentional — `onerror` is a Worker-environment event, not an in-protocol error response.
+
+## Out of scope
+
+- **Worker-side helper tests** — PR3. Requires designing the helper extraction surface from `machineWorker.ts`.
+- **Component tests** (Toolbar, MachineView) — PR4.
+- **Playwright E2E** — PR5.
+- **CI integration** (running `npm test` as a pre-build gate) — separate small PR after PR2 lands.
+- **Coverage threshold enforcement** — defer until after PR2 lands the rest of `machineRunner` coverage; threshold can then be set realistically (~85%+).
+- **Production-side fix for the `runner.run(...)` async/sync asymmetry** — preserving today's behavior in tests; refactor is out of scope.
+
+## Self-review
+
+After writing tests:
+
+1. **Each PR2 `it()` name matches the `\bR-[a-z-]+: <text>` pattern.** All 16 PR2 tests are `R-`-prefixed (no `S-` IDs in PR2). After PR2:
+   - Total `it()` count in the file: 9 (PR1) + 16 (PR2) = 25.
+   - Total unique `R-` IDs: 9 (PR1) + 16 (PR2) = 25.
+   - Total unique `S-` IDs: 1 (the lone `S-step-paused-off` from PR1's compound citation).
+   - `grep -oE '\bR-[a-z-]+' src/lib/machineRunner.test.ts | sort -u | wc -l` should return 25.
+2. **No production code changed.** `git diff master..HEAD --stat src/lib/machineRunner.ts src/lib/testUtils.ts` should show 0 changes (only `machineRunner.test.ts` modified).
+3. **All tests pass.** `npm test` exits 0; total test count = 9 (PR1) + 16 (PR2) = 25 tests.
+4. **Coverage rises.** `npm run test:coverage` reports `machineRunner.ts` at ≥80% statements (PR1 baseline ~54%).
+5. **Fake timers don't leak.** `describe('pending')` and `describe('error')` tests run on real timers; if the `afterEach` reset fails, those tests may hang or behave oddly — verify by running just those blocks in isolation (`npm test -- -t 'pending'`).
+
+Fix any issues inline before declaring done.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,6 @@ export default [
     },
   },
   {
-    ignores: ['dist', 'node_modules', '.svelte-kit'],
+    ignores: ['dist', 'node_modules', '.svelte-kit', 'coverage'],
   },
 ];

--- a/src/lib/machineRunner.test.ts
+++ b/src/lib/machineRunner.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { MAX_STEPS } from './caps';
-import { MachineRunner } from './machineRunner';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MAX_STEPS, WORKER_TIMEOUT_MS } from './caps';
+// @ts-expect-error — WorkerError used in Task 3
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { MachineRunner, WorkerError } from './machineRunner';
 import { type PausedResponse } from './types';
 import { makeFakeFactory } from './testUtils';
 
@@ -276,6 +278,153 @@ describe('MachineRunner', () => {
         stepsApplied: 0,
       });
       await runPromise;
+    });
+  });
+
+  describe('timer', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('R-timer-build-timeout: build with no response rejects with timeout error and terminates worker', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS);
+
+      await expect(buildPromise).rejects.toThrow(
+        `timeout after ${WORKER_TIMEOUT_MS}ms — worker terminated (likely infinite loop)`,
+      );
+      expect(current().terminated).toBe(true);
+    });
+
+    it('R-timer-step-timeout: step with no response rejects with timeout error and terminates worker', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const stepPromise = runner.step();
+      await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS);
+
+      await expect(stepPromise).rejects.toThrow(/timeout after/);
+      expect(current().terminated).toBe(true);
+    });
+
+    it('R-timer-run-timeout-no-paused: run with no paused/ran rejects with timeout error and terminates worker', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run({ debug: true, onPaused: () => {} });
+      await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS);
+
+      await expect(runPromise).rejects.toThrow(/timeout after/);
+      expect(current().terminated).toBe(true);
+    });
+
+    it('R-timer-suspend-on-paused: paused clears the timer; advancing past WORKER_TIMEOUT_MS does not reject', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run({ debug: true, onPaused: () => {} });
+      current().respond({
+        type: 'paused',
+        tapes: [],
+        commands: [],
+        stepsApplied: 1,
+        state: 'q1',
+        currentSymbols: ['a'],
+        debugBreak: { before: true as const },
+      });
+
+      // Advance time well past the timeout — paused should have cleared it.
+      await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS * 2);
+
+      // Run should still be pending.
+      let runSettled = false;
+      void runPromise.then(
+        () => { runSettled = true; },
+        () => { runSettled = true; },
+      );
+      await Promise.resolve();
+      expect(runSettled).toBe(false);
+
+      // Settle cleanly so the test doesn't leak a pending Promise.
+      current().respond({
+        type: 'ran',
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 1,
+      });
+      await runPromise;
+    });
+
+    it('R-timer-restart-on-resume: resume re-arms the timer; advancing past WORKER_TIMEOUT_MS rejects', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run({ debug: true, onPaused: () => {} });
+      current().respond({
+        type: 'paused',
+        tapes: [],
+        commands: [],
+        stepsApplied: 1,
+        state: 'q1',
+        currentSymbols: ['a'],
+        debugBreak: { before: true as const },
+      });
+
+      runner.resume(false);
+      await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS);
+
+      await expect(runPromise).rejects.toThrow(/timeout after/);
+    });
+
+    it('R-timer-cleared-on-ran: ran response clears the timer; subsequent time advance has no effect', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run();
+      current().respond({
+        type: 'ran',
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 0,
+      });
+      await runPromise;
+
+      // Advance time past WORKER_TIMEOUT_MS — should be a no-op since the timer was cleared on ran.
+      await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS * 2);
+
+      // If the timer had still been alive, it would have called terminate().
+      expect(current().terminated).toBe(false);
     });
   });
 });

--- a/src/lib/machineRunner.test.ts
+++ b/src/lib/machineRunner.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MAX_STEPS, WORKER_TIMEOUT_MS } from './caps';
-// @ts-expect-error — WorkerError used in Task 3
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { MachineRunner, WorkerError } from './machineRunner';
+import { MachineRunner } from './machineRunner';
 import { type PausedResponse } from './types';
 import { makeFakeFactory } from './testUtils';
 
@@ -425,6 +423,108 @@ describe('MachineRunner', () => {
 
       // If the timer had still been alive, it would have called terminate().
       expect(current().terminated).toBe(false);
+    });
+  });
+
+  describe('pending', () => {
+    it('R-pending-simple-overlap: build then step before built rejects step', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      await expect(runner.step()).rejects.toThrow('previous request still pending');
+
+      // Settle the build.
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+    });
+
+    it('R-pending-run-overlap: run then run synchronously throws', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run();
+
+      // run() is NOT async — overlap throws synchronously.
+      expect(() => runner.run()).toThrow('previous request still pending');
+
+      // Settle the first run.
+      current().respond({
+        type: 'ran',
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 0,
+      });
+      await runPromise;
+    });
+
+    it('R-pending-simple-during-run: step during pending run rejects step', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run();
+      await expect(runner.step()).rejects.toThrow('previous request still pending');
+
+      // Settle.
+      current().respond({
+        type: 'ran',
+        tapes: [],
+        truncated: false,
+        commands: [],
+        startStep: 0,
+        stepsApplied: 0,
+      });
+      await runPromise;
+    });
+
+    it('R-pending-rebuild-rejects-pending: second build rejects the first with "superseded by new worker"', async () => {
+      const { factory, all } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const firstBuild = runner.build('// first');
+      expect(all()).toHaveLength(1);
+
+      const secondBuild = runner.build('// second');
+      expect(all()).toHaveLength(2);
+
+      await expect(firstBuild).rejects.toThrow('superseded by new worker');
+      expect(all()[0].terminated).toBe(true);
+
+      // Second build proceeds normally.
+      all()[1].respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await secondBuild;
+    });
+
+    it('R-pending-terminate-rejects-all: terminate rejects pending run; then rejects pending build on a fresh build', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      // Pending run case.
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run();
+      runner.terminate();
+
+      await expect(runPromise).rejects.toThrow('runner terminated');
+      expect(current().terminated).toBe(true);
+
+      // Pending build case (fresh build via spawnWorker, then terminate before built response).
+      const buildAgain = runner.build('// user code');
+      runner.terminate();
+
+      await expect(buildAgain).rejects.toThrow('runner terminated');
     });
   });
 });

--- a/src/lib/machineRunner.test.ts
+++ b/src/lib/machineRunner.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MAX_STEPS, WORKER_TIMEOUT_MS } from './caps';
-import { MachineRunner } from './machineRunner';
+import { MachineRunner, WorkerError } from './machineRunner';
 import { type PausedResponse } from './types';
 import { makeFakeFactory } from './testUtils';
 
@@ -293,11 +293,13 @@ describe('MachineRunner', () => {
       const runner = new MachineRunner('turing', factory);
 
       const buildPromise = runner.build('// user code');
-      await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS);
-
-      await expect(buildPromise).rejects.toThrow(
+      // Attach assertion before advancing the clock so the rejection is
+      // handled the moment setTimeout fires (avoids PromiseRejectionHandledWarning).
+      const assertion = expect(buildPromise).rejects.toThrow(
         `timeout after ${WORKER_TIMEOUT_MS}ms — worker terminated (likely infinite loop)`,
       );
+      await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS);
+      await assertion;
       expect(current().terminated).toBe(true);
     });
 
@@ -310,9 +312,10 @@ describe('MachineRunner', () => {
       await buildPromise;
 
       const stepPromise = runner.step();
+      // Attach assertion before advancing the clock so the rejection is handled immediately.
+      const assertion = expect(stepPromise).rejects.toThrow(/timeout after/);
       await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS);
-
-      await expect(stepPromise).rejects.toThrow(/timeout after/);
+      await assertion;
       expect(current().terminated).toBe(true);
     });
 
@@ -325,9 +328,10 @@ describe('MachineRunner', () => {
       await buildPromise;
 
       const runPromise = runner.run({ debug: true, onPaused: () => {} });
+      // Attach assertion before advancing the clock so the rejection is handled immediately.
+      const assertion = expect(runPromise).rejects.toThrow(/timeout after/);
       await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS);
-
-      await expect(runPromise).rejects.toThrow(/timeout after/);
+      await assertion;
       expect(current().terminated).toBe(true);
     });
 
@@ -394,9 +398,10 @@ describe('MachineRunner', () => {
       });
 
       runner.resume(false);
+      // Attach assertion before advancing the clock so the rejection is handled immediately.
+      const assertion = expect(runPromise).rejects.toThrow(/timeout after/);
       await vi.advanceTimersByTimeAsync(WORKER_TIMEOUT_MS);
-
-      await expect(runPromise).rejects.toThrow(/timeout after/);
+      await assertion;
     });
 
     it('R-timer-cleared-on-ran: ran response clears the timer; subsequent time advance has no effect', async () => {
@@ -525,6 +530,98 @@ describe('MachineRunner', () => {
       runner.terminate();
 
       await expect(buildAgain).rejects.toThrow('runner terminated');
+    });
+  });
+
+  describe('error', () => {
+    it('R-error-wraps-as-worker-error: error response with tapes wraps as WorkerError', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      const tapes = [{ symbols: ['a', 'b'], position: 0 }];
+      current().respond({ type: 'error', message: 'parse error', tapes });
+
+      let caught: unknown;
+      try {
+        await buildPromise;
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBeInstanceOf(WorkerError);
+      expect((caught as WorkerError).message).toBe('parse error');
+      expect((caught as WorkerError).tapes).toEqual(tapes);
+    });
+
+    it('R-error-tapes-default-null: error response without tapes field → tapes is null (not undefined)', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'error', message: 'no edge for symbol' });
+
+      let caught: unknown;
+      try {
+        await buildPromise;
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBeInstanceOf(WorkerError);
+      expect((caught as WorkerError).tapes).toBeNull();
+    });
+
+    it('R-error-during-step: error response during pending step rejects step with WorkerError', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const stepPromise = runner.step();
+      current().respond({ type: 'error', message: 'mid-step error' });
+
+      await expect(stepPromise).rejects.toBeInstanceOf(WorkerError);
+    });
+
+    it('R-error-during-run: error response during pending run rejects run with WorkerError; worker not terminated', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const runPromise = runner.run();
+      current().respond({ type: 'error', message: 'mid-run error' });
+
+      await expect(runPromise).rejects.toBeInstanceOf(WorkerError);
+      expect(current().terminated).toBe(false);
+    });
+
+    it('R-error-onerror-event: worker.onerror fires; pending request rejects with plain Error and "worker error:" prefix', async () => {
+      const { factory, current } = makeFakeFactory();
+      const runner = new MachineRunner('turing', factory);
+
+      const buildPromise = runner.build('// user code');
+      current().respond({ type: 'built', tapes: [], alphabets: [], halted: false });
+      await buildPromise;
+
+      const stepPromise = runner.step();
+      current().errorEvent('worker crashed');
+
+      let caught: unknown;
+      try {
+        await stepPromise;
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      expect(caught).not.toBeInstanceOf(WorkerError);
+      expect((caught as Error).message).toMatch(/^worker error: worker crashed/);
     });
   });
 });


### PR DESCRIPTION
## Summary

PR2 of [#47](https://github.com/mellonis/machines-demo/issues/47). Lands the remaining `machineRunner` test categories — timer behavior, pending-slot model, and error wrapping — as 16 new tests across three sibling `describe` blocks in `src/lib/machineRunner.test.ts`. No production code changes.

What's in this PR:

- **`describe('timer')`** — 6 tests using `vi.useFakeTimers()` per-test for deterministic time control. Covers the per-segment `WORKER_TIMEOUT_MS` cap on build, step, and run; the suspend-on-paused / restart-on-resume behavior; and the clear-on-ran path.
- **`describe('pending')`** — 5 tests covering the two-slot (`simplePending` / `runPending`) model: overlap rejection from build/step/run, supersede-on-rebuild, and `terminate()`-rejects-all. Also documents the runner's async/sync asymmetry (`runner.run(...)` synchronously throws on overlap; `runner.build()` and `.step()` reject).
- **`describe('error')`** — 5 tests covering `WorkerError` wrapping with and without `tapes`, the `simplePending` / `runPending` routing of error responses, and the distinct plain-`Error` path for `worker.onerror` events.
- **`docs/execution-model.md` §14** — already lifted in PR1; PR2's `R-` IDs slot into the existing grammar without further spec changes.
- **`eslint.config.mjs`** — ignore `coverage/` output from `vitest --coverage`.

The plan was 4 tasks (3 describe-block additions + 1 final verification). The verification pass caught a real bug in 4 timer tests (assertion order: the `expect(...).rejects.toThrow(...)` handler must attach before `vi.advanceTimersByTimeAsync(...)`, otherwise the rejection fires unhandled and Vitest counts it as a failure). Fixed inline.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — exit 0
- `npm run build` — succeeds
- `npm test` — 25 / 25 pass (148ms)
- `npm run test:coverage` for `src/lib/machineRunner.ts`:
  - Statements: 92.62% (was ~54% after PR1)
  - Branches: 75.64%
  - Functions: 100%
  - Lines: 99.02%
- Scenario IDs: 26 unique (25 `R-` + 1 `S-`), no orphans

Per-category test counts after PR2:

- protocol shape: 9 tests (PR1, untouched)
- timer: 6 tests (PR2)
- pending: 5 tests (PR2)
- error: 5 tests (PR2)
- **Total: 25 tests**

## Out of scope (deferred to follow-up PRs)

- Worker-side helper extraction + tests (extract pure helpers from `machineWorker.ts`, then unit-test them) — PR3 of #47.
- Component tests (Toolbar, MachineView) — PR4.
- Playwright E2E — PR5.
- CI integration of `npm test` as a pre-build gate — separate small PR.

## Test plan

- [ ] Skim each `describe` block for clarity and assertion strength.
- [ ] Verify the runner async/sync asymmetry is documented in the pending tests' comments.
- [ ] Run `npm test` locally to confirm reproducibility.
- [ ] Spot-check coverage report — confirm timer / pending / error paths in `machineRunner.ts` are exercised.