### PR TITLE
test: Playwright E2E + PR-gate CI workflow (PR5 of #47)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,69 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [master]
+
+env:
+  NODE_VERSION: 24
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci
+      - run: npm run check
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  vitest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+      - run: npm run build
+      - run: npm run test:e2e
+      - name: Upload test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ coverage
 .DS_Store
 .vite
 *.log
+playwright-report
+test-results
+blob-report

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm test` — Vitest one-shot. Runner / helper tests run in node; component tests opt into happy-dom via the `// @vitest-environment happy-dom` per-file pragma. `vitest.setup.ts` registers `@testing-library/jest-dom` matchers globally.
 - `npm run test:watch` — Vitest watch mode
 - `npm run test:coverage` — Vitest with v8 coverage; output in `coverage/` (gitignored)
+- `npm run test:e2e` — Playwright E2E (Chromium; runs `vite preview` automatically; tests in `e2e/`)
+- `npm run test:e2e:ui` — Playwright interactive mode for local debugging
 
 ## Architecture
 
@@ -51,6 +53,15 @@ src/
     ├── format.ts               describeAppliedCommand / formatTape / commandsEntry / tapesEntry
     ├── icons.ts                Tabler icon namespace (?raw imports)
     └── theme.svelte.ts         theme (light / dark) state + matchMedia watcher (Svelte 5 .svelte.ts module)
+
+e2e/
+└── cold-start.spec.ts          Playwright E2E — 4 cold-start scenarios (cites E-cold-start-...)
+
+playwright.config.ts            Chromium project; webServer runs `npm run preview`
+
+.github/workflows/
+├── main.yml                    CD: build + rsync to VPS on push to master
+└── test.yml                    PR gate: check / lint / vitest / playwright
 ```
 
 **`App.svelte`** picks the active engine from the URL pathname (`/turing`, `/post`) and renders one `<MachineView engine={...}>` keyed by engine — switching engines unmounts and remounts the tab (kills CodeMirror undo, cheap CPU). Legacy `?machine=<engine>` URLs are rewritten to the path form on first load. SPA-fallback routing is required (nginx `try_files $uri $uri/ /index.html;` in `vps/nginx/sites/demo.machines.mellonis.ru`; Vite default in dev).
@@ -137,6 +148,7 @@ A `.head-thread` div sits behind the stack as the first child of `.tapes-stack` 
 - **No static literal fallbacks in `var()`.** A `var()` fallback must itself be another CSS custom property (e.g. `var(--dot, var(--head))`) — never a hardcoded color, length, or time. Literals leak out of the design system and bypass theming. Two patterns satisfy this:
   - **Globally-scoped tokens** (colors, surface vars, animation timings) — declared in `:root` in `app.css`. Optionally promoted to `@property` for type-checking and animatable customs (e.g. `@property --anim-button-hover-ms { syntax: '<time>'; inherits: true; initial-value: 120ms }`). When `@property`'s `initial-value` must mirror another token (it can't reference `var()`), document the coupling with a `/* follows --x — keep in sync when theming */` comment above the literal value.
   - **Optional, per-element customs** (e.g. `--dot` in `ControlPanel.svelte`) — either fall back to another token at the read site (`var(--dot, var(--head))`) or declare a class-level default (`.tape-dot { --dot: var(--head); background: var(--dot) }`). Pick the class-level default when the same custom is read in multiple places, the inline fallback when it's a one-off.
+- **Selector convention for E2E**: buttons use accessible names (text content, role-based queries via Playwright's `getByRole`); non-button DOM (tape cells, log entries, container wrappers) uses `data-testid` attributes (e.g. `data-testid="tape-cell"`, `data-testid="log-line"`). Tape cells additionally carry `data-blank={cell.blank}` and log lines carry `data-kind={entry.kind ?? ''}` for filter-by-attribute queries.
 
 ## Snippets
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ npm run lint           # ESLint flat config
 npm test               # Vitest one-shot (runner / helper tests)
 npm run test:watch     # Vitest watch mode
 npm run test:coverage  # Vitest with v8 coverage; output in coverage/
+npm run test:e2e       # Playwright E2E (Chromium; runs `vite preview` automatically)
+npm run test:e2e:ui    # Playwright interactive mode for local debugging
 ```
 
 Static bundle emitted to `dist/`. Serve with any static host. The build references hashed assets, so far-future caching is safe.
@@ -109,6 +111,11 @@ src/
     ├── format.ts               # describeAppliedCommand / formatTape / commandsEntry / tapesEntry
     ├── icons.ts                # Tabler icon namespace
     └── theme.svelte.ts         # theme (light / dark) state + matchMedia watcher
+
+e2e/
+└── cold-start.spec.ts            # Playwright E2E — 4 cold-start scenarios
+
+playwright.config.ts              # Chromium project; webServer = vite preview
 ```
 
 ## License

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -464,9 +464,10 @@ Upstream behaviors the spec encodes (won't change without a major upstream versi
 | `S-` | literal prefix; marks the token as a UI-scenario reference. Used throughout §§4–10. |
 | `R-` | runner / worker / helper internal scenarios (no UI counterpart). Format `R-<topic>-<facet>`, e.g. `R-protocol-build`, `R-timer-suspend-on-paused`. Used in `*.test.ts` files alongside `S-...` IDs. |
 | `C-` | component-test scenarios. Format `C-<component>-<facet>`, e.g. `C-toolbar-run-label-default`, `C-toolbar-disabled-build`. Used in component test files (`*.test.ts` co-located with `.svelte` files). |
+| `E-` | end-to-end scenarios — full UI flow including worker round-trip. Format `E-<from-state-or-context>-<facet>`, e.g. `E-cold-start-run-debug-off`. Used in `e2e/*.spec.ts`. |
 | `<action>` (S only) | `build`, `step`, `run`, `continue`, `stop`, `takectl`, `apply`, `debug-toggle`, `withpause-toggle`, `error`, `truncate`, `timeout` |
 | `<from-state>` (S only) | `demo`, `idle`, `manual`, `auto`, `cont`, `paused`, `halted` (and `step` only in §11 for legacy RUNNING_STEP citations) |
-| `<topic>` (R / C) | `machineRunner.test.ts`: `protocol`, `timer`, `pending`, `error`. `workerHelpers.test.ts`: `movement-code`, `commands`, `snapshot`, `phase-guard`, `step-arm`. `Toolbar.test.ts`: `run-label`, `disabled`, `visibility`, `interval`, `callbacks`. |
+| `<topic>` (R / C / E) | `machineRunner.test.ts`: `protocol`, `timer`, `pending`, `error`. `workerHelpers.test.ts`: `movement-code`, `commands`, `snapshot`, `phase-guard`, `step-arm`. `Toolbar.test.ts`: `run-label`, `disabled`, `visibility`, `interval`, `callbacks`. `e2e/cold-start.spec.ts`: `cold-start`, `continue-from-step`, `stop-while-paused`. |
 | `<facet>` (R only) | short descriptor — `build`, `step-cycle`, `suspend-on-paused`, `reject-overlap`, `wraps-error-with-tapes`, etc. |
 | `<flags?>` (S only) | optional flag suffix(es); `on` / `off` (debug), `auto` / `cont` (withPause when ambiguous), or compound like `off-auto` |
 
@@ -475,7 +476,7 @@ Conventions:
 - One token per slot. Don't run flags together.
 - Drop slots that don't matter — uniform behavior across flags ⇒ no flag suffix.
 - Stable across spec edits — prefer adding new IDs over renaming.
-- All three prefixes follow the regex `\b[SRC]-[a-z-]+`. Tests / CI grep this to find every cited scenario.
+- All four prefixes follow the regex `\b[SRCE]-[a-z-]+`. Tests / CI grep this to find every cited scenario.
 
 Where IDs live:
 - **Matrix cells** (§8): `S-step-paused-off: arm .after, resume(step), → PAUSED`. Text after `:` is the one-line outcome.

--- a/docs/superpowers/plans/2026-05-09-test-infra-pr5.md
+++ b/docs/superpowers/plans/2026-05-09-test-infra-pr5.md
@@ -1,0 +1,608 @@
+# Test infrastructure PR5 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 4 Playwright E2E tests covering cold-start Run / Step+debug / Continue / Stop-while-paused on the default Turing example. Add a PR-gate CI workflow that runs check + lint + Vitest + Playwright on every pull request. PR5 of [#47](https://github.com/mellonis/machines-demo/issues/47).
+
+**Architecture:** New `e2e/` directory at repo root with one `cold-start.spec.ts` file. `playwright.config.ts` runs Chromium-only against `vite preview`. `data-testid` attributes added to Tape cells, Log lines, and key wrappers (buttons keep accessible names). New `.github/workflows/test.yml` runs four parallel jobs (`check`, `lint`, `vitest`, `playwright`) on `pull_request`.
+
+**Tech Stack:** Playwright 1.50.x (Chromium only), Vite 5 preview server, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-05-09-test-infra-pr5-design.md`
+
+**Branch:** `feature/test-infra-pr5-47` (already created at master HEAD; the spec doc commit is the first commit on the branch).
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `package.json` | **Modify** — add `@playwright/test` to devDeps; add `test:e2e` and `test:e2e:ui` scripts. |
+| `playwright.config.ts` | **Create** — Chromium project, `webServer: npm run preview`, `testDir: './e2e'`. |
+| `e2e/cold-start.spec.ts` | **Create** — 4 tests covering the 4 scenarios. |
+| `src/components/Tape.svelte` | **Modify** — add `data-testid` attributes. |
+| `src/components/Log.svelte` | **Modify** — add `data-testid` attributes. |
+| `src/components/TapesStack.svelte` | **Modify** — add `data-testid` to root. |
+| `.github/workflows/test.yml` | **Create** — `pull_request` trigger; 4 parallel jobs. |
+| `docs/execution-model.md` | **Modify** — §14 grammar gains the `E-` prefix; regex → `[SRCE]`. |
+| `CLAUDE.md` | **Modify** — list new scripts, `e2e/` dir, Playwright config; mention testid convention. |
+| `README.md` | **Modify** — same drift sync. |
+| `.gitignore` | **Modify** — add `playwright-report/`, `test-results/`, `blob-report/`. |
+
+---
+
+## Verification model
+
+After each task: `npm run check && npm run lint && npm test` — all exit 0 with **56 unit tests** unchanged. T3 also runs `npm run test:e2e` with **4 E2E tests passing**. T6 runs the full pipeline (check + lint + test + test:e2e + build) and verifies the CI workflow YAML is valid.
+
+---
+
+## Task 1: Add `data-testid` attributes to production components
+
+**Files:**
+- Modify: `src/components/Tape.svelte` (lines 89–106)
+- Modify: `src/components/Log.svelte` (lines 21, 30)
+- Modify: `src/components/TapesStack.svelte` (line 50)
+
+These are non-functional attribute additions only. No behavior changes.
+
+- [ ] **Step 1: Edit `src/components/Tape.svelte`**
+
+Find this block (around line 89–106):
+
+```svelte
+<div
+  class="ui-belt"
+  class:no-caret={!showCaret}
+  style={caretColor ? `--head: ${caretColor};` : undefined}
+>
+  <div class="viewport">
+    <div class="center">
+      <div class="strip transitions-on" bind:this={stripEl}>
+        {#each viewport as cell}
+          <div class="cell" class:blank={cell.blank}>
+            <span class="sym">{cell.sym}</span>
+          </div>
+        {/each}
+      </div>
+    </div>
+    <div class="caret"></div>
+  </div>
+</div>
+```
+
+Replace with:
+
+```svelte
+<div
+  class="ui-belt"
+  class:no-caret={!showCaret}
+  style={caretColor ? `--head: ${caretColor};` : undefined}
+  data-testid="tape"
+>
+  <div class="viewport">
+    <div class="center">
+      <div class="strip transitions-on" bind:this={stripEl}>
+        {#each viewport as cell}
+          <div class="cell" class:blank={cell.blank} data-testid="tape-cell" data-blank={cell.blank}>
+            <span class="sym">{cell.sym}</span>
+          </div>
+        {/each}
+      </div>
+    </div>
+    <div class="caret"></div>
+  </div>
+</div>
+```
+
+- [ ] **Step 2: Edit `src/components/Log.svelte`**
+
+Find this block (around line 21–46):
+
+```svelte
+<div class="log-panel">
+  {#if entries.length > 0}
+    <IconButton icon="eraser" title="Clear log" onClick={onClear} />
+  {/if}
+  <div class="content" bind:this={scrollEl}>
+    {#each entries as entry, i (i)}
+      {#if entry.separator}
+        <hr class="sep" />
+      {:else}
+        <div class="line" class:error={entry.kind === 'error'} class:warn={entry.kind === 'warn'} class:ok={entry.kind === 'ok'}>
+```
+
+Replace the opening `<div class="log-panel">` with `<div class="log-panel" data-testid="log">`, and the inner `<div class="line" ...>` with:
+
+```svelte
+        <div
+          class="line"
+          class:error={entry.kind === 'error'}
+          class:warn={entry.kind === 'warn'}
+          class:ok={entry.kind === 'ok'}
+          data-testid="log-line"
+          data-kind={entry.kind ?? ''}
+        >
+```
+
+- [ ] **Step 3: Edit `src/components/TapesStack.svelte`**
+
+Find (around line 50):
+
+```svelte
+<div class="tapes-stack">
+```
+
+Replace with:
+
+```svelte
+<div class="tapes-stack" data-testid="tapes-stack">
+```
+
+- [ ] **Step 4: Verify nothing breaks**
+
+Run: `npm run check && npm run lint && npm test && npm run build`
+Expected: all four exit 0; **56 unit tests pass** unchanged; build emits to `dist/`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Tape.svelte src/components/Log.svelte src/components/TapesStack.svelte
+git commit -m "ui: add data-testid attributes for E2E selectors (PR5 of #47)"
+```
+
+---
+
+## Task 2: Install Playwright + scripts + config
+
+**Files:**
+- Modify: `package.json` — add devDep + 2 scripts
+- Create: `playwright.config.ts`
+- Modify: `.gitignore` — add Playwright output dirs
+
+- [ ] **Step 1: Add devDependency to `package.json`**
+
+In `package.json`, inside `devDependencies` (alphabetically between `@sveltejs/vite-plugin-svelte` and `@testing-library/jest-dom`):
+
+```jsonc
+"@playwright/test": "^1.50.0",
+```
+
+- [ ] **Step 2: Add scripts to `package.json`**
+
+In the `scripts` block, add (after the existing `test:coverage`):
+
+```jsonc
+"test:e2e": "playwright test",
+"test:e2e:ui": "playwright test --ui"
+```
+
+The final scripts block should have these entries (order: dev, build, preview, check, lint, test, test:watch, test:coverage, test:e2e, test:e2e:ui).
+
+- [ ] **Step 3: Install**
+
+Run: `npm install && npx playwright install --with-deps chromium`
+Expected: completes without errors; `package-lock.json` updates with `@playwright/test` entry; Chromium browser binary downloaded.
+
+- [ ] **Step 4: Create `playwright.config.ts`**
+
+Create `playwright.config.ts` at the repo root with this exact content:
+
+```ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: 'npm run preview',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});
+```
+
+- [ ] **Step 5: Update `.gitignore`**
+
+Append these lines:
+
+```
+playwright-report
+test-results
+blob-report
+```
+
+The final file should be:
+
+```
+node_modules
+dist
+coverage
+.DS_Store
+.vite
+*.log
+playwright-report
+test-results
+blob-report
+```
+
+- [ ] **Step 6: Verify config loads**
+
+Run: `npx playwright test --list`
+Expected: lists 0 tests (no `e2e/*.spec.ts` files exist yet) but does not error on the config itself.
+
+- [ ] **Step 7: Verify nothing else breaks**
+
+Run: `npm run check && npm run lint && npm test`
+Expected: all three exit 0; 56 unit tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add package.json package-lock.json playwright.config.ts .gitignore
+git commit -m "test: install Playwright + preview-server config (PR5 of #47)"
+```
+
+---
+
+## Task 3: Write the 4 E2E tests
+
+**Files:**
+- Create: `e2e/cold-start.spec.ts`
+
+- [ ] **Step 1: Create the directory and file**
+
+Create `e2e/cold-start.spec.ts` with this exact content:
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test.describe('cold-start', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/turing');
+    // Wait for the app to mount before clicking. DEMO mode auto-runs but
+    // doesn't block clicks.
+    await expect(page.getByTestId('tapes-stack')).toBeVisible();
+  });
+
+  test('E-cold-start-run-debug-off: Run advances tape, halt logged', async ({ page }) => {
+    await page.getByRole('button', { name: /^run$/i }).click();
+    await expect(
+      page.getByTestId('log-line').filter({ hasText: /halted after \d+ step\(s\)/ }),
+    ).toBeVisible({ timeout: 10_000 });
+    // Default Turing example transforms ['a','b','c','b','a'] → ['a','*','c','*','a'].
+    // Tape.svelte renders VIEWPORT_WIDTH=23 cells per tape; the * count among
+    // the rendered cells is 2 (both 'b's were replaced).
+    const cells = await page.getByTestId('tape-cell').allInnerTexts();
+    expect(cells.filter((s) => s === '*').length).toBe(2);
+  });
+
+  test('E-cold-start-step-debug-on: Step+debug=on parks at iter-1 with state info', async ({ page }) => {
+    await page.getByRole('checkbox', { name: /^debug$/i }).check();
+    await page.getByRole('button', { name: /^step$/i }).click();
+    // Cold-start Step always uses the run-mode after-trick; with debug=on the
+    // user-set breaks would also fire, but the example has none — the
+    // after-trick pause is what surfaces.
+    await expect(
+      page.getByTestId('log-line').filter({
+        hasText: /paused at .*state .* after applying command for symbols:/,
+      }),
+    ).toBeVisible({ timeout: 5_000 });
+    // Run button relabels to "Continue" while paused.
+    await expect(page.getByRole('button', { name: /^continue$/i })).toBeVisible();
+  });
+
+  test('E-continue-from-step: Continue (debug=off) runs to halt without further pauses', async ({ page }) => {
+    // Reach the paused state via the same flow as the previous test.
+    await page.getByRole('checkbox', { name: /^debug$/i }).check();
+    await page.getByRole('button', { name: /^step$/i }).click();
+    await expect(page.getByRole('button', { name: /^continue$/i })).toBeVisible();
+
+    // Snapshot the pre-Continue paused-line count.
+    const pausedBefore = await page
+      .getByTestId('log-line')
+      .filter({ hasText: /^paused at/ })
+      .count();
+
+    // Toggle debug off, then Continue.
+    await page.getByRole('checkbox', { name: /^debug$/i }).uncheck();
+    await page.getByRole('button', { name: /^continue$/i }).click();
+    await expect(
+      page.getByTestId('log-line').filter({ hasText: /halted after \d+ step\(s\)/ }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // No additional "paused" lines added between Continue click and halt.
+    const pausedAfter = await page
+      .getByTestId('log-line')
+      .filter({ hasText: /^paused at/ })
+      .count();
+    expect(pausedAfter).toBe(pausedBefore);
+  });
+
+  test('E-stop-while-paused: Stop while paused halts; Run/Step stay enabled', async ({ page }) => {
+    await page.getByRole('checkbox', { name: /^debug$/i }).check();
+    await page.getByRole('button', { name: /^step$/i }).click();
+    await expect(page.getByRole('button', { name: /^continue$/i })).toBeVisible();
+
+    // Stop returns the machine to MANUAL with workerLive=true: Run/Step stay
+    // clickable so the user can keep poking the same machine state.
+    await page.getByRole('button', { name: /^stop$/i }).click();
+    await expect(
+      page.getByTestId('log-line').filter({ hasText: /^stopped/ }),
+    ).toBeVisible();
+
+    // After Stop, Run-button reverts to "Run" and is enabled; Step is enabled
+    // too. Stop button itself disappears (stopVisible is false in MANUAL).
+    await expect(page.getByRole('button', { name: /^run$/i })).toBeEnabled();
+    await expect(page.getByRole('button', { name: /^step$/i })).toBeEnabled();
+    await expect(page.getByRole('button', { name: /^stop$/i })).not.toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Build the bundle (the `webServer` block needs `dist/`)**
+
+Run: `npm run build`
+Expected: emits `dist/`.
+
+- [ ] **Step 3: Run E2E tests**
+
+Run: `npm run test:e2e`
+Expected: 4 tests pass; preview server spins up, tests run, server tears down. Reporter prints `4 passed`.
+
+If any test fails, investigate (do NOT modify production code to make tests pass — investigate the discrepancy and report it):
+- A common failure is an over-eager `getByRole` that matches multiple buttons. Use the `^...$`-anchored regexes already in the spec.
+- If the preview server fails to start, check that `dist/` exists (Step 2).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/cold-start.spec.ts
+git commit -m "test: Playwright E2E for cold-start scenarios (PR5 of #47)"
+```
+
+---
+
+## Task 4: Add CI workflow
+
+**Files:**
+- Create: `.github/workflows/test.yml`
+
+- [ ] **Step 1: Create the workflow**
+
+Create `.github/workflows/test.yml` with this exact content:
+
+```yaml
+name: Test
+
+on:
+  pull_request:
+    branches: [master]
+
+env:
+  NODE_VERSION: 24
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci
+      - run: npm run check
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  vitest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+      - run: npm run build
+      - run: npm run test:e2e
+      - name: Upload test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+```
+
+- [ ] **Step 2: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))" 2>&1 || echo "OK if no python: skip"`
+Expected: no output (valid YAML), or "OK if no python: skip" — either is acceptable. If yaml errors, fix the file.
+
+- [ ] **Step 3: Verify the workflow file is in the right place**
+
+Run: `ls -la .github/workflows/`
+Expected: lists both `main.yml` (existing CD workflow) and `test.yml` (new PR-gate workflow).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/test.yml
+git commit -m "ci: PR-gate workflow with check / lint / vitest / playwright (PR5 of #47)"
+```
+
+---
+
+## Task 5: Update §14 grammar in `docs/execution-model.md`
+
+**Files:**
+- Modify: `docs/execution-model.md`
+
+- [ ] **Step 1: Read §14 to confirm structure**
+
+Read `docs/execution-model.md` lines 458–490.
+
+- [ ] **Step 2: Add `E-` row to the prefix table**
+
+After the `C-` row (added in PR4), insert a new row:
+
+```
+| `E-` | end-to-end scenarios — full UI flow including worker round-trip. Format `E-<from-state-or-context>-<facet>`, e.g. `E-cold-start-run-debug-off`. Used in `e2e/*.spec.ts`. |
+```
+
+- [ ] **Step 3: Update the `<topic>` row to include the e2e file**
+
+Locate the `<topic>` row (PR4 left it as `(R / C)`). Update its slot label from `(R / C)` to `(R / C / E)` and append:
+
+```
+ `e2e/cold-start.spec.ts`: `cold-start`, `continue-from-step`, `stop-while-paused`.
+```
+
+- [ ] **Step 4: Update the regex line**
+
+Change `\b[SRC]-[a-z-]+` to `\b[SRCE]-[a-z-]+`. Update prose from "All three prefixes" to "All four prefixes".
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/execution-model.md
+git commit -m "docs: register E- prefix for E2E test scenarios (PR5 of #47)"
+```
+
+---
+
+## Task 6: Sync `CLAUDE.md` + `README.md` + final verification
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Update `CLAUDE.md` Commands section**
+
+Locate the Commands section (around lines 7–17). After the `test:coverage` line, add:
+
+```
+- `npm run test:e2e` — Playwright E2E (Chromium; runs `vite preview` automatically)
+- `npm run test:e2e:ui` — Playwright interactive mode for local debugging
+```
+
+- [ ] **Step 2: Add `e2e/` and `playwright.config.ts` to the CLAUDE.md tree**
+
+In the Architecture tree (around lines 18–53), add after the `└── theme.svelte.ts` line (so outside `src/`):
+
+```
+e2e/
+├── cold-start.spec.ts          Playwright E2E — 4 scenarios (cites E-cold-start-...)
+playwright.config.ts            Chromium project; webServer runs `npm run preview`
+.github/workflows/
+├── main.yml                    CD: build + rsync to VPS on push to master
+└── test.yml                    PR gate: check / lint / vitest / playwright
+```
+
+(The `e2e/` and `playwright.config.ts` entries land inside the same `\`\`\`...\`\`\`` code block as the `src/` tree, but at the same indentation as the top-level `src/`.)
+
+- [ ] **Step 3: Add a Conventions note about `data-testid`**
+
+In CLAUDE.md's Conventions section (search for "## Conventions"), add a bullet:
+
+```
+- **Selector convention for E2E**: buttons use accessible names (already exposed via text content); non-button DOM (tape cells, log entries, container wrappers) uses `data-testid` attributes. Tape cells additionally carry `data-blank` for the blank-flag distinction.
+```
+
+- [ ] **Step 4: Update `README.md` scripts section**
+
+In `README.md`, locate the Scripts block. Add after `npm run test:coverage`:
+
+```sh
+npm run test:e2e        # Playwright E2E (Chromium; runs `vite preview` automatically)
+npm run test:e2e:ui     # Playwright interactive mode for local debugging
+```
+
+- [ ] **Step 5: Add `e2e/` to the README.md Layout tree**
+
+In README.md's Layout section, add after the `theme.svelte.ts` line and before the closing `\`\`\``:
+
+```
+e2e/
+├── cold-start.spec.ts            # Playwright E2E — 4 cold-start scenarios
+playwright.config.ts              # Chromium project; webServer = vite preview
+```
+
+- [ ] **Step 6: Final pipeline verification**
+
+Run: `npm run check && npm run lint && npm test && npm run build && npm run test:e2e`
+Expected: all five exit 0; 56 unit tests, 4 E2E tests; build emits `dist/`.
+
+- [ ] **Step 7: Verify scenario IDs**
+
+Run: `grep -oE '\bE-[a-z-]+' e2e/cold-start.spec.ts | sort -u | wc -l`
+Expected: `4` (each unique `E-<facet>` ID appears once).
+
+- [ ] **Step 8: Verify production-side change scope**
+
+Run: `git diff master..HEAD --stat src/`
+Expected: only `src/components/Tape.svelte`, `src/components/Log.svelte`, `src/components/TapesStack.svelte` modified — and the diff is purely attribute additions (no behavior changes). No `src/lib/` files modified.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add CLAUDE.md README.md
+git commit -m "docs: register e2e/ + Playwright + test workflow (PR5 of #47)"
+```
+
+---
+
+## Self-review (after T6)
+
+1. **All 4 PR5 `test()` names match `\bE-[a-z-]+: <text>`.** All 4 are `E-`-prefixed, unique.
+2. **Production diff is attribute-only.** `git diff master..HEAD -- src/components/Tape.svelte src/components/Log.svelte src/components/TapesStack.svelte` shows only `data-testid` / `data-blank` / `data-kind` additions — no logic changes.
+3. **Unit-test count unchanged.** `npm test` still reports 56.
+4. **E2E test count = 4.** `npm run test:e2e` reports `4 passed`.
+5. **Build still passes.** `npm run build` exits 0.
+6. **No CD workflow changes.** `.github/workflows/main.yml` untouched. The new `test.yml` is additive.
+7. **Workflow file is valid YAML.** Either `python3 -c "import yaml; ..."` succeeds, or `actionlint` (if installed) reports zero errors.
+
+Fix any issues inline before declaring done.

--- a/docs/superpowers/specs/2026-05-09-test-infra-pr5-design.md
+++ b/docs/superpowers/specs/2026-05-09-test-infra-pr5-design.md
@@ -1,0 +1,313 @@
+# Test infrastructure — PR5 (Playwright E2E + CI gate) — design
+
+Tracks: [#47](https://github.com/mellonis/machines-demo/issues/47) (test infrastructure). PR5 of a 5-PR series. Builds on PR1 (#55), PR2 (#56), PR3 (#57), PR4 (#58).
+
+## Problem
+
+PR1–PR4 covered the runner protocol, worker helpers, and Toolbar component derivations — but only at the unit boundary. The full worker round-trip (postMessage → `new Function()` user code → engine yields → tape commands → main-thread mirror replay → DOM) has no automated coverage. Issue #47 scope item 5 enumerates four flows where the round-trip plus DOM both matter; if any one breaks, the demo silently regresses (passes type-check, lint, all unit tests). The Step-semantics regression that motivated #47 in the first place is the canonical example — Vitest + Toolbar tests would not have caught it.
+
+PR5 adds those four E2E scenarios via Playwright, adds `data-testid` attributes to the few non-button DOM elements the tests query, and introduces the project's first CI test gate (a new `pull_request` workflow that runs check + lint + Vitest + Playwright). The existing CD workflow on master push is unchanged — the PR gate adds a feedback layer in front of it without slowing deploys.
+
+## Decisions
+
+- **Scope: 4 scenarios, default Turing example only.** Issue #47's literal list. No Post-engine duplicates (the worker contract is identical; doubling for redundant signal violates "Keep this minimal — E2E is expensive to maintain"). No smoke test (the 4 scenarios already cover catastrophic failure modes — page mounts, worker spawns, log renders).
+- **Browser: Chromium only.** Playwright's default project. The demo has no Safari- or Firefox-specific concerns; multi-browser tripling adds maintenance for no expected signal. Reconsider when a real cross-browser issue surfaces.
+- **Server: `vite preview` (built bundle), not `vite dev`.** Tests the artifact users actually load. Matches the production CSP, the hashed asset paths, the worker spawn from the built file. `npm run preview` is the existing script; Playwright's `webServer` config block runs it before the tests.
+- **CI: PR-gate workflow** (`.github/workflows/test.yml`, triggered on `pull_request`). Existing CD workflow on `push: master` stays separate. Four jobs: `check`, `lint`, `vitest`, `playwright` — separate jobs so a failure on one diagnoses in parallel rather than blocking the others. The Vitest + Playwright runs are the first automated test gate the project has.
+- **Selectors: `data-testid` for non-button DOM** (Tape cells, Log lines, container wrappers). Buttons keep their accessible names — Toolbar already exposes them and Playwright's `getByRole` handles them natively. Test IDs decouple tests from CSS-class refactors; the production noise is small (one attribute per element family) and explicit.
+- **Test directory: `e2e/` at repo root.** Separate from Vitest's `src/**/*.test.ts`. Playwright's default convention. `vitest.config.ts`'s `include` already excludes `e2e/`; nothing to configure on the Vitest side.
+- **Scenario IDs: `E-<scenario>` prefix.** Registered in `docs/execution-model.md` §14 alongside existing `S-` / `R-` / `C-`. Format `E-<from-state-or-context>-<flag-or-action>`, e.g. `E-cold-start-run-debug-off`. The scenarios already correspond to spec walk-throughs in §10; the `E-` IDs are independent of those `S-` IDs because tests at this layer assert UI-observable outcomes, not state-machine transitions per se.
+- **No watch mode for Playwright.** Local-iteration UX is `npx playwright test --ui` (Playwright's interactive mode); a `test:e2e` npm script wraps `playwright test` for one-shot runs. No `test:e2e:watch` script.
+
+## File map
+
+| File | Change |
+|---|---|
+| `package.json` | **Modify** — add `@playwright/test` to devDeps; add `test:e2e` and `test:e2e:ui` npm scripts. |
+| `playwright.config.ts` | **Create** — Chromium project, `webServer` block running `npm run preview`, `testDir: './e2e'`, traces on first retry. |
+| `e2e/cold-start.spec.ts` | **Create** — 4 tests covering the issue-#47 scenarios. ~150 lines. |
+| `src/components/Tape.svelte` | **Modify** — add `data-testid="tape-cell"` + `data-blank` to each cell; add `data-testid="tape"` to the per-tape wrapper. |
+| `src/components/Log.svelte` | **Modify** — add `data-testid="log-line"` + `data-kind` to each line; `data-testid="log"` to the panel. |
+| `src/components/TapesStack.svelte` | **Modify** — add `data-testid="tapes-stack"` to the stack container. |
+| `.github/workflows/test.yml` | **Create** — `pull_request` trigger; jobs `check`, `lint`, `vitest`, `playwright`. |
+| `docs/execution-model.md` | **Modify** — §14 grammar registers `E-` prefix; updates regex to `\b[SRCE]-[a-z-]+`. |
+| `CLAUDE.md` | **Modify** — list new scripts, `e2e/` directory, Playwright config; mention `data-testid` selectors as the convention for non-button DOM. |
+| `README.md` | **Modify** — same drift sync. |
+| `.gitignore` | **Modify** — add `playwright-report/`, `test-results/`, `blob-report/`. |
+| `vitest.config.ts` | **No change** — `include: ['src/**/*.test.ts']` already excludes `e2e/`. |
+
+No other production source files modified. The `data-testid` additions are non-functional and don't affect rendering, accessibility, or behavior.
+
+## Test layout
+
+`e2e/cold-start.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test.describe('cold-start', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/turing');
+    // Wait for the page mount to settle (DEMO mode auto-runs but doesn't block clicks).
+    await expect(page.getByTestId('tapes-stack')).toBeVisible();
+  });
+
+  test('E-cold-start-run-debug-off: Run advances tape, halt logged', async ({ page }) => {
+    // ... see scenario-detail section below
+  });
+
+  test('E-cold-start-step-debug-on: Step+debug=on parks at iter-1', async ({ page }) => { ... });
+
+  test('E-continue-from-step: Continue (debug=off) runs to halt', async ({ page }) => { ... });
+
+  test('E-stop-while-paused: Stop while paused halts; Run/Step stay enabled', async ({ page }) => { ... });
+});
+```
+
+## Scenarios — full detail
+
+### `E-cold-start-run-debug-off`
+
+```ts
+test('E-cold-start-run-debug-off: Run advances tape, halt logged', async ({ page }) => {
+  await page.getByRole('button', { name: /^run$/i }).click();
+  await expect(page.getByTestId('log-line').filter({ hasText: /halted after \d+ step\(s\)/ })).toBeVisible({ timeout: 10_000 });
+  // Default Turing example transforms ['a','b','c','b','a'] → ['a','*','c','*','a']
+  // (head ends on 'a' at position 4 after the trailing-blank → halt transition).
+  // Tape.svelte renders VIEWPORT_WIDTH=23 cells per tape; assert the * count among them.
+  const cells = await page.getByTestId('tape-cell').allInnerTexts();
+  expect(cells.filter((s) => s === '*').length).toBe(2);
+});
+```
+
+### `E-cold-start-step-debug-on`
+
+```ts
+test('E-cold-start-step-debug-on: Step+debug=on parks at iter-1 with state info', async ({ page }) => {
+  await page.getByRole('checkbox', { name: /^debug$/i }).check();
+  await page.getByRole('button', { name: /^step$/i }).click();
+  // Cold-start Step always uses the run-mode `after`-trick; with debug=on the
+  // user-set breaks would also fire, but the example has none — the after-trick
+  // pause is what surfaces.
+  await expect(
+    page.getByTestId('log-line').filter({ hasText: /paused at .* state .* after applying command for symbols:/ }),
+  ).toBeVisible({ timeout: 5_000 });
+  // Run button relabels to "Continue" while paused.
+  await expect(page.getByRole('button', { name: /^continue$/i })).toBeVisible();
+});
+```
+
+### `E-continue-from-step`
+
+```ts
+test('E-continue-from-step: Continue (debug=off) runs to halt without further pauses', async ({ page }) => {
+  // Reach the paused state via the same flow as #2.
+  await page.getByRole('checkbox', { name: /^debug$/i }).check();
+  await page.getByRole('button', { name: /^step$/i }).click();
+  await expect(page.getByRole('button', { name: /^continue$/i })).toBeVisible();
+
+  // Snapshot pre-Continue paused-line count so we can detect spurious additional pauses later.
+  const pausedBefore = await page.getByTestId('log-line').filter({ hasText: /^paused at/ }).count();
+
+  // Toggle debug off, then Continue.
+  await page.getByRole('checkbox', { name: /^debug$/i }).uncheck();
+  await page.getByRole('button', { name: /^continue$/i }).click();
+  await expect(
+    page.getByTestId('log-line').filter({ hasText: /halted after \d+ step\(s\)/ }),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // No extra "paused" lines added between Continue click and halt.
+  const pausedAfter = await page.getByTestId('log-line').filter({ hasText: /^paused at/ }).count();
+  expect(pausedAfter).toBe(pausedBefore);
+});
+```
+
+### `E-stop-while-paused`
+
+```ts
+test('E-stop-while-paused: Stop while paused halts; Run/Step stay enabled', async ({ page }) => {
+  await page.getByRole('checkbox', { name: /^debug$/i }).check();
+  await page.getByRole('button', { name: /^step$/i }).click();
+  await expect(page.getByRole('button', { name: /^continue$/i })).toBeVisible();
+
+  // Click Stop. Per execution-model spec: Stop returns to MANUAL with workerLive=true,
+  // so Run/Step stay clickable for the user to keep poking the same machine state.
+  await page.getByRole('button', { name: /^stop$/i }).click();
+  await expect(page.getByTestId('log-line').filter({ hasText: /^stopped/ })).toBeVisible();
+
+  // After Stop, Run-button reverts to "Run" (no longer paused) and is enabled;
+  // Step is enabled too. Stop button itself disappears (stopVisible is false in MANUAL).
+  await expect(page.getByRole('button', { name: /^run$/i })).toBeEnabled();
+  await expect(page.getByRole('button', { name: /^step$/i })).toBeEnabled();
+  await expect(page.getByRole('button', { name: /^stop$/i })).not.toBeVisible();
+});
+```
+
+## `playwright.config.ts`
+
+```ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: 'npm run preview',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});
+```
+
+`vite preview` defaults to `127.0.0.1:4173`. `reuseExistingServer` lets local iteration leave the server up across runs.
+
+## `package.json` additions
+
+`devDependencies`: `"@playwright/test": "^1.50.0"`.
+
+`scripts`:
+- `"test:e2e": "playwright test"` — one-shot, used in CI.
+- `"test:e2e:ui": "playwright test --ui"` — Playwright's interactive mode for local debugging.
+
+## `.github/workflows/test.yml`
+
+```yaml
+name: Test
+
+on:
+  pull_request:
+    branches: [master]
+
+env:
+  NODE_VERSION: 24
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci
+      - run: npm run check
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  vitest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+      - run: npm run build
+      - run: npm run test:e2e
+      - name: Upload test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+```
+
+The Vitest job runs only `npm test` (Vitest); it does not run Playwright. The Playwright job builds first (so `vite preview` has `dist/` to serve) then runs `test:e2e`. On failure, the HTML report is uploaded as an artifact for diagnosis.
+
+## `data-testid` additions — exact placement
+
+**`src/components/Tape.svelte`** (around line 90–106):
+
+- The outer `.ui-belt` wrapper gains `data-testid="tape"`.
+- The inner `.cell` gains `data-testid="tape-cell"` + `data-blank={cell.blank}`.
+
+**`src/components/Log.svelte`** (around line 21–55):
+
+- `.log-panel` gains `data-testid="log"`.
+- `.line` gains `data-testid="log-line"` + `data-kind={entry.kind ?? ''}`.
+
+**`src/components/TapesStack.svelte`** (root container):
+
+- The stack root gains `data-testid="tapes-stack"`.
+
+These are the only DOM additions. No CSS class changes, no element restructuring, no new wrappers introduced.
+
+## §14 grammar update (`docs/execution-model.md`)
+
+Existing prefix table after PR4:
+
+| `S-` | UI-scenario reference. |
+| `R-` | runner / worker / helper internal. |
+| `C-` | component-test scenarios. |
+
+After PR5, add:
+
+| `E-` | end-to-end scenarios — full UI flow including worker round-trip. Format `E-<from-state-or-context>-<facet>`, e.g. `E-cold-start-run-debug-off`. Used in `e2e/*.spec.ts`. |
+
+`<topic>` row gains: `e2e/cold-start.spec.ts`: `cold-start`, `continue-from-step`, `stop-while-paused`.
+
+Regex line: change `\b[SRC]-[a-z-]+` to `\b[SRCE]-[a-z-]+`. Prose: change "All three prefixes" to "All four prefixes".
+
+## Self-review
+
+After implementation:
+
+1. **All 4 PR5 `test()` names match `\bE-[a-z-]+: <text>` pattern.** All 4 scenario IDs unique.
+2. **No production-side functional changes.** `data-testid` additions are accessibility-neutral and don't affect rendering. `git diff master..HEAD -- src/lib/` empty (only `src/components/Tape.svelte`, `Log.svelte`, `TapesStack.svelte` touched, and only with attribute additions).
+3. **All 56 unit tests still pass.** `data-testid` additions don't break `Toolbar.test.ts` (it queries by role, not testid).
+4. **`npm run test:e2e` exits 0** locally (with built `dist/`). Test count = 4.
+5. **CI workflow runs all four jobs in parallel** on a representative test PR.
+6. **`.gitignore` excludes** `playwright-report/`, `test-results/`, `blob-report/`.
+
+## Out of scope
+
+- **Post engine E2E** — worker contract identical to Turing; signal redundancy.
+- **Multi-browser matrix** — Chromium only until a real cross-browser issue surfaces.
+- **Visual regression** — separate concern; tools like Chromatic / Percy are heavy.
+- **Accessibility audits** (axe-core via `@axe-core/playwright`) — worth doing but a separate PR.
+- **CD workflow change** — existing `main.yml` stays as-is. Adding test gating to deploys is a follow-up; for now the PR-gate catches issues before merge.
+- **Visual coverage of the snippets / examples / save-popover flows** — covered indirectly via Playwright if they break the build, but no targeted scenarios; component-test PR or future E2E batch.
+- **Test-result publication / dashboards** — the GitHub-action HTML upload-on-failure is sufficient; no third-party reporter integration.

--- a/e2e/cold-start.spec.ts
+++ b/e2e/cold-start.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('cold-start', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/turing');
+    // Wait for the app to mount before clicking. DEMO mode auto-runs but
+    // doesn't block clicks.
+    await expect(page.getByTestId('tapes-stack')).toBeVisible();
+  });
+
+  test('E-cold-start-run-debug-off: Run advances tape, halt logged', async ({ page }) => {
+    await page.getByRole('button', { name: /^run$/i }).click();
+    await expect(
+      page.getByTestId('log-line').filter({ hasText: /halted after \d+ step\(s\)/ }),
+    ).toBeVisible({ timeout: 10_000 });
+    // Default Turing example transforms ['a','b','c','b','a'] → ['a','*','c','*','a'].
+    // Tape.svelte renders VIEWPORT_WIDTH=23 cells per tape; the * count among
+    // the rendered cells is 2 (both 'b's were replaced).
+    const cells = await page.getByTestId('tape-cell').allInnerTexts();
+    expect(cells.filter((s) => s === '*').length).toBe(2);
+  });
+
+  test('E-cold-start-step-debug-on: Step+debug=on parks at iter-1 with state info', async ({ page }) => {
+    await page.getByRole('checkbox', { name: /^debug$/i }).check();
+    await page.getByRole('button', { name: /^step$/i }).click();
+    // Cold-start Step always uses the run-mode after-trick; with debug=on the
+    // user-set breaks would also fire, but the example has none — the
+    // after-trick pause is what surfaces.
+    await expect(
+      page.getByTestId('log-line').filter({
+        hasText: /paused at .*state .* after applying command for symbols:/,
+      }),
+    ).toBeVisible({ timeout: 5_000 });
+    // Run button relabels to "Continue" while paused.
+    await expect(page.getByRole('button', { name: /^continue$/i })).toBeVisible();
+  });
+
+  test('E-continue-from-step: Continue (debug=off) runs to halt without further pauses', async ({ page }) => {
+    // Reach the paused state via the same flow as the previous test.
+    await page.getByRole('checkbox', { name: /^debug$/i }).check();
+    await page.getByRole('button', { name: /^step$/i }).click();
+    await expect(page.getByRole('button', { name: /^continue$/i })).toBeVisible();
+
+    // Snapshot the pre-Continue paused-line count.
+    const pausedBefore = await page
+      .getByTestId('log-line')
+      .filter({ hasText: /^paused at/ })
+      .count();
+
+    // Toggle debug off, then Continue.
+    await page.getByRole('checkbox', { name: /^debug$/i }).uncheck();
+    await page.getByRole('button', { name: /^continue$/i }).click();
+    await expect(
+      page.getByTestId('log-line').filter({ hasText: /halted after \d+ step\(s\)/ }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // No additional "paused" lines added between Continue click and halt.
+    const pausedAfter = await page
+      .getByTestId('log-line')
+      .filter({ hasText: /^paused at/ })
+      .count();
+    expect(pausedAfter).toBe(pausedBefore);
+  });
+
+  test('E-stop-while-paused: Stop while paused halts; Run/Step stay enabled', async ({ page }) => {
+    await page.getByRole('checkbox', { name: /^debug$/i }).check();
+    await page.getByRole('button', { name: /^step$/i }).click();
+    await expect(page.getByRole('button', { name: /^continue$/i })).toBeVisible();
+
+    // Stop returns the machine to MANUAL with workerLive=true: Run/Step stay
+    // clickable so the user can keep poking the same machine state.
+    await page.getByRole('button', { name: /^stop$/i }).click();
+    await expect(
+      page.getByTestId('log-line').filter({ hasText: /^stopped/ }),
+    ).toBeVisible();
+
+    // After Stop, Run-button reverts to "Run" and is enabled; Step is enabled
+    // too. Stop button itself disappears (stopVisible is false in MANUAL).
+    await expect(page.getByRole('button', { name: /^run$/i })).toBeEnabled();
+    await expect(page.getByRole('button', { name: /^step$/i })).toBeEnabled();
+    await expect(page.getByRole('button', { name: /^stop$/i })).not.toBeVisible();
+  });
+});

--- a/e2e/cold-start.spec.ts
+++ b/e2e/cold-start.spec.ts
@@ -16,7 +16,7 @@ test.describe('cold-start', () => {
     // Default Turing example transforms ['a','b','c','b','a'] → ['a','*','c','*','a'].
     // Tape.svelte renders VIEWPORT_WIDTH=23 cells per tape; the * count among
     // the rendered cells is 2 (both 'b's were replaced).
-    const cells = await page.getByTestId('tape-cell').allInnerTexts();
+    const cells = await page.getByTestId('tape').first().getByTestId('tape-cell').allInnerTexts();
     expect(cells.filter((s) => s === '*').length).toBe(2);
   });
 
@@ -69,6 +69,7 @@ test.describe('cold-start', () => {
 
     // Stop returns the machine to MANUAL with workerLive=true: Run/Step stay
     // clickable so the user can keep poking the same machine state.
+    await expect(page.getByRole('button', { name: /^stop$/i })).toBeVisible();
     await page.getByRole('button', { name: /^stop$/i }).click();
     await expect(
       page.getByTestId('log-line').filter({ hasText: /^stopped/ }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "svelte-codemirror-editor": "^2.1.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.50.0",
         "@sveltejs/vite-plugin-svelte": "^4.0.0",
         "@testing-library/jest-dom": "^6.6.0",
         "@testing-library/svelte": "^5.2.0",
@@ -993,6 +994,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@post-machine-js/machine": {
@@ -3836,6 +3853,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "svelte-check --tsconfig ./tsconfig.json && vite build",
-    "preview": "vite preview",
+    "preview": "vite preview --host 127.0.0.1",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "lint": "eslint .",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.0",
@@ -25,6 +27,7 @@
     "svelte-codemirror-editor": "^2.1.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.50.0",
     "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/svelte": "^5.2.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: 'npm run preview',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/src/components/Log.svelte
+++ b/src/components/Log.svelte
@@ -18,7 +18,7 @@
   });
 </script>
 
-<div class="log-panel">
+<div class="log-panel" data-testid="log">
   {#if entries.length > 0}
     <IconButton icon="eraser" title="Clear log" onClick={onClear} />
   {/if}
@@ -27,7 +27,14 @@
       {#if entry.separator}
         <hr class="sep" />
       {:else}
-        <div class="line" class:error={entry.kind === 'error'} class:warn={entry.kind === 'warn'} class:ok={entry.kind === 'ok'}>
+        <div
+          class="line"
+          class:error={entry.kind === 'error'}
+          class:warn={entry.kind === 'warn'}
+          class:ok={entry.kind === 'ok'}
+          data-testid="log-line"
+          data-kind={entry.kind ?? ''}
+        >
           <div
             class="head"
             style={entry.color && !entry.kind ? `color: ${entry.color};` : undefined}

--- a/src/components/Tape.svelte
+++ b/src/components/Tape.svelte
@@ -90,12 +90,13 @@
   class="ui-belt"
   class:no-caret={!showCaret}
   style={caretColor ? `--head: ${caretColor};` : undefined}
+  data-testid="tape"
 >
   <div class="viewport">
     <div class="center">
       <div class="strip transitions-on" bind:this={stripEl}>
         {#each viewport as cell}
-          <div class="cell" class:blank={cell.blank}>
+          <div class="cell" class:blank={cell.blank} data-testid="tape-cell" data-blank={cell.blank}>
             <span class="sym">{cell.sym}</span>
           </div>
         {/each}

--- a/src/components/TapesStack.svelte
+++ b/src/components/TapesStack.svelte
@@ -47,7 +47,7 @@
   }
 </script>
 
-<div class="tapes-stack">
+<div class="tapes-stack" data-testid="tapes-stack">
   <div class="head-thread" style:background={headThreadBackground}></div>
   {#each Array(tapeCount) as _, i}
     <Tape


### PR DESCRIPTION
## Summary

- Adds **4 Playwright E2E tests** in `e2e/cold-start.spec.ts` covering the worker round-trip flows: cold-start Run, cold-start Step+debug=on, Continue-from-step, Stop-while-paused. Default Turing example, Chromium-only, runs against `vite preview`.
- Adds the project's **first CI test gate** in `.github/workflows/test.yml`: 4 parallel jobs (`check`, `lint`, `vitest`, `playwright`) triggered on every PR to master. Playwright job caches `~/.cache/ms-playwright` and uploads the HTML report on failure (7-day retention). Existing `main.yml` (CD on push) is unchanged.
- Production-side surface is minimal: `data-testid` attributes on `tape`, `tape-cell`, `tapes-stack`, `log`, `log-line` (3 components touched). `data-blank` on tape cells and `data-kind` on log lines are pre-wired for future filter-by-attribute queries; documented in CLAUDE.md's Conventions section.
- `vite preview --host 127.0.0.1` (in `package.json`'s preview script) ensures IPv4 host parity with Playwright's `baseURL` (Vite preview otherwise binds IPv6 by default).
- Registers a fourth scenario-ID prefix `E-<from-state-or-context>-<facet>` in `docs/execution-model.md` §14 (alongside `S-` / `R-` / `C-`); regex updated to `\b[SRCE]-[a-z-]+`.
- Total test count after this PR: **60** (56 Vitest + 4 Playwright). Closes the 5-PR series for #47.

## Post-merge action required

**Configure branch protection on master** to require all 4 CI status checks (`check`, `lint`, `vitest`, `playwright`) — the workflow file alone does not enforce the gate without GitHub UI settings. One-time manual setup.

## Test plan

- [x] \`npm test\` → 3 test files, 56 tests passed
- [x] \`npm run check\` → 0 errors, 0 warnings
- [x] \`npm run lint\` → clean
- [x] \`npm run build\` → builds successfully
- [x] \`npm run test:e2e\` → 4 tests passed (Chromium, ~2s)
- [x] No production-side functional changes (\`data-testid\` additions are non-functional)
- [x] \`grep -oE '\bE-[a-z-]+' e2e/cold-start.spec.ts | sort -u | wc -l\` → 4
- [x] Closes #47 (PR5 of 5; full series: #55 #56 #57 #58 + this)

## Notes

- The two fixup commits (`b8e391d` host parity, `c26a316` review fixes) will collapse into the squash merge.
- A follow-up issue is worth filing to tighten \`/halted after \\d+ step\\(s\\)/\` to \`/halted after [1-9]\\d{0,2} step\\(s\\)/\` so a silent \`MAX_STEPS = 100_000\` truncation can't masquerade as a clean halt.