### PR TITLE
graph highlight: callable subtree, frame border, pulse rule

### DIFF
--- a/src/components/MachineGraph.svelte
+++ b/src/components/MachineGraph.svelte
@@ -11,6 +11,13 @@
      *  active highlight. Driven by MachineView mode + pause-response data
      *  (machines-demo#10). */
     highlight?: GraphHighlight | null;
+    /** Monotonic per-event counter from the worker (machines-demo#10). Used
+     *  as a reactivity tick: when two consecutive paused events have
+     *  structurally identical highlights (Copy-tape step-mode looping on
+     *  id:1), the $derived wouldn't re-run and this $effect wouldn't
+     *  re-fire — so the pulse would never restart. Reading it in the effect
+     *  body subscribes the effect to per-event ticks. */
+    stepsApplied?: number;
     collapsed: boolean;
     onToggleCollapsed: () => void;
     /** When provided, the header shows an expand-to-modal button. Omit to
@@ -25,6 +32,7 @@
   let {
     graph,
     highlight = null,
+    stepsApplied = 0,
     collapsed,
     onToggleCollapsed,
     onExpand,
@@ -61,6 +69,32 @@
   const nodeCache = new Map<number | 'idle', SVGElement>();
   // eslint-disable-next-line svelte/prefer-svelte-reactivity
   const edgeCache = new Map<string, SVGElement>();
+  // GraphNode.id → containing callable-subtree frameId, derived from the
+  // engine's Graph (machines-demo#10). Drives the "frame active" border
+  // highlight when the strong state lives inside a subgraph.
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  const nodeFrameMap = new Map<number, number>();
+  // frameId → corresponding `<g class="cluster">` element. Mermaid emits
+  // each subgraph as a cluster whose id contains the subgraph token
+  // (`w_<frameId>`), so we extract the number once at render time.
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  const clusterCache = new Map<number, SVGElement>();
+  // frameId → list of wrappers calling into that frame, each with the
+  // wrapper's GraphNode id and the wrapper's override-target id (the
+  // post-return continuation; `null` if the override is the engine's halt
+  // singleton). Drives the "return chain" highlight when an in-frame
+  // transition halts the bare: light up the return arrow `w_N → wrapper`,
+  // the wrapper node, the wrapper-to-override edge, and the override
+  // target — so the user sees the full post-pop visual path.
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  const frameWrappersMap = new Map<number, { wrapperId: number; overrideId: number | null }[]>();
+
+  // Strong-node id from the most recent PAUSED apply (machines-demo#10).
+  // The pulse condition is "paused on the same state as the previous
+  // paused event" — idles never trigger or update this. Reset to null on
+  // highlight-clear so a mode transition doesn't leave stale state matching
+  // the next paused event spuriously.
+  let lastPausedStrongId: number | 'idle' | null = null;
 
   // Local non-reactive counter for mermaid render-id uniqueness. mermaid.render
   // requires a unique id per call; reusing an id causes the call to fail or
@@ -231,20 +265,52 @@
   // `data-id` to sidestep the render-id prefix.
   $effect(() => {
     void svg; // re-run when svg changes
+    void graph; // re-run when graph changes (drives nodeFrameMap)
     nodeCache.clear();
     edgeCache.clear();
+    nodeFrameMap.clear();
+    clusterCache.clear();
+    frameWrappersMap.clear();
+    if (graph) {
+      for (const node of Object.values(graph.nodes)) {
+        if (node.frameId !== null) nodeFrameMap.set(node.id, node.frameId);
+      }
+      // For each wrapper, find which frame it calls into (via its bare's
+      // frameId) and append to frameWrappersMap[frameId]. Multiple wrappers
+      // can share the same bare with different overrides; we record them all
+      // and the apply-highlight effect highlights each — visually surfacing
+      // any ambiguity when the engine pops the stack at halt.
+      for (const node of Object.values(graph.nodes)) {
+        if (!node.isWrapper || node.bareStateId === null) continue;
+        const bare = graph.nodes[node.bareStateId];
+        if (!bare || bare.frameId === null) continue;
+        const entry = { wrapperId: node.id, overrideId: node.overriddenHaltStateId };
+        const arr = frameWrappersMap.get(bare.frameId);
+        if (arr) arr.push(entry);
+        else frameWrappersMap.set(bare.frameId, [entry]);
+      }
+    }
     if (!svgHostEl) return;
     const root = svgHostEl.querySelector('svg');
     if (!root) return;
     root.querySelectorAll<SVGElement>('g.node').forEach((el) => {
       // id shape: `${renderId}-flowchart-${nodeId}-${suffix}`. Extract `nodeId`.
+      // `sN` → numeric state id N. `cN` → halt marker for frame N, keyed as
+      // negative -N (engine doc: "halt marker id = -frameId"); the highlight
+      // effect retargets `toId === 0` (real halt) to `-frameId` when the
+      // source state lives inside frame N, so the visible edge ends at the
+      // in-frame marker rather than the outside real-halt singleton.
+      // `idle` → synthetic entry sentinel. `w_N` → subgraph wrapper (the
+      // cluster IS user-facing for #10 frame-active border, but that lookup
+      // uses clusterCache, not nodeCache).
       const m = el.id.match(/-flowchart-(s\d+|idle|c\d+|w_\d+)-/);
       if (!m) return;
       const tok = m[1];
       const key: number | 'idle' | null =
         tok === 'idle' ? 'idle'
         : tok.startsWith('s') ? Number(tok.slice(1))
-        : null; // cN / w_N skipped — not user-facing for #10.
+        : tok.startsWith('c') ? -Number(tok.slice(1))
+        : null; // w_N skipped here — clusterCache handles those.
       if (key === null) return;
       if (!nodeCache.has(key)) nodeCache.set(key, el);
     });
@@ -253,6 +319,76 @@
       if (!dataId) return;
       // Multiple elements (path + label) share a data-id; first one wins.
       if (!edgeCache.has(dataId)) edgeCache.set(dataId, el);
+    });
+    // Populate the per-frame cluster cache so the apply-highlight effect
+    // can light up the enclosing subgraph border when m.state lives inside
+    // a callable subtree. Mermaid v11 stringifies the subgraph's id object
+    // as the literal `[object Object]` in the DOM, so we can't extract
+    // `w_<n>` from `el.id`. Match by cluster-label text instead — the
+    // engine emits a deterministic label per frame (`callable subtree of
+    // NAME` for single-bare, `callable scope: A ∪ B …` for union, bare
+    // names sorted by id; see `graphFormats.ts`) so we can recompute the
+    // expected label from `graph` and map it back to frameId.
+    if (graph) {
+      // A frame-bare is a non-wrapper, non-halt-marker node that some
+      // wrapper points at via `bareStateId`. Build one set so the per-frame
+      // pass doesn't re-scan all nodes per check.
+      // eslint-disable-next-line svelte/prefer-svelte-reactivity
+      const bareIds = new Set<number>();
+      for (const n of Object.values(graph.nodes)) {
+        if (n.isWrapper && n.bareStateId !== null) bareIds.add(n.bareStateId);
+      }
+      // frameId → sorted-by-id bare names (engine sorts by id, see
+      // `graphFormats.ts`).
+      // eslint-disable-next-line svelte/prefer-svelte-reactivity
+      const frameToBareNames = new Map<number, string[]>();
+      for (const n of Object.values(graph.nodes).sort((a, b) => a.id - b.id)) {
+        if (n.isWrapper || n.isHaltMarker || n.frameId === null) continue;
+        if (!bareIds.has(n.id)) continue;
+        const arr = frameToBareNames.get(n.frameId) ?? [];
+        arr.push(n.name);
+        frameToBareNames.set(n.frameId, arr);
+      }
+      // eslint-disable-next-line svelte/prefer-svelte-reactivity
+      const labelToFrameId = new Map<string, number>();
+      for (const [frameId, names] of frameToBareNames) {
+        const label = names.length > 1
+          ? `callable scope: ${names.join(' ∪ ')}`
+          : `callable subtree of ${names[0] ?? frameId}`;
+        labelToFrameId.set(label, frameId);
+      }
+      root.querySelectorAll<SVGElement>('g.cluster').forEach((el) => {
+        // Cluster label is rendered into `.cluster-label` (a child `<g>`)
+        // which holds a `<foreignObject>` with the literal label text.
+        const labelText = el.querySelector('.cluster-label')?.textContent?.trim();
+        if (!labelText) return;
+        const frameId = labelToFrameId.get(labelText);
+        if (frameId === undefined) return;
+        if (!clusterCache.has(frameId)) clusterCache.set(frameId, el);
+      });
+    }
+    // Materialize highlight-color variants of mermaid's shared markers
+    // (machines-demo#10). Mermaid emits one `<marker>` per arrowhead shape
+    // and colors them all from `#mg-N .marker { fill: lightgrey; ... }`, so
+    // every arrowhead is grey regardless of its referencing edge's stroke.
+    // `context-stroke` would fix this declaratively but isn't reliable
+    // cross-browser yet; instead clone each marker into a sibling with id
+    // suffix `-mg-hl`, tag its inner shape with `mg-hl-arrow-shape` so CSS
+    // can fix fill/stroke to `--graph-highlight`, and swap a highlighted
+    // path's `marker-end` to the variant at apply-highlight time.
+    root.querySelectorAll<SVGMarkerElement>('marker.marker').forEach((marker) => {
+      // Skip our own clones from a prior pass through this effect — otherwise
+      // each re-fire (graph change + svg change in close succession) clones
+      // the clones, layering `-mg-hl-mg-hl-…` indefinitely.
+      if (marker.id.endsWith('-mg-hl')) return;
+      const hlId = marker.id + '-mg-hl';
+      if (root.querySelector(`#${CSS.escape(hlId)}`)) return; // already added
+      const clone = marker.cloneNode(true) as SVGMarkerElement;
+      clone.id = hlId;
+      clone.querySelectorAll('.arrowMarkerPath').forEach((shape) => {
+        shape.classList.add('mg-hl-arrow-shape');
+      });
+      marker.parentNode!.insertBefore(clone, marker.nextSibling);
     });
   });
 
@@ -271,19 +407,46 @@
   $effect(() => {
     const h = highlight;
     void svg; // track render output too — cache repopulates on re-render
+    void stepsApplied; // tick: re-fire on every worker event even when
+    // the highlight object is structurally identical to the previous one
+    // (Copy-tape step-mode looping on the same state — without this read,
+    // Svelte's fine-grained reactivity skips the apply).
     if (!svgHostEl) return;
     const root = svgHostEl.querySelector('svg');
     if (!root) return;
     // Clear previous highlight classes. No inline-style restore needed —
     // we strip the engine's classDef tags at render time so all visuals
     // are author-CSS-driven; toggling classes is enough.
-    root.querySelectorAll('.mg-highlight-from, .mg-highlight-to, .mg-highlight-strong, .mg-highlight-edge')
+    root.querySelectorAll('.mg-highlight-from, .mg-highlight-to, .mg-highlight-strong, .mg-highlight-edge, .mg-frame-active')
       .forEach((el) => {
-        el.classList.remove('mg-highlight-from', 'mg-highlight-to', 'mg-highlight-strong', 'mg-highlight-edge');
+        el.classList.remove('mg-highlight-from', 'mg-highlight-to', 'mg-highlight-strong', 'mg-highlight-edge', 'mg-frame-active');
+        // Restore the original `marker-end` if we swapped it for the
+        // highlight variant. Stored as a plain attribute (not dataset) so
+        // we don't need to narrow `Element` to `SVGElement` here.
+        if (el.tagName === 'path' && el.hasAttribute('data-mg-orig-marker-end')) {
+          el.setAttribute('marker-end', el.getAttribute('data-mg-orig-marker-end')!);
+          el.removeAttribute('data-mg-orig-marker-end');
+        }
       });
-    if (!h) return;
+    if (!h) {
+      lastPausedStrongId = null;
+      return;
+    }
+    // Retarget halt-bound transitions of in-frame states to that frame's
+    // halt-marker node (id = -frameId). The engine reports
+    // `nextStateId === 0` (real halt singleton) for any halt-bound
+    // transition, but `toGraph` rewrites in-frame halts to the frame's
+    // halt-marker (`cN`) and emits the visible edge ending there. Without
+    // this translation the highlight would land on the real-halt circle
+    // OUTSIDE the frame, and the edge lookup (`L_sX_s0_…`) would miss the
+    // actually-emitted edge (`L_sX_cN_…`).
+    let toId: number | null = h.toId;
+    if (toId === 0 && typeof h.fromId === 'number') {
+      const fromFrameId = nodeFrameMap.get(h.fromId);
+      if (fromFrameId !== undefined) toId = -fromFrameId;
+    }
     const fromEl = nodeCache.get(h.fromId);
-    const toEl = h.toId !== null ? nodeCache.get(h.toId) : undefined;
+    const toEl = toId !== null ? nodeCache.get(toId) : undefined;
     if (fromEl) {
       fromEl.classList.add('mg-highlight-from');
       if (h.strong === 'from') fromEl.classList.add('mg-highlight-strong');
@@ -296,23 +459,97 @@
     // ix fired (engine doesn't expose it); pick the first matching from→to
     // pair. For self-loops and multi-edge-to-same-target, this can
     // over-highlight — acceptable for v1.
-    const fromKey = h.fromId === 'idle' ? 'idle' : `s${h.fromId}`;
-    const toKey = h.toId !== null ? `s${h.toId}` : null;
-    if (toKey) {
+    //
+    // Mermaid emits multiple SVG elements with the same `data-id` for a
+    // single edge — at minimum the `<path>` under `g.edgePaths` and the
+    // `<g class="edgeLabel">` under `g.edgeLabels`. Walking via
+    // querySelectorAll instead of the (first-wins) edgeCache lets us tag
+    // both, so the CSS can color the label to match the highlighted edge.
+    const highlightEdgeByDataId = (fromTok: string, toTok: string): void => {
       for (let ix = 0; ix < 10; ix++) {
-        const el = edgeCache.get(`L_${fromKey}_${toKey}_${ix}`);
-        if (el) {
+        const els = root.querySelectorAll<SVGElement>(
+          `[data-id="L_${fromTok}_${toTok}_${ix}"]`,
+        );
+        if (els.length === 0) continue;
+        els.forEach((el) => {
           el.classList.add('mg-highlight-edge');
-          break;
+          // Swap the arrowhead on the `<path>` to its `-mg-hl` variant so
+          // the end-triangle picks up the highlight color (the variants
+          // are materialized in the cache-build effect above). Other
+          // matching elements (e.g. the `<g class="label">` edge label)
+          // have no `marker-end` and are skipped.
+          if (el.tagName === 'path') {
+            const orig = el.getAttribute('marker-end');
+            if (orig && !el.hasAttribute('data-mg-orig-marker-end')) {
+              el.setAttribute('data-mg-orig-marker-end', orig);
+              el.setAttribute('marker-end', orig.replace(/\)$/, '-mg-hl)'));
+            }
+          }
+        });
+        return;
+      }
+    };
+    const fromKey = h.fromId === 'idle' ? 'idle' : `s${h.fromId}`;
+    const toKey = toId === null ? null
+                : toId < 0 ? `c${-toId}` // halt-marker
+                : `s${toId}`;
+    if (toKey) highlightEdgeByDataId(fromKey, toKey);
+
+    // Return chain (machines-demo#10): when the just-fired transition lands
+    // on a frame's halt-marker (`toId < 0` means in-frame halt, set by the
+    // retarget above), the engine will pop the stack and resume at the
+    // wrapper's override. Light up the visual path so the user sees the
+    // post-pop trajectory before the next iter relocates the strong node:
+    //   return-arrow `w_N → wrapper` (dotted) + wrapper node
+    //   + wrapper-to-override edge + override target node.
+    // If multiple wrappers call into the frame (shared bare), we highlight
+    // each — the engine's runtime choice depends on stack state which the
+    // demo doesn't track, so surfacing the ambiguity beats picking one.
+    if (toId !== null && toId < 0) {
+      const frameId = -toId;
+      const wrappers = frameWrappersMap.get(frameId) ?? [];
+      for (const { wrapperId, overrideId } of wrappers) {
+        highlightEdgeByDataId(`w_${frameId}`, `s${wrapperId}`);
+        const wrapperEl = nodeCache.get(wrapperId);
+        if (wrapperEl) wrapperEl.classList.add('mg-highlight-to');
+        if (overrideId !== null) {
+          highlightEdgeByDataId(`s${wrapperId}`, `s${overrideId}`);
+          const overrideEl = nodeCache.get(overrideId);
+          if (overrideEl) overrideEl.classList.add('mg-highlight-to');
         }
       }
     }
+    // Frame highlight: when the strong state lives inside a callable-
+    // subtree subgraph, mark the enclosing cluster so its border lights
+    // up (CSS does border-only — fill stays unchanged so contained nodes
+    // don't gain extra visual weight from the frame).
+    const strongId = h.strong === 'from' ? h.fromId : h.toId;
+    if (typeof strongId === 'number') {
+      const frameId = nodeFrameMap.get(strongId);
+      if (frameId !== undefined) {
+        const clusterEl = clusterCache.get(frameId);
+        if (clusterEl) clusterEl.classList.add('mg-frame-active');
+      }
+    }
+    // Pulse only when THIS apply is a paused event AND lands on the same
+    // state as the previous paused event. Idles never pulse and never
+    // update lastPausedStrongId, so an idle that happens to report the
+    // same state doesn't interfere. Web Animations API restarts on each
+    // call without class-juggling.
+    const strongEl = h.strong === 'from' ? fromEl : toEl;
+    const pausedRevisit = h.paused && strongId !== null && strongId === lastPausedStrongId;
+    if (strongEl && pausedRevisit) {
+      strongEl.animate(
+        [{ opacity: 1 }, { opacity: 0.35 }, { opacity: 1 }],
+        { duration: 220, easing: 'ease-in-out' },
+      );
+    }
+    if (h.paused) lastPausedStrongId = strongId;
     // Scroll the strong node into view so users don't have to hunt for
     // it in large graphs. Manual offset math (vs Element.scrollIntoView)
     // keeps full control over the threshold + smooth scroll target and
     // is robust to whatever ancestor sizing/transform decisions the panel
     // adopts in the future.
-    const strongEl = h.strong === 'from' ? fromEl : toEl;
     if (strongEl) {
       void tick().then(() => {
         const scrollContainer = svgHostEl?.closest<HTMLElement>('.body');
@@ -605,14 +842,15 @@
   .svg-host :global(g.edgeLabel) {
     background-color: transparent !important;
   }
-  /* Subgraph (cluster) backgrounds. Force dashed stroke so the cluster
-     container reads as "structural wrapper", not "another state node" —
-     Mermaid's default emit leaves stroke-dasharray="none" on cluster
-     rects, making them visually identical to state rects. */
+  /* Subgraph (cluster) backgrounds. Mermaid's default emit gives clusters
+     the same stroke color as state-node rects, so we restate fill/stroke
+     here from our tokens to ensure the cluster reads distinctly from
+     contained nodes via fill + a different stroke color, not via a dashed
+     pattern. */
   .svg-host :global(g.cluster rect) {
     fill: var(--graph-cluster-fill) !important;
     stroke: var(--graph-cluster-stroke) !important;
-    stroke-dasharray: 6 4 !important;
+    stroke-dasharray: 0 !important;
     stroke-width: 1px !important;
   }
   .svg-host :global(g.cluster .cluster-label),
@@ -725,5 +963,73 @@
     stroke: var(--graph-highlight) !important;
     stroke-width: 2.5px !important;
     transition: stroke 150ms ease, stroke-width 150ms ease;
+  }
+
+  /* Arrowheads / cross / circle endcaps inherit the referencing path's
+     stroke color via `context-stroke`. Mermaid emits a single shared
+     marker per shape under `<defs>` and styles it with `#mg-N .marker
+     { fill: lightgrey; stroke: lightgrey }` — so without this override
+     every endcap stays grey, including on a highlighted edge (the
+     triangle reads as detached from its now-amber line). `context-stroke`
+     lets one shared marker render in each referencing path's stroke
+     color — also a bonus for the dotted enter / thick call edges, whose
+     bodies were already colored but whose triangles weren't.
+     Requires Chrome 123+ / Firefox / Safari 16.4+. In browsers without
+     support this rule is silently dropped — the explicit `.mg-hl-arrow-shape`
+     rule below still gives highlighted edges a colored triangle via the
+     materialized `-mg-hl` marker variant. */
+  .svg-host :global(.marker path.arrowMarkerPath),
+  .svg-host :global(.marker circle.arrowMarkerPath),
+  .svg-host :global(.marker polygon.arrowMarkerPath) {
+    fill: context-stroke !important;
+    stroke: context-stroke !important;
+  }
+
+  /* Explicit color for the inner shape of the materialized `-mg-hl` marker
+     clones. The cache-build effect adds this class to each cloned shape
+     so the highlighted edge's arrowhead is amber even in browsers without
+     `context-stroke` support. Lower specificity than the `.marker path.arrowMarkerPath`
+     rule above, but that rule's `context-stroke` is silently dropped where
+     unsupported, leaving this one to apply. */
+  .svg-host :global(.mg-hl-arrow-shape) {
+    fill: var(--graph-highlight) !important;
+    stroke: var(--graph-highlight) !important;
+  }
+
+  /* Edge label color when the edge is highlighted — pull text toward
+     the highlight stroke color so the label reads as part of the same
+     "this transition just fired" visual unit. Mermaid emits the edge
+     label as `<g class="edgeLabel"><g class="label" data-id="L_..."><foreignObject>…`
+     — the `data-id` lands on the INNER `g.label`, so that's what our
+     querySelectorAll sweep tags with `mg-highlight-edge`. `g.label` is
+     also used by node labels, but only edge labels carry `data-id` /
+     pick up our class, so this selector is safe. */
+  .svg-host :global(g.label.mg-highlight-edge),
+  .svg-host :global(g.label.mg-highlight-edge *) {
+    color: var(--graph-highlight) !important;
+    transition: color 150ms ease;
+  }
+
+  /* Active callable-subtree frame: when the strong state lives inside a
+     subgraph, the apply-highlight effect tags that subgraph's
+     `<g class="cluster">` with this class. Border-only — only stroke is
+     overridden, so the cluster's fill stays unchanged and contained
+     nodes don't gain extra visual weight from the frame. The default
+     `g.cluster rect` rule sets `stroke-dasharray: 0`, so the active
+     border inherits solid (no need to restate). */
+  .svg-host :global(g.cluster.mg-frame-active rect) {
+    stroke: var(--graph-highlight) !important;
+    stroke-width: 2px !important;
+    transition: stroke 150ms ease, stroke-width 150ms ease;
+  }
+
+  /* Dim the weak end of the highlighted triple (the node that is NOT
+     m.state) so the strong node reads as the focal point. Subtle —
+     soft-fill already mutes it; this just adds a slight transparency on
+     the whole node group. */
+  .svg-host :global(g.node.mg-highlight-from:not(.mg-highlight-strong)),
+  .svg-host :global(g.node.mg-highlight-to:not(.mg-highlight-strong)) {
+    opacity: 0.65;
+    transition: opacity 150ms ease;
   }
 </style>

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -77,6 +77,14 @@
   let graph = $state<TuringGraph | null>(null);
   let graphCollapsed = $state(untrack(() => initialGraphCollapsed(engine)));
   let graphModalOpen = $state(false);
