### PR TITLE
chore: bump engines to v6

### DIFF
--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -4,7 +4,7 @@
 
 ## 1. Overview
 
-The demo runs user-typed JavaScript inside a Web Worker that drives a `@turing-machine-js/machine` v4 instance. The main thread tracks the worker's progress with a 7-mode state machine: three resting states (DEMO, IDLE, MANUAL), three running states (RUNNING_AUTO, RUNNING_CONTINUOUS, RUNNING_PAUSED), and one terminal (HALTED).
+The demo runs user-typed JavaScript inside a Web Worker that drives a `@turing-machine-js/machine` v6 instance. The main thread tracks the worker's progress with a 7-mode state machine: three resting states (DEMO, IDLE, MANUAL), three running states (RUNNING_AUTO, RUNNING_CONTINUOUS, RUNNING_PAUSED), and one terminal (HALTED).
 
 Most user actions are mode transitions; a few — debug toggle, withPause toggle, Apply — are flag changes or in-place mirror writes that don't move the mode.
 
@@ -287,7 +287,7 @@ sequenceDiagram
 
     User->>Main: click Run [debug=on]
     Main->>Worker: postMessage { type: 'run', debug: true }
-    Worker->>Engine: machine.run({ onDebugBreak })
+    Worker->>Engine: machine.run({ onPause })
     Engine-->>Worker: yield N, state.debug.before fires
     Worker-->>Main: { type: 'paused', state, currentSymbols, debugBreak: { before: true } }
     Note over Worker: timer suspended
@@ -297,7 +297,7 @@ sequenceDiagram
     Main->>Main: arm m.state.debug.after = true (pendingRestore captured)
     Main->>Worker: postMessage { type: 'resume', step: true }
     Note over Worker: timer restarted
-    Worker->>Engine: resolve onDebugBreak Promise
+    Worker->>Engine: resolve onPause Promise
     Engine-->>Worker: yield N+1, state.debug.after fires (armed)
     Worker->>Worker: pendingRestore() — undo arm
     Worker-->>Main: { type: 'paused', debugBreak: { after: true } }
@@ -334,7 +334,7 @@ A Run with `debug=on` and user-authored `state.debug` triggers a sequence of pau
 **Sequence (debug=off).**
 1. User clicks Run while in RUNNING_PAUSED. The button reads "Continue".
 2. Main thread sends `resume({ step: false })`.
-3. Worker resolves the pending Promise. `debugEnabled = false` so `onDebugBreak` returns immediately on subsequent breaks.
+3. Worker resolves the pending Promise. `debugEnabled = false` so `onPause` returns immediately on subsequent breaks.
 4. Run continues to halt; worker sends `ran` → HALTED.
 
 **Sequence (debug=on).**
@@ -366,7 +366,7 @@ Stop is visible while in RUNNING_AUTO, RUNNING_CONTINUOUS, and RUNNING_PAUSED.
 
 The `debugMode` UI checkbox is reactive across mode transitions. A change while in any RUNNING_* mode pushes `setDebug(on)` to the worker.
 
-- `S-debug-toggle-auto` / `S-debug-toggle-cont` — `runner.setDebug(on)` posts a fire-and-forget message. Worker flips an internal `debugEnabled` flag. Subsequent `onDebugBreak` calls honor the new value (no run restart).
+- `S-debug-toggle-auto` / `S-debug-toggle-cont` — `runner.setDebug(on)` posts a fire-and-forget message. Worker flips an internal `debugEnabled` flag. Subsequent `onPause` calls honor the new value (no run restart).
 - `S-debug-toggle-paused` — same `setDebug()` send. The current paused state is unaffected; the next break (after Continue) is gated by the new flag value.
 - In DEMO / IDLE / MANUAL / HALTED — flag flip only; no worker call (the worker is idle, the flag is read at the next `run()`).
 
@@ -425,7 +425,7 @@ A run that doesn't halt naturally hits `MAX_STEPS = 100_000` inside the worker's
 **Log entries**
 - `timeout after 5000ms — worker terminated (likely infinite loop)`
 
-**Edge case.** Today's API doesn't expose any callback hook to user code — `state.debug.before` / `state.debug.after` are filter values (`true | string[] | null`), not user-supplied functions, and the worker's `onStep` / `onDebugBreak` wrap the run on the demo side. So a "stall via async user callback" isn't reachable in the current surface. The per-segment cap defends against the cases that *are* reachable: infinite loops in user code, hung worker-side Promises, and any future API surface that might let user-supplied async logic interpose.
+**Edge case.** Today's API doesn't expose any callback hook to user code — `state.debug.before` / `state.debug.after` are filter values (`true | string[] | null`), not user-supplied functions, and the worker's `onStep` / `onPause` wrap the run on the demo side. So a "stall via async user callback" isn't reachable in the current surface. The per-segment cap defends against the cases that *are* reachable: infinite loops in user code, hung worker-side Promises, and any future API surface that might let user-supplied async logic interpose.
 
 ## 11. Current divergences from spec
 
