### PR TITLE
feat: bump to v7 + step log notation parity (#69)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "@codemirror/lang-javascript": "^6.2.5",
         "@codemirror/lint": "^6.9.6",
         "@codemirror/theme-one-dark": "^6.1.3",
-        "@post-machine-js/machine": "^6.4.0",
+        "@post-machine-js/machine": "^7.0.0-alpha.4",
         "@tabler/icons": "^3.44.0",
-        "@turing-machine-js/machine": "^6.4.0",
+        "@turing-machine-js/machine": "^7.0.0-alpha.3",
         "codemirror": "^6.0.2",
         "svelte-codemirror-editor": "^2.1.0"
       },
@@ -578,15 +578,15 @@
       }
     },
     "node_modules/@post-machine-js/machine": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@post-machine-js/machine/-/machine-6.4.0.tgz",
-      "integrity": "sha512-eJMv6f//GvCEDTp/NSguqbVJF9dySK2wJRxok01j/n0qrk/yl5qHWDa5qv0s0l4SbG1kwAxiadbEOyxFADUlmQ==",
+      "version": "7.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@post-machine-js/machine/-/machine-7.0.0-alpha.4.tgz",
+      "integrity": "sha512-9vcbZ22TwtpjRtMYMQhR6sOwT6W/ZKG8gVT/fYHK6unHTy/MXrfHhuOL7rjJ21hyL975tUX59xmgTHu37EwwSg==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^6.4.0"
+        "@turing-machine-js/machine": "^7.0.0-alpha.3"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1004,9 +1004,9 @@
       "license": "MIT"
     },
     "node_modules/@turing-machine-js/machine": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-6.4.0.tgz",
-      "integrity": "sha512-kvpKl+qe9v4W7dBzBKQRM85++DgX9CAx1IG7Mvt1WCml2jSZCD+JOX2iqG5WQD05pWpP9RHUAdvXGwLkN3Q3Pg==",
+      "version": "7.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-7.0.0-alpha.3.tgz",
+      "integrity": "sha512-+5FW2WRikdcXM2o7qKVnWeMCFuOMIAySV01ATZoFiYlz9o797+MFxVjpSmJ3KQNqTijeXutIPlVdQl2a0VHhXA==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lint": "^6.9.6",
     "@codemirror/theme-one-dark": "^6.1.3",
-    "@post-machine-js/machine": "^6.4.0",
+    "@post-machine-js/machine": "^7.0.0-alpha.4",
     "@tabler/icons": "^3.44.0",
-    "@turing-machine-js/machine": "^6.4.0",
+    "@turing-machine-js/machine": "^7.0.0-alpha.3",
     "codemirror": "^6.0.2",
     "svelte-codemirror-editor": "^2.1.0"
   },

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -449,7 +449,13 @@
       if (res.commands.length > 0) {
         log.appendBatch(
           res.commands.map((commands, i) =>
-            commandsEntry(commands, { stepNumber: res.startStep + i + 1 }, CARET_COLORS),
+            commandsEntry(
+              res.reads[i] ?? null,
+              commands,
+              alphabets,
+              { stepNumber: res.startStep + i + 1 },
+              CARET_COLORS,
+            ),
           ),
         );
       }
@@ -477,8 +483,11 @@
     const startStep = data.stepsApplied - data.commands.length;
     for (let i = 0; i < data.commands.length; i++) {
       const commands = data.commands[i];
+      const reads = data.reads[i] ?? null;
       reflectToActivePanel(commands);
-      log.report(commandsEntry(commands, { stepNumber: startStep + i + 1 }, CARET_COLORS));
+      log.report(
+        commandsEntry(reads, commands, alphabets, { stepNumber: startStep + i + 1 }, CARET_COLORS),
+      );
       renderChain = renderChain.then(() => renderFromMirror(commands, animate));
     }
   }
@@ -492,7 +501,13 @@
       const startStep = paused.stepsApplied - paused.commands.length;
       log.appendBatch(
         paused.commands.map((commands, i) =>
-          commandsEntry(commands, { stepNumber: startStep + i + 1 }, CARET_COLORS),
+          commandsEntry(
+            paused.reads[i] ?? null,
+            commands,
+            alphabets,
+            { stepNumber: startStep + i + 1 },
+            CARET_COLORS,
+          ),
         ),
       );
     }