+  // Monotonic iter counter, mirrored from worker responses (idle / paused /
+  // ran). Passed to MachineGraph purely as a reactivity tick: when two
+  // consecutive paused events have identical currentStateId / nextStateId /
+  // pauseBefore (e.g. Copy-tape step-mode looping on id:1), graphHighlight's
+  // $derived wouldn't re-run and MachineGraph's highlight effect wouldn't
+  // re-fire — so the pulse animation would never restart. Bumping this
+  // forces the effect to re-fire per event.
+  let stepsApplied = $state(0);
 
   // Persist the user's expand/collapse choice per engine. Skip the initial
   // value (it already came from localStorage or the viewport default) so we
@@ -202,36 +210,53 @@
 
   // State-graph highlight (#10): mirrors the LAST FIRED transition (so the
   // graph stays in lockstep with the most recent log entry). Strong on
-  // m.state in all cases — "you are here". Only fires on RUNNING_PAUSED.
+  // m.state in all cases — "you are here".
   //
+  // RUNNING_PAUSED:
   //   before pause at X (came from Y):
   //       triple = (Y, edge, X), strong on TO (= X = m.state)
   //   after / iter-end pause at X (next will be Z):
   //       triple = (X, edge, Z), strong on FROM (= X = m.state)
+  //   First iter's before pause has no prior state — `prevStateId` is null;
+  //   we use the synthetic `idle` sentinel as FROM (matches the idle-enter
+  //   arrow in the rendered graph, so the "transition that brought us
+  //   here" is the start-arrow itself).
   //