@@ -443,8 +443,8 @@ A punchlist of where today's code differs from the spec, each with a tracking-is
 
 Upstream behaviors the spec encodes (won't change without a major upstream version, so the spec works around them):
 
-- `onDebugBreak` after-fire payload substitutes `m` to `prevYield` — the un-substituted `machineState` is not exposed. Affects step-over-from-after implementations. Cross-ref [turing-machine-js#107](https://github.com/mellonis/turing-machine-js/issues/107).
-- `onStep` and `onDebugBreak` after-fire payloads carry semantically identical `MachineState`. Both hooks are documented; the demo wires both for orthogonal reasons (per-step buffer vs. pause cycle). Cross-ref [turing-machine-js#109](https://github.com/mellonis/turing-machine-js/issues/109).
+- `onPause` after-fire payload substitutes `m` to `prevYield` — the un-substituted `machineState` is not exposed. Affects step-over-from-after implementations. Cross-ref [turing-machine-js#107](https://github.com/mellonis/turing-machine-js/issues/107).
+- `onStep` and `onPause` after-fire payloads carry semantically identical `MachineState`. Both hooks are documented; the demo wires both for orthogonal reasons (per-step buffer vs. pause cycle). Cross-ref [turing-machine-js#109](https://github.com/mellonis/turing-machine-js/issues/109).
 
 §11 vs §12: §11 lists demo-side gaps to be closed; §12 lists engine semantics that won't change. Items can move from §12 to §11 if the upstream issue lands and a corresponding demo-side simplification becomes possible.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "@codemirror/lang-javascript": "^6.2.0",
         "@codemirror/lint": "^6.8.0",
         "@codemirror/theme-one-dark": "^6.1.0",
-        "@post-machine-js/machine": "^4.0.0",
+        "@post-machine-js/machine": "^6.0.0",
         "@tabler/icons": "^3.41.1",
-        "@turing-machine-js/machine": "^4.0.0",
+        "@turing-machine-js/machine": "^6.0.0",
         "codemirror": "^6.0.1",
         "svelte-codemirror-editor": "^2.1.0"
       },
@@ -578,15 +578,15 @@
       }
     },
     "node_modules/@post-machine-js/machine": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@post-machine-js/machine/-/machine-4.0.0.tgz",
-      "integrity": "sha512-BjG70ywFaPYRRAuaMBth8RKPQvYLZvMnDdYfoUMPRMNbwSffQsyC/rkrxTaX5/p3z1MPp3YtimySwci/VDjbDg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@post-machine-js/machine/-/machine-6.0.0.tgz",
+      "integrity": "sha512-wggwMFpV6mjL8UPIsWnWCkTK7okpssO3OKLmCSmdixqe6pyb/Jon6m9bWLU2/zMus6wIqi6a2zBf7+sn3XtvnA==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^4.0.0"
+        "@turing-machine-js/machine": "^6.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1004,9 +1004,9 @@
       "license": "MIT"
     },
     "node_modules/@turing-machine-js/machine": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-4.0.0.tgz",
-      "integrity": "sha512-gSdhz1/0b0ZeFwyn+rLQgWwehveu/HsXO6rLossenrRwaVIY3ej32wUqS5bZTNqYTManAWSfyZ1ASYBYxQbYcg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-6.0.1.tgz",
+      "integrity": "sha512-nnp1z8bmGa+OBe9nPi8JloATkj5Aa6KSbjj/9SZ8k+evFvLs96s0tvbAD8+Pivf1Jc/zngWKkC9dCwtdyE/cYQ==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "@codemirror/lang-javascript": "^6.2.0",
     "@codemirror/lint": "^6.8.0",
     "@codemirror/theme-one-dark": "^6.1.0",
-    "@post-machine-js/machine": "^4.0.0",
+    "@post-machine-js/machine": "^6.0.0",
     "@tabler/icons": "^3.41.1",
-    "@turing-machine-js/machine": "^4.0.0",
+    "@turing-machine-js/machine": "^6.0.0",
     "codemirror": "^6.0.1",
     "svelte-codemirror-editor": "^2.1.0"
   },

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -7,7 +7,7 @@
  *   idle → (build) → built → (run) → running → (paused) → paused → (resume) → running
  *                          → (step) → built (same, halted advances)
  *
- * A `paused` response is sent when `onDebugBreak` fires; the worker's `run()`
+ * A `paused` response is sent when `onPause` fires; the worker's `run()`
  * Promise stays pending until a `resume` request resolves the internal Promise.
  */
 
