### PR TITLE
feat: link @turing-machine-js/visuals version in footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "machines-demo",
-  "version": "1.0.0-alpha.17",
+  "version": "1.0.0-alpha.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "machines-demo",
-      "version": "1.0.0-alpha.17",
+      "version": "1.0.0-alpha.18",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@post-machine-js/machine": "^7.0.0-alpha.6",
         "@tabler/icons": "^3.44.0",
         "@turing-machine-js/machine": "^7.0.0-alpha.6",
+        "@turing-machine-js/visuals": "^7.0.0-alpha.6",
         "codemirror": "^6.0.2",
         "mermaid": "^11.15.0",
         "svelte-codemirror-editor": "^2.1.0"
@@ -1076,6 +1077,18 @@
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@turing-machine-js/visuals": {
+      "version": "7.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/visuals/-/visuals-7.0.0-alpha.6.tgz",
+      "integrity": "sha512-NHve/c5UM4Rvq1B/ISR6P+efVuWbOqKtNXIzNiX+dbMD3xm5SqDvVQpNGlm8evA2TVvMUiggQd+MYWOJezCuCw==",
+      "license": "GPL-3.0-or-later",
+      "engines": {
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "@turing-machine-js/machine": "^7.0.0-alpha.6"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machines-demo",
   "private": true,
-  "version": "1.0.0-alpha.17",
+  "version": "1.0.0-alpha.18",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@post-machine-js/machine": "^7.0.0-alpha.6",
     "@tabler/icons": "^3.44.0",
     "@turing-machine-js/machine": "^7.0.0-alpha.6",
+    "@turing-machine-js/visuals": "^7.0.0-alpha.6",
     "codemirror": "^6.0.2",
     "mermaid": "^11.15.0",
     "svelte-codemirror-editor": "^2.1.0"

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { turingVersion, postVersion, appVersion } from 'virtual:lib-versions';
+  import { turingVersion, postVersion, visualsVersion, appVersion } from 'virtual:lib-versions';
   import MachineView from './components/MachineView.svelte';
   import { icons } from './lib/icons.ts';
   import { theme } from './lib/theme.svelte.ts';
@@ -122,6 +122,13 @@
       rel="noopener"
       title="@post-machine-js/machine on npm"
     >post v{postVersion}</a>
+    <span class="sep" aria-hidden="true">·</span>
+    <a
+      href="https://www.npmjs.com/package/@turing-machine-js/visuals"
+      target="_blank"
+      rel="noopener"
+      title="@turing-machine-js/visuals on npm"
+    >visuals v{visualsVersion}</a>
   </span>
   <a
     class="repo-link"

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -9,5 +9,6 @@ declare module '*.svg?raw' {
 declare module 'virtual:lib-versions' {
   export const turingVersion: string;
   export const postVersion: string;
+  export const visualsVersion: string;
   export const appVersion: string;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,9 +19,11 @@ const libVersions = (): Plugin => ({
     if (id !== `\0${VIRTUAL_ID}`) return;
     const turing = pkgVersion('@turing-machine-js/machine');
     const post = pkgVersion('@post-machine-js/machine');
+    const visuals = pkgVersion('@turing-machine-js/visuals');
     const app = appVersion();
     return `export const turingVersion = ${JSON.stringify(turing)};
 export const postVersion = ${JSON.stringify(post)};
+export const visualsVersion = ${JSON.stringify(visuals)};
 export const appVersion = ${JSON.stringify(app)};
 `;
   },


### PR DESCRIPTION
## Summary

Adds `@turing-machine-js/visuals` to dependencies and renders its version + npm link in the footer, mirroring the existing `turing` and `post` entries. Visuals was just published lockstep with the engine at `7.0.0-alpha.6` ([turing-machine-js#220](https://github.com/mellonis/turing-machine-js/pull/220)).

This is a tiny PR purely about the footer chip; the broader machines-demo cleanup (drop local copies of `highlightOps`, `graphUtils`, `graphIndexes`, `applyHighlight` + spec, `GraphHighlight`/`TapeSnapshot` types, the rules doc) is a separate follow-up (step 2 of [turing-machine-js#204](https://github.com/mellonis/turing-machine-js/issues/204)).

## Changes

- `package.json` + `package-lock.json` — add `@turing-machine-js/visuals@^7.0.0-alpha.6`.
- `vite.config.ts` — extend the `lib-versions` virtual module with `visualsVersion` (read from `node_modules/@turing-machine-js/visuals/package.json`).
- `src/App.svelte` — import `visualsVersion`, render `visuals v{version}` chunk in the footer between `post` and the GitHub icon, linking to https://www.npmjs.com/package/@turing-machine-js/visuals.

## Test plan

- [x] `npm run dev` boots cleanly; footer shows `visuals v7.0.0-alpha.6` between `post` and the GitHub icon.
- [x] Footer link target resolves (visuals is now published on npm `next`).
- [ ] No regression to existing Turing/Post tabs.