-  // First iter's before pause has no prior state — `prevStateId` is null;
-  // we use the synthetic `idle` sentinel as FROM (matches the idle-enter
-  // arrow in the rendered graph, so the "transition that brought us here"
-  // is the start-arrow itself).
+  // RUNNING_AUTO (driven by `idle` per-iter notifications):
+  //   triple = (currentStateId, edge, nextStateId), strong on FROM —
+  //   identical shape to the after/iter-end pause case (the iter just
+  //   ran; we're between iters). Update cadence equals the user's
+  //   `intervalMs`; strobe risk is the user's knob to manage.
   //
   // Other modes return null:
   //  - DEMO/MANUAL: no truth value (random / user-chosen commands).
-  //  - RUNNING_AUTO/CONTINUOUS: too fast to read; would strobe.
+  //  - RUNNING_CONTINUOUS: no per-iter signal (worker doesn't send `idle`).
   //  - HALTED: follow-up sub-branch (highlight last edge + halt node).
   const graphHighlight = $derived.by<GraphHighlight | null>(() => {
     if (!graph) return null;
+    if (executionMode === 'RUNNING_AUTO') {
+      if (currentStateId === null) return null;
+      return {
+        fromId: currentStateId,
+        toId: nextStateId,
+        strong: 'from',
+        paused: false,
+      };
+    }
     if (executionMode !== 'RUNNING_PAUSED' || currentStateId === null) return null;
     if (pauseBefore) {
       return {
         fromId: prevStateId ?? 'idle',
         toId: currentStateId,
         strong: 'to',
+        paused: true,
       };
     }
     return {
       fromId: currentStateId,
       toId: nextStateId,
       strong: 'from',
+      paused: true,
     };
   });
 