@@ -567,7 +582,13 @@
       if (res.commands.length > 0) {
         log.appendBatch(
           res.commands.map((commands, i) =>
-            commandsEntry(commands, { stepNumber: res.startStep + i + 1 }, CARET_COLORS),
+            commandsEntry(
+              res.reads[i] ?? null,
+              commands,
+              alphabets,
+              { stepNumber: res.startStep + i + 1 },
+              CARET_COLORS,
+            ),
           ),
         );
       }
@@ -669,8 +690,13 @@
   }
 
   async function onApply(commands: Command[]): Promise<void> {
+    // Capture pre-apply head symbols so the log entry mirrors a regular
+    // step's `[reads] → [writes]/[moves]` notation. Reads come from the
+    // main-thread mirror (source of truth for tape state in MANUAL mode).
+    const reads: string[] | null =
+      mirrorTapeBlock?.tapes.map((t) => t.symbols[t.position] ?? '') ?? null;
     await renderFromMirror(commands, true);
-    log.report(commandsEntry(commands, 'applied', CARET_COLORS));
+    log.report(commandsEntry(reads, commands, alphabets, 'applied', CARET_COLORS));
   }
 
   function resetCodeToSelected(): void {

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { commandsEntry } from './format.ts';
+import type { Command } from './types.ts';
+
+// Engine edge-label notation (machines-demo#69): `[reads] → [writes]/[moves]`.
+// Read cells: literal-quoted `'X'` or `B` (blank). Write cells: literal-quoted
+// or `K` (keep, command.symbol === null) or `E` (erase, command.symbol equals
+// blank). Move cells: bare `L`/`R`/`S`.
+
+describe('commandsEntry — edge-label notation', () => {
+  const alphabets = [[' ', '0', '1']]; // single-tape: blank = ' ', symbols 0/1
+
+  it('formats single-tape literal read + literal write + R move', () => {
+    const reads = ['1'];
+    const commands: Command[] = [{ movement: 'R', symbol: '0' }];
+    const entry = commandsEntry(reads, commands, alphabets, { stepNumber: 12 });
+    expect(entry.text).toBe(`step 12: ['1'] → ['0']/[R]`);
+  });
+
+  it('uses K when command.symbol is null (keep)', () => {
+    const reads = ['1'];
+    const commands: Command[] = [{ movement: 'S', symbol: null }];
+    const entry = commandsEntry(reads, commands, alphabets, { stepNumber: 3 });
+    expect(entry.text).toBe(`step 3: ['1'] → [K]/[S]`);
+  });
+
+  it('uses E when command.symbol equals the blank (erase)', () => {
+    const reads = ['1'];
+    const commands: Command[] = [{ movement: 'L', symbol: ' ' }];
+    const entry = commandsEntry(reads, commands, alphabets, { stepNumber: 5 });
+    expect(entry.text).toBe(`step 5: ['1'] → [E]/[L]`);
+  });
+
+  it('uses B when the read symbol equals the blank', () => {
+    const reads = [' ']; // blank under head
+    const commands: Command[] = [{ movement: 'R', symbol: '1' }];
+    const entry = commandsEntry(reads, commands, alphabets, { stepNumber: 7 });
+    expect(entry.text).toBe(`step 7: [B] → ['1']/[R]`);
+  });
+
+  it('renders manual `applied` entries with no [reads] prefix when reads is null', () => {
+    const commands: Command[] = [{ movement: 'R', symbol: '1' }];
+    const entry = commandsEntry(null, commands, alphabets, 'applied');
+    expect(entry.text).toBe(`applied: ['1']/[R]`);
+  });
+
+  it('renders manual `applied` entries with [reads] prefix when reads supplied', () => {
+    const reads = ['0'];
+    const commands: Command[] = [{ movement: 'R', symbol: '1' }];
+    const entry = commandsEntry(reads, commands, alphabets, 'applied');
+    expect(entry.text).toBe(`applied: ['0'] → ['1']/[R]`);
+  });
+
+  it('multi-tape: one row per tape with engine notation', () => {
+    const multiAlphabets = [
+      [' ', '0', '1'],
+      [' ', 'a', 'b'],
+    ];
+    const reads = ['1', 'a'];
+    const commands: Command[] = [
+      { movement: 'R', symbol: '0' },
+      { movement: 'L', symbol: 'b' },
+    ];
+    const entry = commandsEntry(reads, commands, multiAlphabets, { stepNumber: 2 });
+    expect(entry.text).toBe('step 2:');
+    expect(entry.rows).toHaveLength(2);
+    expect(entry.rows?.[0].text).toBe(`- Tape 1: ['1'] → ['0']/[R]`);
+    expect(entry.rows?.[1].text).toBe(`- Tape 2: ['a'] → ['b']/[L]`);
+  });
+
+  it('multi-tape: per-tape blank handling — B and E independently', () => {
+    const multiAlphabets = [
+      [' ', '0', '1'],
+      ['_', 'a', 'b'], // tape 2 uses '_' as blank
+    ];
+    const reads = [' ', 'a']; // tape 1 reads blank, tape 2 reads literal
+    const commands: Command[] = [
+      { movement: 'S', symbol: '_' }, // tape 1 writes literal '_' (NOT its blank ' ')
+      { movement: 'S', symbol: '_' }, // tape 2 writes '_' which IS its blank → E
+    ];
+    const entry = commandsEntry(reads, commands, multiAlphabets, { stepNumber: 1 });
+    expect(entry.rows?.[0].text).toBe(`- Tape 1: [B] → ['_']/[S]`);
+    expect(entry.rows?.[1].text).toBe(`- Tape 2: ['a'] → [E]/[S]`);
+  });
+
+  it('empty / null commands → just the header', () => {
+    expect(commandsEntry(null, null, alphabets, { stepNumber: 1 }).text).toBe('step 1:');
+    expect(commandsEntry(null, [], alphabets, { stepNumber: 1 }).text).toBe('step 1:');
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,25 +1,47 @@
 import type { Alphabets, Command, TapeSnapshot } from './types.ts';
 import type { LogEntry } from './log.ts';
 
-function describeAppliedCommand(command: Command): string {
-  // Display symbol — literal char from the alphabet (no UI substitution; the
-  // user controls what their blank looks like via the alphabet definition).
-  // Single-quote-wrap so an invisible blank (e.g. literal space) still reads
-  // as something on a log line. `sym` (not `symbol`) avoids shadowing the
-  // built-in TS/JS `symbol` type used by the upstream library's movement
-  // primitives.
-  const sym = command.symbol === null ? 'kept' : `wrote '${command.symbol}'`;
-  const movement = command.movement === 'L' ? 'moved left' : command.movement === 'R' ? 'moved right' : 'stayed';
-  // Paper-style shorthand: `<sym>/<mvmt>`. Actual symbols wrap in single
-  // quotes so a literal `*` (valid alphabet symbol) reads as `'*'` and stays
-  // distinct from the bare `*` wildcard used for "kept" (no write).
-  const shortSym = command.symbol === null ? '*' : `'${command.symbol}'`;
-  return `${sym} + ${movement} (${shortSym}/${command.movement})`;
-}
+/** Engine edge-label format (machines-demo#69) — matches turing-machine-js's
+ *  `toMermaid` emit so a logged step's notation lines up byte-for-byte with
+ *  the same transition's edge label in the rendered state graph.
+ *
+ *  Format: `[reads] → [writes]/[moves]` (writes/moves omit the `[reads] →`
+ *  prefix when `reads === null`, e.g. manual Apply where no transition
+ *  matched).
+ *
+ *  Per-cell encoding:
+ *  - Read cell: `'X'` (literal symbol, always single-quoted) or `B` (blank).
+ *    `*` (the engine's `ifOtherSymbol` catch-all) never appears at runtime —
+ *    the head reads a concrete symbol on every step.
+ *  - Write cell: `'X'` (literal) | `K` (keep, no write — `command.symbol`
+ *    is null because the resolved symbol matched current) | `E` (erase,
+ *    write equals blank).
+ *  - Move cell: `L` | `R` | `S`.
+ *
+ *  Multi-tape: per-tape entries are comma-separated inside one outer
+ *  bracket per role: `['1','a'] → ['0','b']/[R,L]`.
+ */
+function formatStepNotation(
+  reads: readonly string[] | null,
+  commands: readonly Command[],
+  blanks: readonly string[],
+): string {
+  const writes = commands
+    .map((c, i) => {
+      if (c.symbol === null) return 'K';
+      if (c.symbol === blanks[i]) return 'E';
+      return `'${c.symbol}'`;
+    })
+    .join(',');
+  const moves = commands.map((c) => c.movement).join(',');
+  const writesPart = `[${writes}]/[${moves}]`;
 
-/** Quoted, comma-separated rest-of-alphabet (excludes the blank at index 0). */
-function alphabetRest(alphabet: readonly string[]): string {
-  return alphabet.slice(1).map((s) => `'${s}'`).join(', ');
+  if (reads === null) return writesPart;
+
+  const readsStr = reads
+    .map((r, i) => (r === blanks[i] ? 'B' : `'${r}'`))
+    .join(',');
+  return `[${readsStr}] → ${writesPart}`;
 }
 
 export function formatTape(tape: TapeSnapshot): string {
@@ -29,6 +51,11 @@ export function formatTape(tape: TapeSnapshot): string {
   return tape.symbols
     .map((sym, i) => (i === tape.position ? `[${sym}]` : sym))
     .join('');
+}
+
+/** Quoted, comma-separated rest-of-alphabet (excludes the blank at index 0). */
+function alphabetRest(alphabet: readonly string[]): string {
+  return alphabet.slice(1).map((s) => `'${s}'`).join(', ');
 }
 
 /* ───── log entries ─────
@@ -79,26 +106,63 @@ export function tapesEntry(
 export type CommandsApplication = { stepNumber: number } | 'applied';
 
 /**
- * One log entry describing applied commands — replaces the previous
- * `stepEntry` / `appliedEntry` split. Single-tape: header followed by inline
- * description (`step 3: wrote 'a' + moved right ('a'/R)`). Multi-tape:
- * header on its own line and `- Tape N: …` rows per tape.
+ * One log entry rendering an applied step in engine edge-label notation
+ * (`[reads] → [writes]/[moves]`, machines-demo#69). Single-tape gets a
+ * one-line header + inline notation; multi-tape gets a header line with
+ * `- Tape N: …` rows per tape.
+ *
+ * `reads` parallels `commands` (per-tape symbols read at each head before
+ * the step applied). Manual `'applied'` from the control panel doesn't
+ * have a transition match in the engine sense; callers pass the symbols
+ * at the heads at apply-time when available, or `null` to render just
+ * `[writes]/[moves]`.
+ *
+ * `alphabets[i][0]` is the per-tape blank symbol — used to choose `B` over
+ * `'<literal>'` for reads and `E` over `'<literal>'` for writes when the
+ * symbol matches the blank.
  */
 export function commandsEntry(
+  reads: readonly string[] | readonly string[][] | null,
   commands: readonly Command[] | null,
+  alphabets: Alphabets,
   application: CommandsApplication,
   colors?: readonly string[],
 ): LogEntry {
   const prefix = application === 'applied' ? 'applied' : `step ${application.stepNumber}`;
   if (!commands || commands.length === 0) return { text: `${prefix}:` };
+
+  const blanks = alphabets.map((a) => a[0] ?? '');
+  // Single-tape: `reads` and `commands` are flat per-tape arrays.
   if (commands.length === 1) {
-    return { text: `${prefix}: ${describeAppliedCommand(commands[0])}`, color: colors?.[0] };
+    const tapeRead =
+      reads === null
+        ? null
+        : ((reads as readonly string[])[0] ?? null);
+    const notation = formatStepNotation(
+      tapeRead === null ? null : [tapeRead],
+      commands,
+      blanks,
+    );
+    return { text: `${prefix}: ${notation}`, color: colors?.[0] };
   }
+
+  // Multi-tape: one bracketed group per tape on its own row.
   return {
     text: `${prefix}:`,
-    rows: commands.map((command, i) => ({
-      text: `- Tape ${i + 1}: ${describeAppliedCommand(command)}`,
-      color: colors?.[i],
-    })),
+    rows: commands.map((command, i) => {
+      const tapeRead =
+        reads === null
+          ? null
+          : ((reads as readonly string[])[i] ?? null);
+      const notation = formatStepNotation(
+        tapeRead === null ? null : [tapeRead],
+        [command],
+        [blanks[i] ?? ''],
+      );
+      return {
+        text: `- Tape ${i + 1}: ${notation}`,
+        color: colors?.[i],
+      };
+    }),
   };
 }

--- a/src/lib/machineRunner.test.ts
+++ b/src/lib/machineRunner.test.ts
@@ -46,6 +46,7 @@ describe('MachineRunner', () => {
         type: 'stepped' as const,
         halted: false,
         commands: null,
+        reads: null,
         nextCommands: null,
         stepsApplied: 1,
       };
@@ -79,6 +80,7 @@ describe('MachineRunner', () => {
         tapes: [],
         truncated: false,
         commands: [],
+        reads: [],
         startStep: 0,
         stepsApplied: 5,
       };
@@ -110,6 +112,7 @@ describe('MachineRunner', () => {
         tapes: [],
         truncated: false,
         commands: [],
+        reads: [],
         startStep: 0,
         stepsApplied: 0,
       });
@@ -138,6 +141,7 @@ describe('MachineRunner', () => {
         type: 'paused',
         tapes: [],
         commands: [],
+        reads: [],
         stepsApplied: 1,
         state: 'q1',
         currentSymbols: ['a'],
@@ -169,6 +173,7 @@ describe('MachineRunner', () => {
         tapes: [],
         truncated: false,
         commands: [],
+        reads: [],
         startStep: 0,
         stepsApplied: 1,
       });
@@ -219,6 +224,7 @@ describe('MachineRunner', () => {
         type: 'paused' as const,
         tapes: [],
         commands: [],
+        reads: [],
         stepsApplied: 1,
         state: 'q1',
         currentSymbols: ['a'],
@@ -244,6 +250,7 @@ describe('MachineRunner', () => {
         tapes: [],
         truncated: false,
         commands: [],
+        reads: [],
         startStep: 0,
         stepsApplied: 5,
       };
@@ -269,6 +276,7 @@ describe('MachineRunner', () => {
         tapes: [],
         truncated: false,
         commands: [],
+        reads: [],
         startStep: 0,
         stepsApplied: 0,
       });
@@ -288,6 +296,7 @@ describe('MachineRunner', () => {
         type: 'paused',
         tapes: [],
         commands: [],
+        reads: [],
         stepsApplied: 1,
         state: 'q1',
         currentSymbols: ['a'],
@@ -305,6 +314,7 @@ describe('MachineRunner', () => {
         tapes: [],
         truncated: false,
         commands: [],
+        reads: [],
         startStep: 0,
         stepsApplied: 1,
       });
@@ -324,6 +334,7 @@ describe('MachineRunner', () => {
         type: 'paused',
         tapes: [],
         commands: [],
+        reads: [],
         stepsApplied: 1,
         state: 'q1',
         currentSymbols: ['a'],
@@ -341,6 +352,7 @@ describe('MachineRunner', () => {
         tapes: [],
         truncated: false,
         commands: [],
+        reads: [],
         startStep: 0,
         stepsApplied: 1,
       });
@@ -365,6 +377,7 @@ describe('MachineRunner', () => {
         tapes: [],
         truncated: false,
         commands: [],
+        reads: [],
         startStep: 0,
         stepsApplied: 1,
       });
@@ -399,12 +412,14 @@ describe('MachineRunner', () => {
       current().respond({
         type: 'idle',
         commands: [[{ movement: 'R', symbol: null }]],
+        reads: [['_']],
         stepsApplied: 1,
       });
       current().respond({ type: 'busy' });
       current().respond({
         type: 'idle',
         commands: [[{ movement: 'L', symbol: null }]],
+        reads: [['_']],
         stepsApplied: 2,
       });
       current().respond({ type: 'busy' });
@@ -425,6 +440,7 @@ describe('MachineRunner', () => {
         tapes: [],
         truncated: false,
         commands: [],
+        reads: [],
         startStep: 2,
         stepsApplied: 2,
       });
@@ -453,6 +469,7 @@ describe('MachineRunner', () => {
         tapes: [],
         truncated: false,
         commands: [],
+        reads: [],
         startStep: 0,
         stepsApplied: 0,
       });
@@ -529,6 +546,7 @@ describe('MachineRunner', () => {
         type: 'paused',
         tapes: [],
         commands: [],
+        reads: [],
         stepsApplied: 1,
         state: 'q1',
         currentSymbols: ['a'],
@@ -553,6 +571,7 @@ describe('MachineRunner', () => {
         tapes: [],
         truncated: false,
         commands: [],
+        reads: [],
         startStep: 0,
         stepsApplied: 1,
       });
@@ -572,6 +591,7 @@ describe('MachineRunner', () => {
         type: 'paused',
         tapes: [],
         commands: [],
+        reads: [],
         stepsApplied: 1,
         state: 'q1',
         currentSymbols: ['a'],
@@ -598,6 +618,7 @@ describe('MachineRunner', () => {
       current().respond({
         type: 'idle',
         commands: [[{ movement: 'R', symbol: null }]],
+        reads: [['_']],
         stepsApplied: 1,
       });
 
@@ -618,6 +639,7 @@ describe('MachineRunner', () => {
         tapes: [],
         truncated: false,
         commands: [],
+        reads: [],
         startStep: 1,
         stepsApplied: 1,
       });
@@ -636,6 +658,7 @@ describe('MachineRunner', () => {
       current().respond({
         type: 'idle',
         commands: [[{ movement: 'R', symbol: null }]],
+        reads: [['_']],
         stepsApplied: 1,
       });
       current().respond({ type: 'busy' });
@@ -660,6 +683,7 @@ describe('MachineRunner', () => {
         tapes: [],
         truncated: false,
         commands: [],
+        reads: [],
         startStep: 0,
         stepsApplied: 0,
       });
@@ -705,6 +729,7 @@ describe('MachineRunner', () => {
         tapes: [],
         truncated: false,
         commands: [],
+        reads: [],
         startStep: 0,
         stepsApplied: 0,
       });
@@ -728,6 +753,7 @@ describe('MachineRunner', () => {
         tapes: [],
         truncated: false,
         commands: [],
+        reads: [],
         startStep: 0,
         stepsApplied: 0,
       });

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -15,6 +15,7 @@ import * as turing from '@turing-machine-js/machine';
 import * as post from '@post-machine-js/machine';
 import {
   commandsFromYield,
+  readsFromYield,
   snapshotTapes,
   snapshotAlphabets,
   expectPhase,
@@ -144,8 +145,10 @@ let resumeResolve: (() => void) | null = null;
 
 // Per-run buffer of commands captured by onStep. Drained on `paused` (sent
 // in the response), on `idle` per-iter (auto mode), and on `ran` (sent in
-// the response).
+// the response). `runReadsBuffer` is the parallel array of pre-step head
+// symbols (machines-demo#69) — same length, same per-step index.
 let runCommandBuffer: Command[][] = [];
+let runReadsBuffer: string[][] = [];
 let runStartStep = 0;
 
 // Runtime-mutable gate consulted inside onPause. Initialized from the
@@ -185,6 +188,7 @@ function reset(): void {
   pendingCommand = null;
   resumeResolve = null;
   runCommandBuffer = [];
+  runReadsBuffer = [];
   runStartStep = 0;
   debugEnabled = false;
   stepRequested = false;
@@ -272,13 +276,19 @@ function build(engine: Engine, code: string): void {
   }
 }
 
-function step(): { commands: Command[] | null; nextCommands: Command[] | null; halted: boolean } {
+function step(): {
+  commands: Command[] | null;
+  reads: string[] | null;
+  nextCommands: Command[] | null;
+  halted: boolean;
+} {
   expectPhase(phase.kind, ['built']);
   const built = phase as Extract<WorkerPhase, { kind: 'built' }>;
   if (built.halted || !pendingCommand || !generator) {
-    return { commands: null, nextCommands: null, halted: true };
+    return { commands: null, reads: null, nextCommands: null, halted: true };
   }
   const commands = commandsFromYield(pendingCommand);
+  const reads = readsFromYield(pendingCommand);
   const r = generator.next();
   stepsApplied += 1;
   let halted: boolean;
@@ -291,7 +301,7 @@ function step(): { commands: Command[] | null; nextCommands: Command[] | null; h
   }
   phase = { kind: 'built', halted };
   const nextCommands = pendingCommand ? commandsFromYield(pendingCommand) : null;
-  return { commands, nextCommands, halted };
+  return { commands, reads, nextCommands, halted };
 }
 
 /**
@@ -312,12 +322,15 @@ async function dispatchPause(info: {
   debugBreak: { before?: true; after?: true };
 }): Promise<void> {
   const commandsBatch = runCommandBuffer;
+  const readsBatch = runReadsBuffer;
   runCommandBuffer = [];
+  runReadsBuffer = [];
   phase = { kind: 'paused' };
   send({
     type: 'paused',
     tapes: snapshotTapes(tapes),
     commands: commandsBatch,
+    reads: readsBatch,
     stepsApplied,
     state: info.state,
     currentSymbols: info.currentSymbols,
@@ -355,6 +368,7 @@ async function run(
 
   runStartStep = stepsApplied;
   runCommandBuffer = [];
+  runReadsBuffer = [];
   phase = { kind: 'running' };
   debugEnabled = debug;
   stepRequested = step;
@@ -410,8 +424,10 @@ async function run(
 
     if (runIntervalMs !== null && runIntervalMs > 0) {
       const drained = runCommandBuffer;
+      const drainedReads = runReadsBuffer;
       runCommandBuffer = [];
-      send({ type: 'idle', commands: drained, stepsApplied });
+      runReadsBuffer = [];
+      send({ type: 'idle', commands: drained, reads: drainedReads, stepsApplied });
       await new Promise<void>((resolve) => {
         pendingTimeoutResolve = resolve;
         pendingTimeoutId = _setTimeout(() => {
@@ -437,6 +453,7 @@ async function run(
     stepsLimit: maxSteps,
     onStep: (m: MachineYield) => {
       runCommandBuffer.push(commandsFromYield(m));
+      runReadsBuffer.push(readsFromYield(m));
       stepsApplied += 1;
     },
     onPause: onPauseFn,
@@ -500,11 +517,12 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
     }
 
     if (req.type === 'step') {
-      const { commands, nextCommands, halted } = step();
+      const { commands, reads, nextCommands, halted } = step();
       send({
         type: 'stepped',
         halted,
         commands,
+        reads,
         nextCommands,
         stepsApplied,
       });
@@ -523,10 +541,12 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
         tapes: snapshotTapes(tapes),
         truncated,
         commands: runCommandBuffer,
+        reads: runReadsBuffer,
         startStep,
         stepsApplied,
       });
       runCommandBuffer = [];
+      runReadsBuffer = [];
       return;
     }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -74,6 +74,13 @@ export type SteppedResponse = {
   type: 'stepped';
   halted: boolean;
   commands: Command[] | null;
+  /**
+   * Per-tape symbols read at each head BEFORE this step applied. Parallel to
+   * `commands`; one entry per tape. Drives `[reads] → [writes]/[moves]`
+   * edge-label-style log rendering (machines-demo#69). `null` when
+   * `commands` is `null` (halted, no step ran).
+   */
+  reads: string[] | null;
   nextCommands: Command[] | null;
   stepsApplied: number;
 };
@@ -83,6 +90,8 @@ export type RanResponse = {
   tapes: TapeSnapshot[];
   truncated: boolean;
   commands: Command[][];
+  /** Per-step, per-tape reads captured before each step. Parallel to `commands`. */
+  reads: string[][];
   startStep: number;
   stepsApplied: number;
 };
@@ -104,6 +113,8 @@ export type PausedResponse = {
    * from `tapes` (snap, no animation), same path as `ran`.
    */
   commands: Command[][];
+  /** Per-step, per-tape reads captured before each step. Parallel to `commands`. */
+  reads: string[][];
   stepsApplied: number;
   /** `m.state.name` — the user's State instance does not cross the boundary. */
   state: string;
@@ -131,6 +142,8 @@ export type PausedResponse = {
 export type IdleResponse = {
   type: 'idle';
   commands: Command[][];
+  /** Per-step, per-tape reads captured before each step. Parallel to `commands`. */
+  reads: string[][];
   stepsApplied: number;
 };
 export type BusyResponse = { type: 'busy' };

--- a/src/lib/workerHelpers.test.ts
+++ b/src/lib/workerHelpers.test.ts
@@ -3,6 +3,7 @@ import * as turing from '@turing-machine-js/machine';
 import {
   movementCode,
   commandsFromYield,
+  readsFromYield,
   snapshotTapes,
   snapshotAlphabets,
   expectPhase,
@@ -62,6 +63,28 @@ describe('workerHelpers', () => {
         { movement: 'S', symbol: 'B' },
         { movement: 'L', symbol: null },
       ]);
+    });
+  });
+
+  describe('reads', () => {
+    it('R-reads-single-tape: returns the pre-step head symbol', () => {
+      const yieldVal: MachineYield = {
+        movements: [turing.movements.right],
+        currentSymbols: ['a'],
+        nextSymbols: ['b'],
+      };
+      expect(readsFromYield(yieldVal)).toEqual(['a']);
+    });
+
+    it('R-reads-defensive-copy: mutating the returned array does not affect the yield', () => {
+      const yieldVal: MachineYield = {
+        movements: [turing.movements.stay],
+        currentSymbols: ['a', 'b'],
+        nextSymbols: ['a', 'b'],
+      };
+      const reads = readsFromYield(yieldVal);
+      reads.push('z');
+      expect(yieldVal.currentSymbols).toEqual(['a', 'b']);
     });
   });
 

--- a/src/lib/workerHelpers.ts
+++ b/src/lib/workerHelpers.ts
@@ -27,6 +27,13 @@ export function commandsFromYield(y: MachineYield): Command[] {
   });
 }
 
+/** Per-tape read symbols at the heads BEFORE the yielded step applied.
+ *  Parallel to `commandsFromYield`; defensive-copies so the caller can
+ *  mutate without aliasing the engine's array (machines-demo#69). */
+export function readsFromYield(y: MachineYield): string[] {
+  return [...y.currentSymbols];
+}
+
 // --- Tape / alphabet snapshots ---
 
 export type TapeLike = {


### PR DESCRIPTION
## Summary

Two changes bundled in one PR:

### 1. Dep bump v6 → v7

- \`@post-machine-js/machine\` \`^6.4.0\` → \`^7.0.0-alpha.4\`
- \`@turing-machine-js/machine\` \`^6.4.0\` → \`^7.0.0-alpha.3\`

Zero code changes for the bump alone — the demo only uses high-level API that's stable across the v6→v7 boundary (no \`withOverriddenHaltState\` direct references, no wrapper-name parsing, etc.). Unblocks the rest of the \`v7-upstream\` labelled issues (#9, #10, #37) on the demo.

### 2. Step log notation parity (closes #69)

Each logged step now renders in the engine's \`[reads] → [writes]/[moves]\` edge-label notation, matching what \`toMermaid\` emits — so a logged step lines up byte-for-byte with the corresponding edge in the rendered state graph.

**Sample before/after** (single-tape, head reads '1', writes '0', moves right):

\`\`\`
- step 12: wrote '0' + moved right ('0'/R)
+ step 12: ['1'] → ['0']/[R]
\`\`\`

**Notation conventions** (mirror engine v7):

| Role | Cell encoding |
|---|---|
| Read | \`'X'\` literal, \`B\` blank |
| Write | \`'X'\` literal, \`K\` (keep — \`command.symbol === null\`), \`E\` (erase — write equals blank) |
| Move | bare \`L\` / \`R\` / \`S\` |

Multi-tape uses comma-separated entries per role bracket: \`['1','a'] → ['0','b']/[R,L]\`.

### Implementation notes

- **Worker captures pre-step head symbols** in a parallel \`runReadsBuffer\` alongside \`runCommandBuffer\` — same index, same length, drained / reset at the same points.
- **Response types** (\`stepped\`, \`ran\`, \`paused\`, \`idle\`) carry a \`reads\` field parallel to \`commands\`.
- **MachineView** threads \`reads\` + \`alphabets\` (for blank detection) through all 5 \`commandsEntry\` call sites, including the manual \`applied\` path where reads are captured from the main-thread mirror at apply-time.
- **\`formatStepNotation\`** is a new private helper in \`format.ts\`; the public \`commandsEntry\` signature changed to accept reads + alphabets. No backward-compat layer (single consumer).

## Test plan

- [x] \`npm test\` — 97/97 (added 9 new \`format.test.ts\` cases covering literal/B/K/E/null-reads/multi-tape/per-tape-blank; added \`readsFromYield\` cases in \`workerHelpers.test.ts\`)
- [x] \`npm run check\` (svelte-check + tsc) — 0 errors / 0 warnings
- [x] \`npm run lint\` — clean
- [x] \`npm run build\` — clean
- [ ] Manual smoke: load a bundled example, run with pause, confirm log entries render in the new format and match graph edge labels visually
- [ ] Multi-tape Turing machine smoke (the comma-separated rendering only kicks in for >1 tape)
- [ ] Apply via control panel (manual \`onApply\`) — verify the \`applied:\` entry shows the captured pre-apply read