@@ -40,8 +40,8 @@ import {
  * The strong types live at the worker postMessage boundary instead.
  */
 
-// onDebugBreak payload subset we read. Engine's full type carries more.
-type DebugBreakPayload = {
+// onPause payload subset we read. Engine's full type carries more.
+type OnPausePayload = {
   state: { name?: string };
   currentSymbols: string[];
   nextState: { debug: { before?: true; after?: true } | null };
@@ -54,8 +54,8 @@ type AnyMachine = {
     initialState?: unknown;
     stepsLimit?: number;
     onStep?: (m: MachineYield) => void;
-    onDebugBreak?: (m: DebugBreakPayload) => void | Promise<void>;
-    __onDebugBreak?: (m: DebugBreakPayload) => void | Promise<void>;
+    onPause?: (m: OnPausePayload) => void | Promise<void>;
+    __onPause?: (m: OnPausePayload) => void | Promise<void>;
   }) => Promise<void>;
   initialState?: unknown;
   tape?: AnyTape;
@@ -128,7 +128,7 @@ let generator: Generator<MachineYield, void, void> | null = null;
 let stepsApplied = 0;
 let pendingCommand: MachineYield | null = null;
 
-// Holds the resolver of the Promise awaited inside onDebugBreak. Set when
+// Holds the resolver of the Promise awaited inside onPause. Set when
 // the worker is paused at a break; cleared on `resume`. Concurrent `run`
 // requests are rejected by the phase machine before they reach this slot.
 let resumeResolve: ((action: { step: boolean }) => void) | null = null;
@@ -144,7 +144,7 @@ let pendingRestore: (() => void) | null = null;
 let runCommandBuffer: Command[][] = [];
 let runStartStep = 0;
 
-// Runtime-mutable gate consulted inside onDebugBreak. Initialized from the
+// Runtime-mutable gate consulted inside onPause. Initialized from the
 // `run` request's `debug` flag; toggled mid-run via the `setDebug` message
 // so the user can flip the checkbox without restarting.
 let debugEnabled = false;
@@ -302,7 +302,7 @@ async function run(
   // mid-run. The hook self-gates on `debugEnabled` and resolves immediately
   // when off — engine continues without pausing — UNLESS the user just
   // clicked Step, in which case the next break always pauses.
-  const onDebugBreakFn = async (m: DebugBreakPayload) => {
+  const onPauseFn = async (m: OnPausePayload) => {
         // Restore the synthesized one-shot before the user observes the break.
         // (Done unconditionally — clean up even when debug is currently off,
         // so a Step-armed mutation doesn't leak past a debug toggle.)
@@ -353,10 +353,9 @@ async function run(
         }
       };
 
-  // PostMachine.run() uses `__onDebugBreak` and does not accept `initialState`
-  // (uses its own #initialState). TuringMachine.run() uses `onDebugBreak` and
-  // requires `initialState`. Branch on the presence of `__onDebugBreak` in the
-  // machine's `run` signature to route correctly.
+  // PostMachine.run() uses `__onPause` and does not accept `initialState`
+  // (uses its own #initialState). TuringMachine.run() uses `onPause` and
+  // requires `initialState`. Branch on the machine class to route correctly.
   const runOpts: Parameters<AnyMachine['run']>[0] = {
     stepsLimit: maxSteps,
     onStep: (m: MachineYield) => {
@@ -366,13 +365,13 @@ async function run(
   };
 
   if (machine instanceof post.PostMachine) {
-    // PostMachine.run() uses `__onDebugBreak` and ignores `initialState`
+    // PostMachine.run() uses `__onPause` and ignores `initialState`
     // (it carries its own #initialState internally).
-    runOpts.__onDebugBreak = onDebugBreakFn;
+    runOpts.__onPause = onPauseFn;
   } else {
-    // TuringMachine.run() uses `onDebugBreak` and requires `initialState`.
+    // TuringMachine.run() uses `onPause` and requires `initialState`.
     runOpts.initialState = initialState;
-    runOpts.onDebugBreak = onDebugBreakFn;
+    runOpts.onPause = onPauseFn;
   }
 
   try {


### PR DESCRIPTION
## Summary
- `@turing-machine-js/machine` and `@post-machine-js/machine` bumped `^4.0.0` → `^6.0.0`. Post-machine v6 widens its peer dep on the engine to `^6.0.0`, so this is one combined bump.
- Engine v5 renamed the `run()` option key `onDebugBreak` → `onPause`; post-machine v6 likewise renamed `__onDebugBreak` → `__onPause`. `src/lib/machineWorker.ts` updated accordingly — option keys, `DebugBreakPayload` → `OnPausePayload`, callback variable, routing comments. The per-yield `m.debugBreak` field name is unchanged in v6, so the worker's `paused` response shape and downstream UI are untouched.
- `docs/execution-model.md`: version pin v4 → v6 and the same `onDebugBreak` → `onPause` mechanical rename across mermaid + walk-throughs + §12. §11/§12 cross-refs to closed engine issues (#107/#108/#109) left as-is — those need a content-level rework that's out of scope here.

`haltState.debug.after` (rejected at write-time since engine v5) and the v6 per-iter lifecycle reorder (`before → step → after`) aren't reachable from any bundled example, so no demo-side adjustments needed beyond the rename.

Closes #61.

## Test plan
- [x] `npm run check` — 222 files, 0 errors / 0 warnings
- [x] `npm run lint` — clean
- [x] `npm test` — 56/56 passing
- [x] `npm run build` — clean
- [x] `npm run test:e2e` — 4/4 cold-start scenarios passing (covers the step-with-debug-on path end-to-end through the renamed `onPause`)