@@ -400,6 +425,7 @@
       lastSnapshots = res.tapes;
       halted = res.halted;
       graph = res.graph;
+      stepsApplied = 0;
       _buildMirrorMachine(res.tapes, res.alphabets);
       await tick();
       setAllFromMirror();
@@ -530,6 +556,7 @@
       _buildMirrorMachine(res.tapes, alphabets);
       setAllFromMirror();
       halted = true;
+      stepsApplied = res.stepsApplied;
       reflectNeutral();
       if (res.commands.length > 0) {
         log.appendBatch(
@@ -575,6 +602,13 @@
       );
       renderChain = renderChain.then(() => renderFromMirror(commands, animate));
     }
+    // Drive the per-iter graph highlight (#10). Iter-end semantics: we
+    // just landed in `currentStateId`, and `nextStateId` is where the
+    // next iter would go. The RUNNING_AUTO branch of `graphHighlight`
+    // reads these without touching `pauseBefore`.
+    currentStateId = data.currentStateId;
+    nextStateId = data.nextStateId;
+    stepsApplied = data.stepsApplied;
   }
 
   function onPausedHandler(paused: PausedResponse): void {
@@ -585,6 +619,7 @@
     currentStateId = paused.currentStateId;
     nextStateId = paused.nextStateId;
     pauseBefore = paused.debugBreak.before === true;
+    stepsApplied = paused.stepsApplied;
 
     // Replay buffered per-step commands so the trace leading to the break is
     // visible. In RUNNING_AUTO the buffer is drained per iter via `idle` and
@@ -643,6 +678,13 @@
       return;
     }
     reflectNeutral();
+    // Drop stale highlight IDs from any prior run so RUNNING_AUTO's
+    // $derived branch doesn't flash a previous run's triple before the
+    // first `idle` arrives. (Resume-from-paused path keeps them; the
+    // paused values are still valid until the next idle / pause.)
+    prevStateId = null;
+    currentStateId = null;
+    nextStateId = null;
     executionMode = withPause ? 'RUNNING_AUTO' : 'RUNNING_CONTINUOUS';
     codeChangedWarned = false;
     if (withPause) {
@@ -671,6 +713,7 @@
         setAllFromMirror();
       });
       halted = true;
+      stepsApplied = res.stepsApplied;
       reflectNeutral();
       if (res.commands.length > 0) {
         log.appendBatch(
@@ -947,6 +990,7 @@
           <MachineGraph
             {graph}
             highlight={graphHighlight}
+            {stepsApplied}
             collapsed={false}
             onToggleCollapsed={() => { graphModalOpen = false; }}
             onRenderError={(msg: string) => log.report(msg, 'error')}
@@ -999,6 +1043,7 @@
       <MachineGraph
         {graph}
         highlight={graphHighlight}
+        {stepsApplied}
         collapsed={graphCollapsed}
         onToggleCollapsed={() => { graphCollapsed = !graphCollapsed; }}
         onExpand={() => { graphModalOpen = true; }}

--- a/src/lib/defaultCode.ts
+++ b/src/lib/defaultCode.ts
@@ -95,6 +95,65 @@ const initialState = new State({
 return { machine, initialState };
 `;
 
+const TURING_CALLABLE_SUBTREE = `// Task: walk right to the first blank cell, then mark it with '*'.
+// Demonstrates a callable subtree via State.withOverriddenHaltState:
+// 'walkToBlank' self-loops while reading a letter and halts at the first
+// blank. Halting INSIDE a wrapped subroutine pops the engine's halt-stack
+// and resumes at the wrapper's continuation ('writeMarker') instead of
+// terminating the run.
+//
+// In the rendered state graph, the subroutine sits inside a dashed
+// subgraph frame; the frame's border lights up while m.state is INSIDE
+// it (during the self-loop iters), then unlights when execution returns
+// to the after-call continuation.
+
+/*
+ * Available imports (named exports of @turing-machine-js/machine):
+ *   Alphabet, State, Tape, TapeBlock, TuringMachine,
+ *   haltState, ifOtherSymbol, movements, ...
+ *
+ * Return: { machine, initialState }
+ */
+
+const {
+  Alphabet, State, Tape, TapeBlock, TuringMachine,
+  haltState, ifOtherSymbol, movements,
+} = imports;
+
+const alphabet = new Alphabet([' ', 'a', 'b', '*']);
+const tape = new Tape({ alphabet, symbols: ['a', 'b', 'a'] });
+const tapeBlock = TapeBlock.fromTapes([tape]);
+const machine = new TuringMachine({ tapeBlock });
+const { symbol } = tapeBlock;
+
+// Subroutine: walk right while reading a letter; halt at the first blank.
+// (A 'halt' inside this subroutine = return to caller's continuation.)
+// Note key order: specific patterns first, ifOtherSymbol last — State
+// returns the first matching key, and ifOtherSymbol always matches.
+const walkToBlank = new State({
+  [symbol([alphabet.blankSymbol])]: {
+    command: [{ movement: movements.stay }],
+    nextState: haltState,
+  },
+  [ifOtherSymbol]: {
+    command: [{ movement: movements.right }],
+  },
+}, 'walkToBlank');
+
+// Continuation: write '*' under the head and halt for real.
+const writeMarker = new State({
+  [ifOtherSymbol]: {
+    command: [{ symbol: '*', movement: movements.stay }],
+    nextState: haltState,
+  },
+}, 'writeMarker');
+
+// Entry: call walkToBlank, then resume with writeMarker.
+const initialState = walkToBlank.withOverriddenHaltState(writeMarker);
+
+return { machine, initialState };
+`;
+
 const POST_WALK_MARK = `// Task: walk right while marked; mark the first blank cell found.
 
 /*
@@ -130,6 +189,7 @@ return { machine };
 const TURING_EXAMPLES: readonly Example[] = [
   { id: 'replace-b', title: "Replace 'b' with '*'", code: TURING_REPLACE_B },
   { id: 'copy-two-tapes', title: 'Copy tape (multi-tape)', code: TURING_COPY_TWO_TAPES },
+  { id: 'callable-subtree', title: 'Callable subtree (withOverriddenHaltState)', code: TURING_CALLABLE_SUBTREE },
 ];
 
 const POST_EXAMPLES: readonly Example[] = [

--- a/src/lib/machineRunner.test.ts
+++ b/src/lib/machineRunner.test.ts
@@ -438,6 +438,7 @@ describe('MachineRunner', () => {
         commands: [[{ movement: 'R', symbol: null }]],
         reads: [['_']],
         currentStateId: null,
+        nextStateId: null,
         stepsApplied: 1,
       });
       current().respond({ type: 'busy' });
@@ -446,6 +447,7 @@ describe('MachineRunner', () => {
         commands: [[{ movement: 'L', symbol: null }]],
         reads: [['_']],
         currentStateId: null,
+        nextStateId: null,
         stepsApplied: 2,
       });
       current().respond({ type: 'busy' });
@@ -655,6 +657,7 @@ describe('MachineRunner', () => {
         commands: [[{ movement: 'R', symbol: null }]],
         reads: [['_']],
         currentStateId: null,
+        nextStateId: null,
         stepsApplied: 1,
       });
 
@@ -697,6 +700,7 @@ describe('MachineRunner', () => {
         commands: [[{ movement: 'R', symbol: null }]],
         reads: [['_']],
         currentStateId: null,
+        nextStateId: null,
         stepsApplied: 1,
       });
       current().respond({ type: 'busy' });

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -478,6 +478,9 @@ async function run(
         commands: drained,
         reads: drainedReads,
         currentStateId: m.state.id,
+        nextStateId: machine?.tapeBlock
+          ? nextStateIdFromYield(m as unknown as MachineYield, machine.tapeBlock)
+          : null,
         stepsApplied,
       });
       await new Promise<void>((resolve) => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,6 +22,18 @@ export type GraphHighlight = {
   fromId: number | 'idle';
   toId: number | null;
   strong: 'from' | 'to';
+  /**
+   * True when this highlight reflects a paused-event apply (RUNNING_PAUSED),
+   * false for per-iter idle applies (RUNNING_AUTO). MachineGraph uses this
+   * to detect cross-pause same-state revisits — pulsing the strong node when
+   * the current paused apply lands on the same state as the previous paused
+   * apply, even when intermediate idle applies pointed elsewhere
+   * (e.g., stateA breakpoint → continue → run through stateB/C → stateA
+   * breakpoint fires again). The simpler "previous apply's strong matches"
+   * check already covers AUTO self-loops; this flag drives the second pulse
+   * trigger.
+   */
+  paused: boolean;
 };
 
 export const ENGINES = ['turing', 'post'] as const;
@@ -218,10 +230,19 @@ export type IdleResponse = {
   reads: string[][];
   /**
    * Engine State.id of the state about to fire on the next iteration
-   * (post-throttle resume). Updates the current-state highlight per iter
-   * during `RUNNING_AUTO` (machines-demo#10). `null` if the run halted.
+   * (post-throttle resume) — i.e. m.state after the just-applied iter.
+   * Drives the `from + edge + to` triple highlight per iter during
+   * `RUNNING_AUTO` (machines-demo#10), strong on FROM (= m.state, "you
+   * are here looking forward"). `null` if the run halted.
    */
   currentStateId: number | null;
+  /**
+   * Engine State.id of the state that will follow `currentStateId` on the
+   * next iter. Drives the `to` end of the per-iter triple highlight in
+   * `RUNNING_AUTO` (machines-demo#10). `null` at halt or when
+   * `currentStateId` is `null`.
+   */
+  nextStateId: number | null;
   stepsApplied: number;
 };
 export type BusyResponse = { type: 'busy' };


### PR DESCRIPTION
## Summary
Extends the #10 debugger highlight to cover the v7 callable-subtree shape and tightens the runtime cue across modes:

- **RUNNING_AUTO per-iter triple highlight** — was paused-only. The worker now ships `nextStateId` on each `IdleResponse`, so the main thread can light the `from → edge → to` triple between iters.
- **Frame border** — when m.state lives inside a callable subtree, the enclosing `<g class="cluster">` gets `mg-frame-active` and a solid (was dashed) accent stroke; background preserved. Cluster lookup switched from `w_<N>` id extraction to cluster-label-text matching: mermaid v11 renders the cluster id object as the literal `[object Object]`, so the old regex never matched. The label comes from the engine deterministically (`callable subtree of NAME` / `callable scope: A ∪ B`), so a small re-derivation in the cache-build effect maps it back to `frameId`.
- **Halt retarget for in-frame transitions** — `toId === 0 && fromId in frame → toId = -frameId`, so the visible highlight ends at the in-frame halt marker rather than the outside real-halt singleton.
- **Return chain** — on in-frame halts, light up the dotted return arrow `w_N → wrapper`, the wrapper node, the wrapper-to-override edge, and the override target — the full post-pop visual path.
- **Pulse on "paused on same state as previous paused"** — idles don't trigger or reset the prev-paused tracker, so cross-pause same-state revisits (stateA breakpoint → continue → stateB/C → stateA breakpoint again) get the visual cue. Driven by a non-reactive `stepsApplied` tick threaded into the apply effect so Svelte fine-grained reactivity re-fires across same-value strong/from/to triples.
- **Marker color** — edge label adopts `--graph-highlight`, and arrow-end triangles inherit the highlight via cloned `-mg-hl` marker variants (clone-and-swap; `context-stroke` isn't reliable cross-browser yet). Re-firing the cache-build effect guards against runaway clone layering.
- **Weak-node dim** — non-strong node in a highlighted triple gets `opacity: 0.65` so the strong cue reads first.
- **Turing example: `walkToBlank(writeMarker)`** — bundled demo composing `walkToBlank` via `withOverriddenHaltState(writeMarker)`, so the callable-subtree wiring has a default exercise on first load. Specific patterns ordered before `ifOtherSymbol` to avoid the catch-all swallowing them.

Paired with engine fix [turing-machine-js#197](https://github.com/mellonis/turing-machine-js/pull/197) (run-scoped halt stack) — without that, the example produced a ghost iter 6 from a leftover stack entry.

## Test plan
- [ ] `npm run check` clean
- [ ] `npm run lint` clean
- [ ] `npm test` — 103/103 passing
- [ ] Browser: `walkToBlank(writeMarker)` example — RUNNING_AUTO highlights `from → to` per iter; pause inside `walkToBlank` lights the frame border; halt-bound transition highlights the in-frame halt marker and the full return chain
- [ ] Browser: palindrome / other examples — pulse fires on same-state cross-pause revisits, doesn't fire on AUTO self-loops (covered by simpler check); weak-node dim doesn't flicker