### PR TITLE
feat: landing page Phase 1 — / route with prerecorded snippet panels (#79)

### DIFF
--- a/docs/superpowers/plans/2026-05-30-landing-page-phase-1.md
+++ b/docs/superpowers/plans/2026-05-30-landing-page-phase-1.md
@@ -641,87 +641,125 @@ Expected: FAIL — component not defined.
 
 - [ ] **Step 3: Implement `SnippetPanel.svelte`**
 
+Frame stepping uses `SnippetPlayer` from `@turing-machine-js/visuals` (alpha.7.1). Frame application is split: graph highlight via `applyHighlight` (re-uses the same DOM-ops pattern MachineView already uses for pause highlights), tape via `tapeViewport` per `MachineGraph.svelte` reflowed-to-snapshot pattern. One `AbortController` scopes the autoplay timer, IntersectionObserver, and Replay click handler.
+
 ```svelte
 <script lang="ts">
   import { onMount } from 'svelte';
+  import {
+    SnippetPlayer, applyHighlight, indexGraph, tapeViewport,
+    type Frame, type HighlightOps, type Snippet,
+  } from '@turing-machine-js/visuals';
   import MachineGraph from './MachineGraph.svelte';
   import TapesStack from './TapesStack.svelte';
-  import type { Snippet } from '@turing-machine-js/visuals';
 
-  type Props = { snippet: Snippet & { id: string; description?: string; intervalMs?: number } };
+  type SnippetWithMeta = Snippet & {
+    engine: 'turing' | 'post';
+    id: string;
+    description?: string;
+    intervalMs?: number;
+  };
+  type Props = { snippet: SnippetWithMeta };
   let { snippet }: Props = $props();
 
   const DEFAULT_INTERVAL_MS = 800;
   const intervalMs = snippet.intervalMs ?? DEFAULT_INTERVAL_MS;
 
+  const player = new SnippetPlayer(snippet);
+  const indexes = indexGraph(snippet.graph);
+
+  // Reactive view of the player — read by the markup; written by applyFrame().
   let frameIndex = $state(0);
-  let playing = $state(false);
   let done = $state(false);
-  let reducedMotion = false;
+  let reducedMotion = $state(false);
+
   let panelEl: HTMLDivElement;
-  let timer: ReturnType<typeof setInterval> | null = null;
+  let machineGraphRef: { getOps(): HighlightOps; clearHighlights(): void } | null = null;
+  let tapesStackRef: { setTapeViewport(i: number, cells: string[], headIndex: number): void } | null = null;
+  let prevHighlight: Parameters<typeof applyHighlight>[3] = null;
 
-  function advance() {
-    if (frameIndex >= snippet.frames.length - 1) {
-      stop();
-      done = true;
-      return;
+  function applyFrame(): void {
+    const frame: Frame = player.currentFrame;
+    frameIndex = player.frameIndex;
+    done = player.done;
+
+    // Tape: per-tape window via tapeViewport. Blank is snippet.alphabets[i][0]
+    // by convention of how the snippets plugin builds alphabets (verify with
+    // the plugin's snapshotAlphabets shape if drift surfaces).
+    frame.tape.forEach((snap, i) => {
+      const blank = snippet.alphabets[i]?.[0] ?? ' ';
+      const { cells, headIndex } = tapeViewport(snap, VIEWPORT_WIDTH, blank);
+      tapesStackRef?.setTapeViewport(i, cells, headIndex);
+    });
+
+    // Graph highlight: wipe previous classes then apply current.
+    const ops = machineGraphRef?.getOps();
+    if (!ops) return;
+    machineGraphRef?.clearHighlights();
+    if (frame.highlight) {
+      prevHighlight = applyHighlight(frame.highlight, snippet.graph, indexes, prevHighlight, ops).nextPrev;
+    } else {
+      prevHighlight = null;
     }
-    frameIndex += 1;
-    applyFrame();
-  }
-
-  function applyFrame() {
-    // (apply highlight to the graph + tape snapshot to TapesStack imperatively
-    // via refs — exact shape depends on MachineGraph/TapesStack APIs)
-  }
-
-  function play() {
-    if (playing) return;
-    playing = true;
-    timer = setInterval(advance, intervalMs);
-  }
-
-  function stop() {
-    playing = false;
-    if (timer !== null) { clearInterval(timer); timer = null; }
-  }
-
-  function replay() {
-    stop();
-    frameIndex = 0;
-    done = false;
-    applyFrame();
-    play();
   }
 
   onMount(() => {
+    const controller = new AbortController();
+    const { signal } = controller;
+
     reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
     if (reducedMotion) {
-      frameIndex = snippet.frames.length - 1; // halt frame
-      done = true;
+      player.goTo(snippet.frames.length - 1);
       applyFrame();
-    } else {
-      const io = new IntersectionObserver(
-        ([entry]) => { if (entry.isIntersecting) { io.disconnect(); play(); } },
-        { threshold: 0.5 },
-      );
-      io.observe(panelEl);
-      return () => io.disconnect();
+      return () => controller.abort();
     }
+
+    applyFrame(); // frame 0 visible before scroll-in
+
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) return;
+        io.disconnect();
+        const timerId = window.setInterval(() => {
+          if (!player.forward()) { window.clearInterval(timerId); return; }
+          applyFrame();
+        }, intervalMs);
+        signal.addEventListener('abort', () => window.clearInterval(timerId), { once: true });
+      },
+      { threshold: 0.5 },
+    );
+    io.observe(panelEl);
+    signal.addEventListener('abort', () => io.disconnect(), { once: true });
+
+    return () => controller.abort();
   });
 
-  $effect(() => { applyFrame(); }); // re-apply on mount
+  function onReplay(): void {
+    player.reset();
+    prevHighlight = null;
+    applyFrame();
+    // Auto-play kicks back in via the existing IntersectionObserver lifecycle?
+    // No — IO already disconnected after first intersect. Re-run a fresh timer.
+    const timerId = window.setInterval(() => {
+      if (!player.forward()) { window.clearInterval(timerId); return; }
+      applyFrame();
+    }, intervalMs);
+    // Caller of onReplay is responsible for clearing; in practice this fires
+    // off a fresh, unmanaged timer that ends on its own at the last frame.
+    // If we want strict teardown on unmount during replay, hoist timerId into
+    // a $state and clear in onMount's controller.abort listener.
+  }
 </script>
 
 <div class="snippet-panel" bind:this={panelEl}>
   <h3>{snippet.description ?? snippet.id}</h3>
-  <MachineGraph graph={snippet.graph} readOnly />
-  <TapesStack tapeCount={snippet.tape.tapes.length} readOnly />
+  <MachineGraph bind:this={machineGraphRef} graph={snippet.graph} readOnly />
+  <TapesStack bind:this={tapesStackRef} tapeCount={snippet.frames[0].tape.length} readOnly />
   <div class="meta" data-testid="snippet-frame-index">{frameIndex}</div>
   <div class="controls">
     {#if done}
-      <button type="button" onclick={replay}>{reducedMotion ? 'Play' : 'Replay'}</button>
+      <button type="button" onclick={onReplay}>{reducedMotion ? 'Play' : 'Replay'}</button>
     {/if}
     <a href={`/${snippet.engine}?example=${snippet.id}`} class="open-in-editor">
       Open in editor
@@ -734,7 +772,11 @@ Expected: FAIL — component not defined.
 </style>
 ```
 
-NOTE: applying frames imperatively to `MachineGraph` / `TapesStack` likely requires they expose imperative methods or accept a reactive `highlight` / `tape` prop. Decide during implementation; if a refactor is needed it may bleed back into Task 6.
+NOTES for the implementer:
+1. **`MachineGraph.svelte` / `TapesStack.svelte` exposed APIs.** Current MachineGraph builds HighlightOps internally for paused-state highlight; for SnippetPanel reuse, expose `getOps(): HighlightOps` and `clearHighlights(): void` as imperative methods on the component (bind via `bind:this={machineGraphRef}`). Similarly `TapesStack` likely already has a `setFromTape(i, tape, …)` imperative method — extend with `setTapeViewport(i, cells, headIndex)` that takes the pre-windowed cells (skipping `Tape.viewport`'s normalise). If the MachineGraph extraction is large enough to be its own task, surface it and split.
+2. **`VIEWPORT_WIDTH`** is the existing constant at `src/lib/caps.ts:VIEWPORT_WIDTH = 23` — import from there.
+3. **Blank symbol convention.** `snippet.alphabets[i][0]` is a guess based on the snippets plugin's likely shape. Verify against the actual plugin output (Task 3): the plugin builds `alphabets` from `tapes.map(t => [...t.alphabet.symbols])`, and `Alphabet`'s symbols start with the blank by convention in this codebase (`new Alphabet([' ', 'a', 'b'])`). If the recorder uses a different ordering, fix at the plugin or expose `blankSymbol` explicitly on the snippet extension shape.
+4. **Replay timer is unmanaged in the sketch above.** If you find this unacceptable, hoist `timerId` into a `$state` field and clear it in the AbortController abort listener. Probably fine for Phase 1 since the timer naturally ends at the last frame.
 
 - [ ] **Step 4: Run tests until they pass**
 

--- a/docs/superpowers/plans/2026-05-30-landing-page-phase-1.md
+++ b/docs/superpowers/plans/2026-05-30-landing-page-phase-1.md
@@ -1,0 +1,928 @@
+# Landing page Phase 1 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land a `/` landing page with prerecorded snippet panels driven by `visuals.recordSnippet` via a Vite plugin. Ship with one placeholder showcase example per engine (Turing + Post) to prove the pipeline end-to-end. `/turing` and `/post` are untouched; DEMO continues to run.
+
+**Architecture:** New `/` route is a first-class entry (not a redirect to `/turing`). Snippets are recorded at build time by a Vite plugin that runs each `showcase: true` example through `@turing-machine-js/visuals`'s `recordSnippet`, exposing the artifacts as a `virtual:snippets` module. `SnippetPanel.svelte` is pure-playback over a `Snippet` artifact — no worker, no `eval`, IntersectionObserver auto-play with `prefers-reduced-motion` opt-out. `MachineGraph` + `TapesStack` gain a `readOnly?: boolean` prop for showcase use.
+
+**Tech Stack:** Vite + Svelte 5 (runes) + TypeScript. New runtime dep `@turing-machine-js/visuals@^7.0.0-alpha.7`. Tests: Vitest (jsdom + node) + Playwright (E2E).
+
+**Spec source:** [`docs/superpowers/specs/2026-05-27-landing-page-design.md`](../specs/2026-05-27-landing-page-design.md) — read first for full design decisions and rationale.
+
+---
+
+## Task ordering
+
+Tasks 1-3 are foundational (dep + types + build-time pipeline). Tasks 4-5 introduce the new routing. Tasks 6-8 land the landing-page UI. Task 9 is E2E. Each task ships independently; subagent-driven-development can fold tasks 1-2 into a single dispatch if desired.
+
+---
+
+### Task 1: Add `@turing-machine-js/visuals` dependency + ambient types
+
+**Files:**
+- Modify: `package.json`
+- Modify: `src/vite-env.d.ts` (already declares `virtual:lib-versions` — verify `visualsVersion` is in there)
+
+- [ ] **Step 1: Install `@turing-machine-js/visuals` as a runtime dependency**
+
+```bash
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo install --save '@turing-machine-js/visuals@next'
+```
+
+Expected: `package.json` gains `"@turing-machine-js/visuals": "^7.0.0-alpha.7"` (or whatever alpha.N is current). `package-lock.json` updates.
+
+- [ ] **Step 2: Verify `npm run check` passes**
+
+```bash
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo run check
+```
+
+Expected: no svelte-check errors. (Visuals types should resolve since visuals is already used elsewhere — this is a no-op verification.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo add package.json package-lock.json
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo commit -m "deps: add @turing-machine-js/visuals as runtime dep (was peer-only via lib import)"
+```
+
+---
+
+### Task 2: Extend `Example` type + flag placeholder showcase examples
+
+**Files:**
+- Modify: `src/lib/defaultCode.ts`
+
+- [ ] **Step 1: Extend the `Example` type**
+
+In `src/lib/defaultCode.ts`, locate the `Example` type definition (likely near `TURING_EXAMPLES` / `POST_EXAMPLES`). Add three optional fields:
+
+```ts
+export type Example = {
+  id: string;
+  title: string;
+  code: string;
+  // Phase 1: showcase flag drives the Vite snippet recorder; description appears
+  // as the panel caption; intervalMs overrides the playback default (800ms).
+  showcase?: boolean;
+  description?: string;
+  intervalMs?: number;
+};
+```
+
+- [ ] **Step 2: Flag one Turing and one Post example as showcase placeholders**
+
+Pick `TURING_REPLACE_B` (or the existing simplest Turing example) and the simplest single-tape Post example. Add `showcase: true` and a temporary `description`:
+
+```ts
+// (in the chosen Turing example)
+{
+  id: 'replace-b',
+  title: 'Replace B with A',
+  code: '...',
+  showcase: true,
+  description: 'Placeholder showcase — replace each B with A until blank.',
+},
+// (in the chosen Post example)
+{
+  id: '<post-id>',
+  title: '...',
+  code: '...',
+  showcase: true,
+  description: 'Placeholder showcase — to be replaced in the content sub-PR.',
+},
+```
+
+- [ ] **Step 3: Run `npm run check` + tests**
+
+```bash
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo run check
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo test
+```
+
+Expected: type-check clean, all existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo add src/lib/defaultCode.ts
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo commit -m "feat(examples): extend Example type with showcase/description/intervalMs; flag one example per engine as placeholder showcase"
+```
+
+---
+
+### Task 3: Vite plugin — `virtual:snippets`
+
+**Files:**
+- Create: `src/vite-plugins/snippets.ts`
+- Create: `src/vite-plugins/snippets.test.ts`
+- Modify: `vite.config.ts`
+
+- [ ] **Step 1: Write the failing plugin tests**
+
+In `src/vite-plugins/snippets.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { createSnippetsPlugin } from './snippets';
+import type { Example } from '../lib/defaultCode';
+
+const stubExamples = (engine: 'turing' | 'post'): Example[] => [
+  {
+    id: 'showcase-1',
+    title: 'A',
+    code: engine === 'turing'
+      ? 'export default ({ machine: { TuringMachine, ... } }) => { /* small program */ }'
+      : 'export default ({ post: { ... } }) => { /* small program */ }',
+    showcase: true,
+    description: 'desc',
+  },
+  { id: 'not-shown', title: 'B', code: 'export default () => {}' },
+];
+
+describe('snippets vite plugin', () => {
+  it('V-plugin-emits-virtual-module — resolves virtual:snippets', async () => {
+    const plugin = createSnippetsPlugin({
+      examples: (engine) => stubExamples(engine),
+    });
+    const resolved = await (plugin.resolveId as any).call({}, 'virtual:snippets');
+    expect(resolved).toBe('\0virtual:snippets');
+  });
+
+  it('V-plugin-only-showcase — non-showcase examples are excluded', async () => {
+    const plugin = createSnippetsPlugin({ examples: stubExamples });
+    const out = await (plugin.load as any).call({}, '\0virtual:snippets');
+    expect(out).toMatch(/showcase-1/);
+    expect(out).not.toMatch(/not-shown/);
+  });
+
+  it('V-plugin-snippet-shape — emitted artifacts match Snippet schema', async () => {
+    const plugin = createSnippetsPlugin({ examples: stubExamples });
+    const out = await (plugin.load as any).call({}, '\0virtual:snippets');
+    // Module source contains JSON.stringify({ turing: [Snippet], post: [Snippet] })
+    const match = out.match(/export default (.+);/);
+    expect(match).toBeTruthy();
+    const data = JSON.parse(match![1]);
+    for (const engine of ['turing', 'post'] as const) {
+      for (const snippet of data[engine]) {
+        expect(snippet).toMatchObject({
+          version: 1,
+          engine,
+          graph: expect.any(Object),
+          alphabets: expect.any(Array),
+          frames: expect.any(Array),
+        });
+      }
+    }
+  });
+
+  it('V-plugin-error-on-runtime-throw — bad example fails the build', async () => {
+    const examples = (engine: 'turing' | 'post') => engine === 'turing'
+      ? [{ id: 'broken', title: 'X', code: 'throw new Error("nope")', showcase: true }]
+      : [];
+    const plugin = createSnippetsPlugin({ examples });
+    await expect((plugin.load as any).call({}, '\0virtual:snippets'))
+      .rejects.toThrow(/broken/);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing test**
+
+```bash
+npx --prefix /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo vitest run src/vite-plugins/snippets.test.ts
+```
+
+Expected: FAIL — `createSnippetsPlugin` not defined.
+
+- [ ] **Step 3: Implement the plugin**
+
+Examples follow the worker's `build()` contract (`src/lib/machineWorker.ts:280-341`):
+- `code` is a JS string evaluated via `new Function('imports', code)` (where `imports` is `{...turing}` or `{...post}` depending on engine).
+- The code destructures from `imports` and `return`s `{ machine, initialState?, tape? }`.
+- `initialState` falls back to `machine.initialState` (post case), then is required.
+- `tape` falls back to `machine.tapeBlock.tapes[0]` if present, then to `machine.tape`.
+
+The plugin mirrors that shape. For minimal duplication: implement a small `evalExampleCode(engine, code) → { machine, initialState, tapeBlock, tapes }` helper inline in the plugin file (or extract to `src/lib/workerHelpers.ts` and call from both worker and plugin — discuss with reviewer; the per-PR diff is similar). For now this plan inlines.
+
+Create `src/vite-plugins/snippets.ts`:
+
+```ts
+import type { Plugin } from 'vite';
+import type { Snippet } from '@turing-machine-js/visuals';
+import { recordSnippet } from '@turing-machine-js/visuals';
+import * as turing from '@turing-machine-js/machine';
+import * as post from '@post-machine-js/machine';
+import type { Example } from '../lib/defaultCode';
+
+type Engine = 'turing' | 'post';
+
+type Options = {
+  // Inject for testability; default to importing the real `examples()` helper.
+  examples?: (engine: Engine) => readonly Example[];
+};
+
+const VIRTUAL_ID = 'virtual:snippets';
+const RESOLVED_VIRTUAL_ID = '\0' + VIRTUAL_ID;
+
+// Mirrors machineWorker.ts:280-341 `build()` — eval user code with the engine's
+// namespace as `imports`, validate the returned shape, derive the tape block.
+function evalExampleCode(engine: Engine, code: string) {
+  const imports = engine === 'post' ? { ...post } : { ...turing };
+  const fn = new Function('imports', code) as (i: Record<string, unknown>) => unknown;
+  const r = fn(imports);
+  if (!r || typeof r !== 'object') {
+    throw new Error('example must return { machine, initialState?, tape? }');
+  }
+  const result = r as { machine?: any; initialState?: any; tape?: any };
+  if (!result.machine) throw new Error('example return value missing `machine`');
+  const machine = result.machine;
+  const initialState = result.initialState ?? machine.initialState ?? null;
+  if (!initialState) throw new Error('example missing `initialState` (and machine.initialState absent)');
+  const tapeBlock = machine.tapeBlock;
+  if (!tapeBlock) throw new Error('example machine has no `tapeBlock`');
+  const tapes = tapeBlock.tapes ?? (result.tape ? [result.tape] : machine.tape ? [machine.tape] : []);
+  if (tapes.length === 0) throw new Error('example produced no tapes');
+  return { machine, initialState, tapeBlock, tapes };
+}
+
+export function createSnippetsPlugin(opts: Options = {}): Plugin {
+  const examplesFn: (engine: Engine) => Promise<readonly Example[]> | readonly Example[] =
+    opts.examples ?? (async (engine) => {
+      const mod = await import('../lib/defaultCode');
+      return mod.examples(engine);
+    });
+
+  return {
+    name: 'machines-demo:snippets',
+
+    resolveId(id) {
+      if (id === VIRTUAL_ID) return RESOLVED_VIRTUAL_ID;
+      return null;
+    },
+
+    async load(id) {
+      if (id !== RESOLVED_VIRTUAL_ID) return null;
+
+      const out: Record<Engine, unknown[]> = { turing: [], post: [] };
+
+      for (const engine of ['turing', 'post'] as const) {
+        const examples = await examplesFn(engine);
+        for (const example of examples) {
+          if (!example.showcase) continue;
+          try {
+            const { machine, initialState, tapeBlock, tapes } = evalExampleCode(engine, example.code);
+            // graph + alphabets shaped like machineWorker.ts:662-669 sends in `built`.
+            const graph = turing.State.toGraph(initialState, tapeBlock);
+            const alphabets = tapes.map((t: any) => [...t.alphabet.symbols]);
+            const snippet = recordSnippet({
+              machine,
+              initialState,
+              graph,
+              alphabets,
+              name: example.title,
+              maxSteps: 1000,
+            });
+            out[engine].push({
+              ...snippet,
+              engine,
+              id: example.id,
+              description: example.description,
+              intervalMs: example.intervalMs,
+            });
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            throw new Error(`snippets plugin: failed to record "${example.id}" (${engine}): ${msg}`);
+          }
+        }
+      }
+
+      return `export default ${JSON.stringify(out)};`;
+    },
+
+    handleHotUpdate(ctx) {
+      // Re-record when defaultCode.ts changes.
+      if (ctx.file.endsWith('/defaultCode.ts')) {
+        const mod = ctx.server.moduleGraph.getModuleById(RESOLVED_VIRTUAL_ID);
+        if (mod) ctx.server.moduleGraph.invalidateModule(mod);
+        return [];
+      }
+    },
+  };
+}
+```
+
+VERIFIED against `@turing-machine-js/visuals@7.0.0-alpha.7`'s `recordSnippet.d.ts`:
+- `RecordSnippetOptions = { machine: TuringMachine; initialState: State; graph: Graph; alphabets: string[][]; name?; maxSteps?; log? }` — `alphabets` is exactly per-tape `string[][]`, matching `tapes.map(t => [...t.alphabet.symbols])`.
+- `Snippet` itself has NO `engine` / `id` / `description` / `intervalMs` fields — those are extension fields the plugin attaches on top. The plan's extension shape is correct.
+
+Post engine note: `PostMachine extends TuringMachine` (see `node_modules/@post-machine-js/machine/dist/classes/PostMachine.d.ts`), so the post example's `{ machine }` IS a TuringMachine — pass directly to `recordSnippet` with no unwrap. `pm.initialState` is exposed as a getter (overriding the engine's).
+
+- [ ] **Step 4: Wire the plugin into vite.config.ts**
+
+In `vite.config.ts`, import and register:
+
+```ts
+import { createSnippetsPlugin } from './src/vite-plugins/snippets';
+// in plugins: [...]
+plugins: [
+  // existing
+  svelte(),
+  createSnippetsPlugin(),
+],
+```
+
+- [ ] **Step 5: Run tests + build**
+
+```bash
+npx --prefix /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo vitest run src/vite-plugins/snippets.test.ts
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo run build
+```
+
+Expected: tests pass, build succeeds and emits the virtual module.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo add src/vite-plugins vite.config.ts
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo commit -m "feat(snippets): vite plugin emitting virtual:snippets via visuals.recordSnippet"
+```
+
+---
+
+### Task 4: Routing — discriminated union + pure helpers
+
+**Files:**
+- Modify: `src/lib/types.ts`
+- Create: `src/lib/routing.ts`
+- Create: `src/lib/routing.test.ts`
+
+- [ ] **Step 1: Add `Route` type to `src/lib/types.ts`**
+
+```ts
+import type { Engine } from './types';
+
+export type Route =
+  | { kind: 'landing' }
+  | { kind: 'engine'; engine: Engine };
+```
+
+- [ ] **Step 2: Write failing routing tests**
+
+In `src/lib/routing.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { readRouteFromUrl, readEngineFromLandingQuery, legacyMachineRewrite } from './routing';
+
+describe('routing helpers', () => {
+  it('R-route-landing-from-root', () => {
+    expect(readRouteFromUrl('/')).toEqual({ kind: 'landing' });
+  });
+  it('R-route-landing-from-unknown', () => {
+    expect(readRouteFromUrl('/foo')).toEqual({ kind: 'landing' });
+  });
+  it('R-route-engine-turing', () => {
+    expect(readRouteFromUrl('/turing')).toEqual({ kind: 'engine', engine: 'turing' });
+  });
+  it('R-route-engine-post', () => {
+    expect(readRouteFromUrl('/post')).toEqual({ kind: 'engine', engine: 'post' });
+  });
+  it('R-route-landing-engine-query — defaults to turing', () => {
+    expect(readEngineFromLandingQuery('')).toBe('turing');
+    expect(readEngineFromLandingQuery('?engine=post')).toBe('post');
+    expect(readEngineFromLandingQuery('?engine=bogus')).toBe('turing');
+  });
+  it('R-route-legacy-machine-rewrite', () => {
+    const url = legacyMachineRewrite(new URL('http://x.test/?machine=post'));
+    expect(url.pathname).toBe('/post');
+    expect(url.searchParams.has('machine')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run failing tests**
+
+```bash
+npx --prefix /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo vitest run src/lib/routing.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement `src/lib/routing.ts`**
+
+```ts
+import { ENGINES, type Engine } from './types';
+import type { Route } from './types';
+
+export function readRouteFromUrl(pathname: string): Route {
+  const seg = pathname.replace(/^\/+/, '').split('/')[0];
+  if ((ENGINES as readonly string[]).includes(seg)) {
+    return { kind: 'engine', engine: seg as Engine };
+  }
+  return { kind: 'landing' };
+}
+
+export function readEngineFromLandingQuery(search: string): Engine {
+  const params = new URLSearchParams(search);
+  const raw = params.get('engine');
+  return (ENGINES as readonly string[]).includes(raw ?? '') ? (raw as Engine) : 'turing';
+}
+
+export function legacyMachineRewrite(url: URL): URL {
+  const legacy = url.searchParams.get('machine');
+  if (legacy !== null) {
+    url.searchParams.delete('machine');
+    if ((ENGINES as readonly string[]).includes(legacy)) {
+      url.pathname = '/' + legacy;
+    }
+  }
+  return url;
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo add src/lib/types.ts src/lib/routing.ts src/lib/routing.test.ts
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo commit -m "feat(routing): extract pure route helpers + discriminated Route union"
+```
+
+---
+
+### Task 5: App.svelte route swap — render Landing on `/`
+
+**Files:**
+- Modify: `src/App.svelte`
+
+- [ ] **Step 1: Replace `activeEngine` with `route`**
+
+Swap the mount/popstate logic to use `readRouteFromUrl(window.location.pathname)`. Strip the old "normalise unknown paths to /turing" block. Add a `selectRoute(route)` helper (replaces `selectEngine`); header tabs always `pushState('/' + engine)`. Landing renders `<Landing />` (new component, created in Task 8 — for now, a placeholder `<div>Landing</div>` so this task is self-contained).
+
+Sketch:
+
+```ts
+import { readRouteFromUrl, readEngineFromLandingQuery, legacyMachineRewrite } from './lib/routing';
+import type { Route } from './lib/types';
+import Landing from './components/Landing.svelte'; // wired in Task 8
+
+let route = $state<Route>({ kind: 'landing' });
+
+onMount(() => {
+  const url = legacyMachineRewrite(new URL(window.location.href));
+  if (url.href !== window.location.href) history.replaceState(null, '', url);
+  route = readRouteFromUrl(window.location.pathname);
+  const onPopState = () => { route = readRouteFromUrl(window.location.pathname); };
+  window.addEventListener('popstate', onPopState);
+  return () => window.removeEventListener('popstate', onPopState);
+});
+
+function selectRoute(next: Route): void {
+  if (route.kind === next.kind && (next.kind === 'landing' || next.engine === (route as any).engine)) return;
+  route = next;
+  history.pushState(null, '', next.kind === 'landing' ? '/' : '/' + next.engine);
+}
+```
+
+Header tab buttons:
+
+```svelte
+<button
+  type="button"
+  class:active={route.kind === 'engine' && route.engine === 'turing'}
+  onclick={() => selectRoute({ kind: 'engine', engine: 'turing' })}
+>Turing</button>
+<!-- analogous for post -->
+```
+
+Main:
+
+```svelte
+<main>
+  {#if route.kind === 'landing'}
+    <Landing />
+  {:else}
+    {#key route.engine}
+      <MachineView engine={route.engine} />
+    {/key}
+  {/if}
+</main>
+```
+
+- [ ] **Step 2: Stub `src/components/Landing.svelte` so App compiles**
+
+```svelte
+<script lang="ts"></script>
+<div class="landing-stub">Landing (placeholder)</div>
+```
+
+- [ ] **Step 3: `npm run check` + dev-server smoke test**
+
+```bash
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo run check
+```
+
+Expected: clean. Manually verify in dev (`npm run dev`) that:
+- `/` shows the Landing stub
+- `/turing` and `/post` show their MachineView
+- Clicking header tabs navigates
+- `?machine=post` legacy URL still rewrites to `/post`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo add src/App.svelte src/components/Landing.svelte
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo commit -m "feat(routing): App renders Landing on /, MachineView on engine paths"
+```
+
+---
+
+### Task 6: `readOnly` prop on `MachineGraph` + `TapesStack`
+
+**Files:**
+- Modify: `src/components/MachineGraph.svelte`
+- Modify: `src/components/TapesStack.svelte`
+
+- [ ] **Step 1: Add `readOnly?: boolean` prop to `MachineGraph.svelte`**
+
+```svelte
+<script lang="ts">
+  // existing props
+  let { graph, readOnly = false }: { graph: Graph; readOnly?: boolean } = $props();
+</script>
+```
+
+Gate breakpoint click handlers and the collapse toggle on `!readOnly`. Search for `onclick` handlers in the component and wrap each interactive surface with `if (readOnly) return;` or guard the markup with `{#if !readOnly}`.
+
+- [ ] **Step 2: Add `readOnly?: boolean` prop to `TapesStack.svelte`**
+
+Same shape. Gate the caret-edit affordance and copy-paste handlers on `!readOnly`. The imperative `setFromTape` / `clearAll` API still works; only the user-facing interactions are disabled.
+
+- [ ] **Step 3: `npm run check` + existing tests**
+
+```bash
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo run check
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo test
+```
+
+Expected: no new failures; default `readOnly = false` preserves existing behavior for MachineView.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo add src/components/MachineGraph.svelte src/components/TapesStack.svelte
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo commit -m "feat(components): readOnly prop on MachineGraph + TapesStack for showcase reuse"
+```
+
+---
+
+### Task 7: `SnippetPanel.svelte` — pure playback component
+
+**Files:**
+- Create: `src/components/SnippetPanel.svelte`
+- Create: `src/components/SnippetPanel.test.ts`
+
+- [ ] **Step 1: Write failing component tests**
+
+In `src/components/SnippetPanel.test.ts` (`// @vitest-environment happy-dom` pragma at top):
+
+```ts
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import SnippetPanel from './SnippetPanel.svelte';
+import type { Snippet } from '@turing-machine-js/visuals';
+
+const stubSnippet = (): Snippet & { id: string; description?: string } => ({
+  version: 1,
+  engine: 'turing',
+  id: 'showcase-1',
+  description: 'A test snippet',
+  graph: { /* minimal valid Graph stub */ } as any,
+  alphabets: [[' ', 'a', 'b']],
+  tape: { tapes: [{ symbols: ['a','b'], position: 0 }] } as any,
+  frames: [
+    { step: 0, tape: [{ symbols: ['a','b'], position: 0 }], highlight: null },
+    { step: 1, tape: [{ symbols: ['b','b'], position: 1 }], highlight: null },
+  ] as any,
+});
+
+beforeEach(() => { vi.useFakeTimers(); });
+afterEach(() => { vi.useRealTimers(); });
+
+describe('SnippetPanel', () => {
+  it('S-snippet-panel-renders-caption', () => {
+    render(SnippetPanel, { snippet: stubSnippet() });
+    expect(screen.getByText(/A test snippet/)).toBeInTheDocument();
+  });
+
+  it('S-snippet-panel-static-on-mount', () => {
+    render(SnippetPanel, { snippet: stubSnippet() });
+    // Without IntersectionObserver firing, panel sits on frame 0.
+    // (verify via a data-testid="snippet-frame-index" attr the component exposes)
+    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('0');
+  });
+
+  // ... S-snippet-panel-autoplay-on-intersect / S-freeze-at-halt / S-replay-resets
+  // / S-reduced-motion / S-deep-link
+});
+```
+
+(The IntersectionObserver test uses `vi.stubGlobal('IntersectionObserver', ...)` with a manual `trigger(isIntersecting)` method.)
+
+- [ ] **Step 2: Run failing tests**
+
+Expected: FAIL — component not defined.
+
+- [ ] **Step 3: Implement `SnippetPanel.svelte`**
+
+```svelte
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import MachineGraph from './MachineGraph.svelte';
+  import TapesStack from './TapesStack.svelte';
+  import type { Snippet } from '@turing-machine-js/visuals';
+
+  type Props = { snippet: Snippet & { id: string; description?: string; intervalMs?: number } };
+  let { snippet }: Props = $props();
+
+  const DEFAULT_INTERVAL_MS = 800;
+  const intervalMs = snippet.intervalMs ?? DEFAULT_INTERVAL_MS;
+
+  let frameIndex = $state(0);
+  let playing = $state(false);
+  let done = $state(false);
+  let reducedMotion = false;
+  let panelEl: HTMLDivElement;
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  function advance() {
+    if (frameIndex >= snippet.frames.length - 1) {
+      stop();
+      done = true;
+      return;
+    }
+    frameIndex += 1;
+    applyFrame();
+  }
+
+  function applyFrame() {
+    // (apply highlight to the graph + tape snapshot to TapesStack imperatively
+    // via refs — exact shape depends on MachineGraph/TapesStack APIs)
+  }
+
+  function play() {
+    if (playing) return;
+    playing = true;
+    timer = setInterval(advance, intervalMs);
+  }
+
+  function stop() {
+    playing = false;
+    if (timer !== null) { clearInterval(timer); timer = null; }
+  }
+
+  function replay() {
+    stop();
+    frameIndex = 0;
+    done = false;
+    applyFrame();
+    play();
+  }
+
+  onMount(() => {
+    reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reducedMotion) {
+      frameIndex = snippet.frames.length - 1; // halt frame
+      done = true;
+      applyFrame();
+    } else {
+      const io = new IntersectionObserver(
+        ([entry]) => { if (entry.isIntersecting) { io.disconnect(); play(); } },
+        { threshold: 0.5 },
+      );
+      io.observe(panelEl);
+      return () => io.disconnect();
+    }
+  });
+
+  $effect(() => { applyFrame(); }); // re-apply on mount
+</script>
+
+<div class="snippet-panel" bind:this={panelEl}>
+  <h3>{snippet.description ?? snippet.id}</h3>
+  <MachineGraph graph={snippet.graph} readOnly />
+  <TapesStack tapeCount={snippet.tape.tapes.length} readOnly />
+  <div class="meta" data-testid="snippet-frame-index">{frameIndex}</div>
+  <div class="controls">
+    {#if done}
+      <button type="button" onclick={replay}>{reducedMotion ? 'Play' : 'Replay'}</button>
+    {/if}
+    <a href={`/${snippet.engine}?example=${snippet.id}`} class="open-in-editor">
+      Open in editor
+    </a>
+  </div>
+</div>
+
+<style>
+  /* layout/styling — match the design system */
+</style>
+```
+
+NOTE: applying frames imperatively to `MachineGraph` / `TapesStack` likely requires they expose imperative methods or accept a reactive `highlight` / `tape` prop. Decide during implementation; if a refactor is needed it may bleed back into Task 6.
+
+- [ ] **Step 4: Run tests until they pass**
+
+```bash
+npx --prefix /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo vitest run src/components/SnippetPanel.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo add src/components/SnippetPanel.svelte src/components/SnippetPanel.test.ts
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo commit -m "feat(components): SnippetPanel — pure-playback with IntersectionObserver auto-play + reduced-motion opt-out"
+```
+
+---
+
+### Task 8: `Landing.svelte` — full landing view
+
+**Files:**
+- Modify: `src/components/Landing.svelte` (was a stub in Task 5)
+
+- [ ] **Step 1: Replace the stub with the real landing view**
+
+```svelte
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import SnippetPanel from './SnippetPanel.svelte';
+  import snippets from 'virtual:snippets';
+  import { readEngineFromLandingQuery } from '../lib/routing';
+  import type { Engine } from '../lib/types';
+
+  let engine = $state<Engine>('turing');
+
+  onMount(() => {
+    engine = readEngineFromLandingQuery(window.location.search);
+    const onPopState = () => { engine = readEngineFromLandingQuery(window.location.search); };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  });
+
+  function setEngine(next: Engine) {
+    if (next === engine) return;
+    engine = next;
+    const url = new URL(window.location.href);
+    if (next === 'turing') url.searchParams.delete('engine');
+    else url.searchParams.set('engine', next);
+    history.pushState(null, '', url);
+  }
+
+  const currentSnippets = $derived(snippets[engine] ?? []);
+</script>
+
+<section class="landing">
+  <header>
+    <h1>Turing & Post machines, visualised</h1>
+    <p>Each panel is a small program that runs to halt. Click <em>Open in editor</em> to step through it yourself.</p>
+  </header>
+
+  <nav class="engine-switcher" role="tablist">
+    <button type="button" class:active={engine === 'turing'} onclick={() => setEngine('turing')}>Turing snippets</button>
+    <button type="button" class:active={engine === 'post'} onclick={() => setEngine('post')}>Post snippets</button>
+  </nav>
+
+  <div class="snippet-grid">
+    {#each currentSnippets as snippet (snippet.id)}
+      <SnippetPanel {snippet} />
+    {/each}
+  </div>
+</section>
+
+<style>
+  /* layout */
+</style>
+```
+
+- [ ] **Step 2: Update App.svelte to render header tabs with no active state on landing**
+
+In App.svelte's header tabs:
+
+```svelte
+<button
+  type="button"
+  class:active={route.kind === 'engine' && route.engine === 'turing'}
+  onclick={() => selectRoute({ kind: 'engine', engine: 'turing' })}
+>Turing</button>
+```
+
+(Already done in Task 5 — verify the `class:active` predicate is correctly false on landing.)
+
+- [ ] **Step 3: `npm run check` + dev smoke**
+
+```bash
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo run check
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo run dev
+```
+
+Manually verify:
+- `/` renders the landing page with one Turing snippet panel
+- Engine switcher swaps to Post snippet, URL becomes `/?engine=post`
+- "Open in editor" navigates to `/turing?example=<id>`
+- Header tabs render with no active state on landing
+- `prefers-reduced-motion` (devtools rendering panel → emulate) shows the halt frame statically
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo add src/components/Landing.svelte
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo commit -m "feat(landing): real Landing view with engine switcher + virtual:snippets binding"
+```
+
+---
+
+### Task 9: E2E — `e2e/landing.spec.ts`
+
+**Files:**
+- Create: `e2e/landing.spec.ts`
+
+- [ ] **Step 1: Write the E2E specs**
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test.describe('landing', () => {
+  test('renders snippet panels on /', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: /Turing & Post machines/ })).toBeVisible();
+    await expect(page.locator('.snippet-panel')).toHaveCount(1); // one placeholder per engine; phase-1 default = turing
+  });
+
+  test('engine switch updates URL and panels', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: /Post snippets/ }).click();
+    await expect(page).toHaveURL(/\?engine=post/);
+    await expect(page.locator('.snippet-panel')).toHaveCount(1);
+  });
+
+  test('deep link to editor opens the example', async ({ page }) => {
+    await page.goto('/');
+    const link = page.getByRole('link', { name: /Open in editor/ });
+    await link.click();
+    await expect(page).toHaveURL(/\/turing\?example=/);
+    // MachineView visible
+    await expect(page.locator('[data-testid="tape-cell"]').first()).toBeVisible();
+  });
+
+  test('header tab navigates from landing', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Turing' }).click();
+    await expect(page).toHaveURL('/turing');
+  });
+
+  test('scroll triggers playback', async ({ page }) => {
+    await page.goto('/');
+    const panel = page.locator('.snippet-panel').first();
+    await panel.scrollIntoViewIfNeeded();
+    // After intervalMs * frames + epsilon, the panel reaches done state
+    await expect(panel.getByRole('button', { name: /Replay/ })).toBeVisible({ timeout: 10_000 });
+  });
+});
+```
+
+- [ ] **Step 2: Run E2E**
+
+```bash
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo run test:e2e -- e2e/landing.spec.ts
+```
+
+Expected: all 5 scenarios pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo add e2e/landing.spec.ts
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/machines-demo commit -m "test(e2e): landing page — render + engine switch + deep-link + scroll-play"
+```
+
+---
+
+## Wrap-up
+
+After Task 9:
+
+- [ ] Open PR against master with the full series of Phase-1 commits
+- [ ] PR description summarizes the new `/` route, the Vite plugin, the SnippetPanel, and links to the spec
+- [ ] Once merged, the content sub-PR (3 curated examples per engine) and Phase 2 (DEMO-mode retirement) become independent follow-ups
+
+## Out of scope (for this plan)
+
+- Phase 2 — DEMO-mode retirement (separate plan)
+- Content sub-PR — three curated examples per engine (separate plan)
+- Anything in the spec's "Out of scope" section (mobile polish, interactive snippet editing, snippet authoring UI, multi-tape Post snippets, etc.)

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('landing', () => {
+  test('renders snippet panels on /', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: /Turing & Post machines/ })).toBeVisible();
+    await expect(page.locator('.snippet-panel')).toHaveCount(1); // one placeholder per engine; phase-1 default = turing
+  });
+
+  test('engine switch updates URL and panels', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: /Post snippets/ }).click();
+    await expect(page).toHaveURL(/\?engine=post/);
+    await expect(page.locator('.snippet-panel')).toHaveCount(1);
+  });
+
+  test('deep link to editor opens the example', async ({ page }) => {
+    await page.goto('/');
+    const link = page.getByRole('link', { name: /Open in editor/ });
+    await link.click();
+    await expect(page).toHaveURL(/\/turing\?example=/);
+    // MachineView visible
+    await expect(page.locator('[data-testid="tape-cell"]').first()).toBeVisible();
+  });
+
+  test('header tab navigates from landing', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Turing', exact: true }).click();
+    await expect(page).toHaveURL('/turing');
+  });
+
+  test('scroll triggers playback', async ({ page }) => {
+    await page.goto('/');
+    const panel = page.locator('.snippet-panel').first();
+    await panel.scrollIntoViewIfNeeded();
+    // After intervalMs * frames + epsilon, the panel reaches done state
+    await expect(panel.getByRole('button', { name: /Replay/ })).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@post-machine-js/machine": "^7.0.0-alpha.6",
         "@tabler/icons": "^3.44.0",
         "@turing-machine-js/machine": "^7.0.0-alpha.6",
-        "@turing-machine-js/visuals": "^7.0.0-alpha.7",
+        "@turing-machine-js/visuals": "^7.0.0-alpha.7.1",
         "codemirror": "^6.0.2",
         "mermaid": "^11.15.0",
         "svelte-codemirror-editor": "^2.1.0"
@@ -1080,9 +1080,9 @@
       }
     },
     "node_modules/@turing-machine-js/visuals": {
-      "version": "7.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@turing-machine-js/visuals/-/visuals-7.0.0-alpha.7.tgz",
-      "integrity": "sha512-Fey4pGx1BrV5JPA63T7p3k2I4HDM34HezliZ1hPWhH39G34s6aOwBUVpotbuzyhxZ3AQoj3gfjSmKoZ0jLEBxg==",
+      "version": "7.0.0-alpha.7.1",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/visuals/-/visuals-7.0.0-alpha.7.1.tgz",
+      "integrity": "sha512-JgwQkHipLc1e95RNKpXZ+yPamG3JtGRqtfwHxZT0V74CKp9KnfbXBZVeaqrJvR9tyjWZbodhztLIIZWX/wjcew==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@post-machine-js/machine": "^7.0.0-alpha.6",
         "@tabler/icons": "^3.44.0",
         "@turing-machine-js/machine": "^7.0.0-alpha.6",
-        "@turing-machine-js/visuals": "^7.0.0-alpha.6.1",
+        "@turing-machine-js/visuals": "^7.0.0-alpha.7",
         "codemirror": "^6.0.2",
         "mermaid": "^11.15.0",
         "svelte-codemirror-editor": "^2.1.0"
@@ -1071,24 +1071,24 @@
       "license": "MIT"
     },
     "node_modules/@turing-machine-js/machine": {
-      "version": "7.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-7.0.0-alpha.6.tgz",
-      "integrity": "sha512-xHlFzcKE1e6YUeYYua3seu59it8HElbOsxBPDzhpwTmixpOgrZgSB3ENs3KaisgEdROSaytlZw/6udWYQ2lj+w==",
+      "version": "7.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-7.0.0-alpha.7.tgz",
+      "integrity": "sha512-HW2qEyjFmZbantxDguG1k8+FpjRSUk0vXNGXXVCgxCQeEMNJCndHAyOvLxp5VSk25/g8a+Q1rKwxpsc8z140UA==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@turing-machine-js/visuals": {
-      "version": "7.0.0-alpha.6.1",
-      "resolved": "https://registry.npmjs.org/@turing-machine-js/visuals/-/visuals-7.0.0-alpha.6.1.tgz",
-      "integrity": "sha512-NXGpUgbg9QIGg3xUQ3R33X8KOsJI8ROBHpqhMcVxdmko68scWRgt1B883385PCGuTLVs/xMoNhDqg1dznQsFvQ==",
+      "version": "7.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/visuals/-/visuals-7.0.0-alpha.7.tgz",
+      "integrity": "sha512-Fey4pGx1BrV5JPA63T7p3k2I4HDM34HezliZ1hPWhH39G34s6aOwBUVpotbuzyhxZ3AQoj3gfjSmKoZ0jLEBxg==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.6"
+        "@turing-machine-js/machine": "^7.0.0-alpha.7"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@post-machine-js/machine": "^7.0.0-alpha.6",
     "@tabler/icons": "^3.44.0",
     "@turing-machine-js/machine": "^7.0.0-alpha.6",
-    "@turing-machine-js/visuals": "^7.0.0-alpha.6.1",
+    "@turing-machine-js/visuals": "^7.0.0-alpha.7",
     "codemirror": "^6.0.2",
     "mermaid": "^11.15.0",
     "svelte-codemirror-editor": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@post-machine-js/machine": "^7.0.0-alpha.6",
     "@tabler/icons": "^3.44.0",
     "@turing-machine-js/machine": "^7.0.0-alpha.6",
-    "@turing-machine-js/visuals": "^7.0.0-alpha.7",
+    "@turing-machine-js/visuals": "^7.0.0-alpha.7.1",
     "codemirror": "^6.0.2",
     "mermaid": "^11.15.0",
     "svelte-codemirror-editor": "^2.1.0"

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,62 +1,47 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { turingVersion, postVersion, visualsVersion, appVersion } from 'virtual:lib-versions';
+  import Landing from './components/Landing.svelte';
   import MachineView from './components/MachineView.svelte';
   import { icons } from './lib/icons.ts';
+  import { legacyMachineRewrite, readRouteFromUrl } from './lib/routing.ts';
   import { theme } from './lib/theme.svelte.ts';
-  import { ENGINES, type Engine } from './lib/types.ts';
+  import type { Route } from './lib/types.ts';
 
-  // Engine lives in the URL path (`/turing`, `/post`). The first path segment
-  // is the engine; anything else (`/`, `/foo`) normalises to the default
-  // engine. Requires SPA-fallback routing on the server (nginx
+  // Route lives in the URL path: `/` is the Landing page, `/turing` and
+  // `/post` mount the engine-specific MachineView. Anything else falls back
+  // to Landing. Requires SPA-fallback routing on the server (nginx
   // `try_files $uri $uri/ /index.html;` for prod; Vite's default in dev).
-  function readEngineFromUrl(): Engine {
-    try {
-      const seg = window.location.pathname.replace(/^\/+/, '').split('/')[0];
-      return (ENGINES as readonly string[]).includes(seg) ? (seg as Engine) : 'turing';
-    } catch {
-      return 'turing';
-    }
-  }
-
-  let activeEngine = $state<Engine>('turing');
+  let route = $state<Route>({ kind: 'landing' });
 
   onMount(() => {
     // Backwards-compat: legacy `?machine=<engine>` → `/<engine>`. Rewrite the
     // URL once on mount so old bookmarks/links don't silently lose context.
-    const url = new URL(window.location.href);
-    const legacy = url.searchParams.get('machine');
-    if (legacy !== null) {
-      url.searchParams.delete('machine');
-      if ((ENGINES as readonly string[]).includes(legacy)) {
-        url.pathname = '/' + legacy;
-      }
+    const url = legacyMachineRewrite(new URL(window.location.href));
+    if (url.href !== window.location.href) {
       history.replaceState(null, '', url);
     }
 
-    // Normalise unknown/root paths to `/<default-engine>` so the URL always
-    // reflects the active engine (no silent fallback discrepancy).
-    const seg = window.location.pathname.replace(/^\/+/, '').split('/')[0];
-    if (!(ENGINES as readonly string[]).includes(seg)) {
-      const normalised = new URL(window.location.href);
-      normalised.pathname = '/turing';
-      history.replaceState(null, '', normalised);
-    }
-
-    activeEngine = readEngineFromUrl();
+    route = readRouteFromUrl(window.location.pathname);
     const onPopState = () => {
-      activeEngine = readEngineFromUrl();
+      route = readRouteFromUrl(window.location.pathname);
     };
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
   });
 
-  function selectEngine(engine: Engine): void {
-    if (engine === activeEngine) return;
-    activeEngine = engine;
-    // Drop existing query params: they are engine-scoped (e.g. `?snippet=`)
-    // and don't carry over to the other engine's namespace.
-    history.pushState(null, '', '/' + engine);
+  function selectRoute(next: Route): void {
+    // Noop on same-route navigation — don't push history entries that don't
+    // change anything.
+    if (route.kind === next.kind) {
+      if (next.kind === 'landing') return;
+      if (route.kind === 'engine' && route.engine === next.engine) return;
+    }
+    route = next;
+    // Engine paths drop existing query params: they are engine-scoped (e.g.
+    // `?snippet=`) and don't carry over to the other engine's namespace or
+    // to the landing page.
+    history.pushState(null, '', next.kind === 'landing' ? '/' : '/' + next.engine);
   }
 
   const themeIcon = $derived(
@@ -75,15 +60,15 @@
   <nav class="tabs">
     <button
       type="button"
-      class:active={activeEngine === 'turing'}
-      onclick={() => selectEngine('turing')}
+      class:active={route.kind === 'engine' && route.engine === 'turing'}
+      onclick={() => selectRoute({ kind: 'engine', engine: 'turing' })}
     >
       Turing
     </button>
     <button
       type="button"
-      class:active={activeEngine === 'post'}
-      onclick={() => selectEngine('post')}
+      class:active={route.kind === 'engine' && route.engine === 'post'}
+      onclick={() => selectRoute({ kind: 'engine', engine: 'post' })}
     >
       Post
     </button>
@@ -100,9 +85,13 @@
 </header>
 
 <main>
-  {#key activeEngine}
-    <MachineView engine={activeEngine} />
-  {/key}
+  {#if route.kind === 'landing'}
+    <Landing />
+  {:else}
+    {#key route.engine}
+      <MachineView engine={route.engine} />
+    {/key}
+  {/if}
 </main>
 
 <footer>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -56,7 +56,15 @@
 </script>
 
 <header>
-  <h1><span class="title-prefix">machines&nbsp;</span>demo</h1>
+  <h1>
+    <button
+      type="button"
+      class="home-link"
+      onclick={() => selectRoute({ kind: 'landing' })}
+      title="Back to landing"
+      aria-label="Back to landing"
+    ><span class="title-prefix">machines&nbsp;</span>demo</button>
+  </h1>
   <nav class="tabs">
     <button
       type="button"
@@ -145,6 +153,22 @@
       font-weight: 500;
       letter-spacing: 0.04em;
       color: var(--accent);
+
+      .home-link {
+        background: transparent;
+        border: none;
+        padding: 0;
+        margin: 0;
+        font: inherit;
+        letter-spacing: inherit;
+        color: inherit;
+        cursor: pointer;
+        transition: opacity var(--anim-button-hover-ms) ease;
+
+        &:hover {
+          opacity: 0.8;
+        }
+      }
 
       .title-prefix {
         @media (max-width: 768px) {

--- a/src/components/Landing.svelte
+++ b/src/components/Landing.svelte
@@ -1,3 +1,137 @@
-<script lang="ts"></script>
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import SnippetPanel from './SnippetPanel.svelte';
+  import snippets from 'virtual:snippets';
+  import { readEngineFromLandingQuery } from '../lib/routing';
+  import type { Engine } from '../lib/types';
 
-<div class="landing-stub">Landing (placeholder)</div>
+  let engine = $state<Engine>('turing');
+
+  onMount(() => {
+    engine = readEngineFromLandingQuery(window.location.search);
+    const onPopState = () => { engine = readEngineFromLandingQuery(window.location.search); };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  });
+
+  function setEngine(next: Engine) {
+    if (next === engine) return;
+    engine = next;
+    const url = new URL(window.location.href);
+    if (next === 'turing') url.searchParams.delete('engine');
+    else url.searchParams.set('engine', next);
+    history.pushState(null, '', url);
+  }
+
+  const currentSnippets = $derived(snippets[engine] ?? []);
+</script>
+
+<section class="landing">
+  <header>
+    <h1>Turing &amp; Post machines, visualised</h1>
+    <p>Each panel is a small program that runs to halt. Click <em>Open in editor</em> to step through it yourself.</p>
+  </header>
+
+  <nav class="engine-switcher">
+    <button
+      type="button"
+      class:active={engine === 'turing'}
+      onclick={() => setEngine('turing')}
+    >Turing snippets</button>
+    <button
+      type="button"
+      class:active={engine === 'post'}
+      onclick={() => setEngine('post')}
+    >Post snippets</button>
+  </nav>
+
+  <div class="snippet-grid">
+    {#each currentSnippets as snippet (snippet.id)}
+      <SnippetPanel {snippet} />
+    {/each}
+  </div>
+</section>
+
+<style>
+  .landing {
+    flex: 1;
+    overflow-y: auto;
+    padding: 32px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    max-width: 1200px;
+    margin: 0 auto;
+    width: 100%;
+    box-sizing: border-box;
+
+    @media (max-width: 768px) {
+      padding: 20px 14px;
+      gap: 24px;
+    }
+  }
+
+  header {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    h1 {
+      margin: 0;
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: var(--fg);
+
+      @media (max-width: 768px) {
+        font-size: 1.25rem;
+      }
+    }
+
+    p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.9375rem;
+      line-height: 1.5;
+    }
+  }
+
+  .engine-switcher {
+    display: flex;
+    gap: 4px;
+
+    button {
+      background: transparent;
+      border: 1px solid transparent;
+      color: var(--muted);
+      padding: 4px 14px;
+      font: inherit;
+      cursor: pointer;
+      border-radius: 6px;
+      transition: background-color var(--anim-button-hover-ms) ease,
+                  color var(--anim-button-hover-ms) ease,
+                  border-color var(--anim-button-hover-ms) ease;
+
+      &.active {
+        color: var(--fg);
+        background: var(--cell-bg);
+        border-color: var(--cell-border);
+      }
+
+      &:hover:not(.active) {
+        color: var(--fg);
+        background: var(--hover-bg);
+      }
+    }
+  }
+
+  .snippet-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 400px), 1fr));
+    gap: 20px;
+    align-items: start;
+
+    @media (max-width: 480px) {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/components/Landing.svelte
+++ b/src/components/Landing.svelte
@@ -1,0 +1,3 @@
+<script lang="ts"></script>
+
+<div class="landing-stub">Landing (placeholder)</div>

--- a/src/components/MachineGraph.svelte
+++ b/src/components/MachineGraph.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
   import { toMermaid, type Graph } from '@turing-machine-js/machine';
-  import {
+    import {
     applyHighlight,
     applyIndicator,
     bareIdOf,
@@ -9,6 +9,7 @@
     indexGraph,
     type GraphHighlight,
     type GraphIndexes,
+    type HighlightOps,
     type NodeKey,
   } from '@turing-machine-js/visuals';
   import type { BreakpointKind } from '../lib/types.ts';
@@ -67,6 +68,12 @@
      *  bare, or wrapper State. Omitted when the parent doesn't want clicks
      *  routed (e.g., view-only contexts). */
     onToggleBreakpoint?: (stateId: number, kind: BreakpointKind) => void;
+    /** Fired when the rendered SVG has mounted and the internal `nodeCache`
+     *  is populated — i.e., the moment imperative consumers (`SnippetPanel`)
+     *  can usefully call `getOps()` / `clearHighlights()` and see the
+     *  highlights actually render. May fire multiple times across re-renders
+     *  (theme swap, direction swap, graph change). Optional. */
+    onReady?: () => void;
   };
 
   let {
@@ -82,6 +89,7 @@
     breakpointKinds,
     onToggleBreakpoint,
     readOnly = false,
+    onReady,
   }: Props = $props();
 
   const instanceId = `mg-${nextInstanceCounter()}`;
@@ -818,6 +826,120 @@
     });
   });
 
+  // Shared highlight-clear pass: strips the four highlight classes and
+  // restores arrowhead markers. Used by the internal apply-highlight effect
+  // AND the exported `clearHighlights()` method (which `SnippetPanel` calls
+  // before each `applyHighlight` since the visuals contract requires
+  // additive ops over an already-cleared canvas).
+  function _clearHighlightsImpl(root: SVGSVGElement): void {
+    root
+      .querySelectorAll('.mg-highlight-from, .mg-highlight-to, .mg-highlight-strong, .mg-highlight-edge')
+      .forEach((el) => {
+        el.classList.remove(
+          'mg-highlight-from',
+          'mg-highlight-to',
+          'mg-highlight-strong',
+          'mg-highlight-edge',
+        );
+        if (el.tagName === 'path' && el.hasAttribute('data-mg-orig-marker-end')) {
+          el.setAttribute('marker-end', el.getAttribute('data-mg-orig-marker-end')!);
+          el.removeAttribute('data-mg-orig-marker-end');
+        }
+      });
+  }
+
+  /**
+   * Imperative API: wipe previously-applied highlight classes + marker swaps
+   * from the rendered SVG. Required before each `applyHighlight` call per
+   * the visuals contract (`HighlightOps` is purely additive). No-op if the
+   * SVG hasn't mounted yet. Also clears any active frame cluster.
+   *
+   * Used by `SnippetPanel` for prerecorded playback; the internal
+   * apply-highlight effect uses `_clearHighlightsImpl` directly and skips
+   * the frame-active strip (it diffs frame transitions separately).
+   */
+  export function clearHighlights(): void {
+    if (!svgHostEl) return;
+    const root = svgHostEl.querySelector('svg');
+    if (!root) return;
+    _clearHighlightsImpl(root);
+    // External callers don't track lastFrameActiveId, so wipe the active
+    // cluster too — they'll re-set it from the next frame's highlight.
+    root.querySelectorAll('.mg-frame-active').forEach((el) => {
+      el.classList.remove('mg-frame-active');
+    });
+  }
+
+  /**
+   * Imperative API: a fresh `HighlightOps` bound to the current SVG, for
+   * external callers (`SnippetPanel`) that drive `applyHighlight` on their
+   * own schedule. Each call returns a new object — cheap (closes over
+   * cached DOM refs); call before each `applyHighlight` so it picks up any
+   * post-render cache rebuild. Returns `null` when the SVG isn't mounted.
+   *
+   * Unlike the internal apply-highlight effect, this ops impl toggles
+   * `mg-frame-active` directly (no diff against a prior frame) — the
+   * external caller is expected to pair each `applyHighlight` with a
+   * preceding `clearHighlights()`.
+   */
+  export function getOps(): HighlightOps | null {
+    if (!svgHostEl) return null;
+    const root = svgHostEl.querySelector('svg');
+    if (!root) return null;
+    return {
+      addNodeClass(id, cls) {
+        nodeCache.get(id)?.classList.add(cls);
+      },
+      highlightEdge(fromKey, toKey) {
+        for (let ix = 0; ix < 10; ix++) {
+          const els = root.querySelectorAll<SVGElement>(
+            `[data-id="L_${fromKey}_${toKey}_${ix}"]`,
+          );
+          if (els.length === 0) continue;
+          els.forEach((el) => {
+            el.classList.add('mg-highlight-edge');
+            if (el.tagName === 'path') {
+              const orig = el.getAttribute('marker-end');
+              if (orig && !el.hasAttribute('data-mg-orig-marker-end')) {
+                el.setAttribute('data-mg-orig-marker-end', orig);
+                el.setAttribute('marker-end', orig.replace(/\)$/, '-mg-hl)'));
+              }
+            }
+          });
+          return;
+        }
+      },
+      markFrameActive(frameId) {
+        clusterCache.get(frameId)?.classList.add('mg-frame-active');
+      },
+      pulse(id) {
+        nodeCache.get(id)?.animate(
+          [{ opacity: 1 }, { opacity: 0.35 }, { opacity: 1 }],
+          { duration: 220, easing: 'ease-in-out' },
+        );
+      },
+      scrollIntoView(id) {
+        const el = nodeCache.get(id);
+        if (!el) return;
+        void tick().then(() => {
+          const scrollContainer = svgHostEl?.closest<HTMLElement>('.body');
+          if (!scrollContainer) return;
+          scrollIntoViewIfNeeded(scrollContainer, el, 'smooth');
+        });
+      },
+    };
+  }
+
+  // Fire `onReady` when the SVG has mounted AND the cache is populated —
+  // the moment external imperative callers can usefully start applying
+  // frames. Re-fires per render (graph / theme / direction swap).
+  $effect(() => {
+    void svg;
+    if (!svg || !svgHostEl) return;
+    if (nodeCache.size === 0) return;
+    onReady?.();
+  });
+
   // Breakpoint indicator effect (machines-demo#37 layer 1). Runs on
   // `breakpoints` change AND on `svg` change (cache repopulates on SVG
   // re-render). Delegates the rule logic to `applyIndicator`; the ops
@@ -860,22 +982,12 @@
     if (!svgHostEl) return;
     const root = svgHostEl.querySelector('svg');
     if (!root) return;
-    // Clear previous highlight classes + marker-end restore. No inline-
-    // style restore needed — we strip the engine's classDef tags at render
-    // time so all visuals are author-CSS-driven; toggling classes is enough.
-    //
-    // `mg-frame-active` is INTENTIONALLY excluded from this strip-all — it's
-    // toggled below based on what applyHighlight actually requests, so the
-    // active cluster's class persists across consecutive in-frame iters
-    // (no visible blink between).
-    root.querySelectorAll('.mg-highlight-from, .mg-highlight-to, .mg-highlight-strong, .mg-highlight-edge')
-      .forEach((el) => {
-        el.classList.remove('mg-highlight-from', 'mg-highlight-to', 'mg-highlight-strong', 'mg-highlight-edge');
-        if (el.tagName === 'path' && el.hasAttribute('data-mg-orig-marker-end')) {
-          el.setAttribute('marker-end', el.getAttribute('data-mg-orig-marker-end')!);
-          el.removeAttribute('data-mg-orig-marker-end');
-        }
-      });
+    // Clear previous highlight classes + marker-end restore via the shared
+    // `clearHighlights()` helper. `mg-frame-active` is INTENTIONALLY
+    // excluded from the strip — it's toggled below based on what
+    // applyHighlight actually requests, so the active cluster's class
+    // persists across consecutive in-frame iters (no visible blink).
+    _clearHighlightsImpl(root);
 
     // Capture the frame the rule evaluator wants active (if any) so we
     // can diff against `lastFrameActiveId` and toggle only on change.

--- a/src/components/MachineGraph.svelte
+++ b/src/components/MachineGraph.svelte
@@ -826,6 +826,22 @@
     });
   });
 
+  // Showcase context (readOnly) opens centered. Engine pages keep the
+  // default (0, 0) origin so the entry node is visible at first paint —
+  // there the user is about to step / run and orientation matters more
+  // than centroid. Triggered on SVG change only (not zoom), so the
+  // initial frame lands centered without fighting subsequent applies.
+  $effect(() => {
+    void svg;
+    if (!readOnly || !svg || !svgHostEl) return;
+    void tick().then(() => {
+      const body = svgHostEl?.closest<HTMLElement>('.body');
+      if (!body) return;
+      body.scrollLeft = (body.scrollWidth - body.clientWidth) / 2;
+      body.scrollTop = (body.scrollHeight - body.clientHeight) / 2;
+    });
+  });
+
   // Shared highlight-clear pass: strips the four highlight classes and
   // restores arrowhead markers. Used by the internal apply-highlight effect
   // AND the exported `clearHighlights()` method (which `SnippetPanel` calls

--- a/src/components/MachineGraph.svelte
+++ b/src/components/MachineGraph.svelte
@@ -30,6 +30,13 @@
     stepsApplied?: number;
     collapsed: boolean;
     onToggleCollapsed: () => void;
+    /** When true, all user-facing interactive surfaces are disabled: the
+     *  collapse toggle, zoom/aim/expand header buttons, pan+wheel gestures,
+     *  and the breakpoint context menu on graph nodes. The imperative render
+     *  pipeline (highlight, applyIndicator, scroll-into-view) is unaffected.
+     *  Default `false` preserves the full interactive behaviour for
+     *  `MachineView`. */
+    readOnly?: boolean;
     /** When true, the panel detaches into a fixed-position 80vw×80vh
      *  overlay (single-instance: same mermaid render, no DOM move).
      *  Backdrop + click-out closing are managed by the parent so this
@@ -74,6 +81,7 @@
     breakpoints,
     breakpointKinds,
     onToggleBreakpoint,
+    readOnly = false,
   }: Props = $props();
 
   const instanceId = `mg-${nextInstanceCounter()}`;
@@ -218,6 +226,7 @@
   let panStartScrollTop = 0;
 
   function onBodyPointerDown(e: PointerEvent): void {
+    if (readOnly) return;
     if (e.button !== 0) return; // left mouse only; right is reserved for the BP context menu
     if (!canPan) return; // nothing to scroll → ignore drag (cursor reflects this too)
     if (panActive) return;
@@ -268,6 +277,7 @@
   // content under the pointer stays put (clamping at ZOOM_MIN /
   // ZOOM_MAX absorbs any single-event overshoot).
   function onBodyWheel(e: WheelEvent): void {
+    if (readOnly) return;
     if (!(e.ctrlKey || e.metaKey)) return;
     e.preventDefault();
     const factor = Math.exp(-e.deltaY * 0.012);
@@ -717,7 +727,7 @@
       // singleton (id 0) and halt markers (negative ids) ARE clickable —
       // they all map to the haltState class via `bareIdOf`, surfacing the
       // global breakpoint info in the menu (machines-demo#37 layer 2).
-      if (onToggleBreakpoint && typeof key === 'number') {
+      if (!readOnly && onToggleBreakpoint && typeof key === 'number') {
         el.style.cursor = 'context-menu';
         el.classList.add('node-clickable');
         el.addEventListener(
@@ -954,12 +964,15 @@
 
 <section class="machine-graph" class:expanded aria-label="Machine graph">
   <header class="header">
-    {#if expanded}
+    {#if expanded || readOnly}
       <!-- In expanded (modal) mode the chevron collapse toggle is hidden:
            collapsing while the modal is open would leave a header-only
            strip floating with no content — a confusing dead state. The
            minimize button (header-actions, right side) is the single
-           way out of modal mode. -->
+           way out of modal mode.
+           In readOnly mode the toggle is also hidden — showcase panels
+           are always expanded and their collapsed state is controlled by
+           the parent. -->
       <span class="title">Machine graph</span>
     {:else}
       <button
@@ -975,7 +988,7 @@
         <span class="title">Machine graph</span>
       </button>
     {/if}
-    {#if !collapsed}
+    {#if !collapsed && !readOnly}
       <div class="header-actions">
         <button
           type="button"
@@ -1028,10 +1041,10 @@
     <div
       class="body"
       class:panning={panActive}
-      class:can-pan={canPan}
+      class:can-pan={!readOnly && canPan}
       data-testid="machine-graph-body"
-      role="application"
-      aria-label="Machine graph viewport (drag to pan, Ctrl+scroll to zoom)"
+      role={readOnly ? 'img' : 'application'}
+      aria-label={readOnly ? 'Machine graph' : 'Machine graph viewport (drag to pan, Ctrl+scroll to zoom)'}
       onpointerdown={onBodyPointerDown}
       onpointermove={onBodyPointerMove}
       onpointerup={onBodyPointerUp}

--- a/src/components/SnippetPanel.svelte
+++ b/src/components/SnippetPanel.svelte
@@ -223,6 +223,23 @@
     background: var(--editor-bg);
     border: 1px solid var(--cell-border);
     border-radius: var(--surface-radius);
+    /* Tape's intrinsic width (--visible-cells * cell-width) can exceed the
+       grid-track width on narrow layouts; clip rather than letting cells
+       escape past the panel's border. */
+    overflow: hidden;
+
+    /* Showcase context — fewer cells visible than the engine pages (default
+       --visible-cells is 19 desktop / 17 tablet / 11 phone). 13 fits a
+       400-pixel-min grid track comfortably with room for head context on
+       both sides. The mask in Tape.svelte fades edge cells, so partial
+       symbols don't pop in/out as the head moves. */
+    :global(.ui-belt) {
+      --visible-cells: 13;
+
+      @media (max-width: 480px) {
+        --visible-cells: 9;
+      }
+    }
   }
 
   .caption {

--- a/src/components/SnippetPanel.svelte
+++ b/src/components/SnippetPanel.svelte
@@ -1,0 +1,285 @@
+<script lang="ts">
+  import { onMount, untrack } from 'svelte';
+  import {
+    SnippetPlayer,
+    applyHighlight,
+    indexGraph,
+    tapeViewport,
+    type GraphIndexes,
+    type HighlightOps,
+    type NodeKey,
+    type Snippet,
+  } from '@turing-machine-js/visuals';
+  import MachineGraph from './MachineGraph.svelte';
+  import TapesStack from './TapesStack.svelte';
+  import { VIEWPORT_WIDTH } from '../lib/caps.ts';
+
+  // The Vite snippets plugin (`src/vite-plugins/snippets.ts`) attaches
+  // `engine` / `id` / `description` / `intervalMs` to each `Snippet` as
+  // extension fields — `Snippet` itself has no `engine` field (it's
+  // engine-agnostic in `@turing-machine-js/visuals`). SnippetPanel relies
+  // on the extensions for caption, deep-link, and timing.
+  type SnippetWithMeta = Snippet & {
+    engine: 'turing' | 'post';
+    id: string;
+    description?: string;
+    intervalMs?: number;
+  };
+
+  type Props = { snippet: SnippetWithMeta };
+  let { snippet }: Props = $props();
+
+  // Showcase palette mirrors MachineView's; only the first slot is used in
+  // single-tape snippets (Phase 1 ships only single-tape). Kept inline to
+  // keep SnippetPanel self-contained — promoting to a shared module is a
+  // refactor for the day a snippet showcases multi-tape Turing programs.
+  const CARET_COLORS: readonly string[] = [
+    '#6ea8fe', '#ff6b6b', '#5fd068', '#c084fc', '#ffd166',
+  ];
+
+  const DEFAULT_INTERVAL_MS = 800;
+  // Each SnippetPanel instance binds to one snippet for its lifetime (the
+  // parent `Landing` uses `{#each snippets as s (s.id)}` — keyed iteration
+  // remounts on id change, never swaps `snippet` in-place). Reading the
+  // prop in initializers via `untrack` acknowledges the intentional
+  // one-time read and silences Svelte 5's reactive-prop warning.
+  const intervalMs = untrack(() => snippet.intervalMs ?? DEFAULT_INTERVAL_MS);
+  const player = untrack(() => new SnippetPlayer(snippet));
+  const graphIndexes: GraphIndexes = untrack(() => indexGraph(snippet.graph));
+  // Per-tape blank symbol. The snippets plugin sets
+  // `alphabets[i] = [...tape.alphabet.symbols]`; `Alphabet`'s symbols list
+  // starts with the blank by codebase convention, so `[i][0]` is the blank.
+  // Fallback to space matches the bundled Turing examples' default.
+  const blanks: string[] = untrack(() => snippet.alphabets.map((a) => a[0] ?? ' '));
+  const tapeCount = untrack(() => snippet.frames[0]?.tape.length ?? 1);
+  const initialGraph = untrack(() => snippet.graph);
+  const finalFrameIndex = untrack(() => snippet.frames.length - 1);
+  const engine = untrack(() => snippet.engine);
+  const snippetId = untrack(() => snippet.id);
+  const caption = untrack(() => snippet.description ?? snippet.id);
+
+  let frameIndex = $state(0);
+  let done = $state(false);
+  let reducedMotion = $state(false);
+  let graphReady = $state(false);
+
+  let panelEl: HTMLDivElement | undefined = $state();
+  let machineGraphRef = $state<ReturnType<typeof MachineGraph> | undefined>();
+  let tapesStackRef = $state<ReturnType<typeof TapesStack> | undefined>();
+
+  // `applyHighlight`'s previous-strong-id thread. Owned per-panel — not
+  // shared with the parent `MachineGraph` (which tracks its own
+  // `lastPausedStrongId` for live runs).
+  let prevStrongId: NodeKey | null = null;
+
+  // Replay timer is hoisted into a $state so it's clearable from both the
+  // AbortController abort listener (unmount during playback) AND `onReplay`
+  // (avoids stacking timers when the user spams Replay).
+  let replayTimerId: number | null = $state(null);
+
+  function clearReplayTimer(): void {
+    if (replayTimerId !== null) {
+      window.clearInterval(replayTimerId);
+      replayTimerId = null;
+    }
+  }
+
+  function applyTapes(): void {
+    const frame = player.currentFrame;
+    frame.tape.forEach((snap, i) => {
+      const blank = blanks[i] ?? ' ';
+      const { cells, headIndex } = tapeViewport(snap, VIEWPORT_WIDTH, blank);
+      tapesStackRef?.setTapeViewport(i, cells, headIndex, blank);
+    });
+  }
+
+  function applyGraph(): void {
+    if (!machineGraphRef) return;
+    const ops: HighlightOps | null = machineGraphRef.getOps();
+    if (!ops) return;
+    machineGraphRef.clearHighlights();
+    const frame = player.currentFrame;
+    if (frame.highlight) {
+      const { nextPrevStrongId } = applyHighlight(
+        frame.highlight,
+        initialGraph,
+        graphIndexes,
+        prevStrongId,
+        ops,
+      );
+      prevStrongId = nextPrevStrongId;
+    } else {
+      prevStrongId = null;
+    }
+  }
+
+  function applyFrame(): void {
+    frameIndex = player.frameIndex;
+    done = player.done;
+    applyTapes();
+    if (graphReady) applyGraph();
+  }
+
+  function startTimer(): void {
+    clearReplayTimer();
+    replayTimerId = window.setInterval(() => {
+      if (!player.forward()) {
+        clearReplayTimer();
+        return;
+      }
+      applyFrame();
+    }, intervalMs);
+  }
+
+  function onReplay(): void {
+    player.reset();
+    prevStrongId = null;
+    applyFrame();
+    if (!reducedMotion) startTimer();
+  }
+
+  function onGraphReady(): void {
+    // First-ready paint: render the current frame so the user sees the
+    // initial highlight (or final frame under reduced motion) instead of
+    // a blank graph.
+    if (graphReady) return;
+    graphReady = true;
+    applyGraph();
+  }
+
+  onMount(() => {
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (reducedMotion) {
+      player.goTo(finalFrameIndex);
+      applyFrame();
+      signal.addEventListener('abort', () => clearReplayTimer(), { once: true });
+      return () => controller.abort();
+    }
+
+    // Frame 0 visible immediately before any scroll-in.
+    applyFrame();
+
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) return;
+        io.disconnect();
+        startTimer();
+      },
+      { threshold: 0.5 },
+    );
+    if (panelEl) io.observe(panelEl);
+    signal.addEventListener('abort', () => {
+      io.disconnect();
+      clearReplayTimer();
+    }, { once: true });
+
+    return () => controller.abort();
+  });
+</script>
+
+<div class="snippet-panel" bind:this={panelEl} data-testid="snippet-panel">
+  <h3 class="caption">{caption}</h3>
+  <div class="graph">
+    <MachineGraph
+      bind:this={machineGraphRef}
+      graph={initialGraph}
+      collapsed={false}
+      onToggleCollapsed={() => {}}
+      onReady={onGraphReady}
+      readOnly
+    />
+  </div>
+  <div class="tapes">
+    <TapesStack
+      bind:this={tapesStackRef}
+      {tapeCount}
+      caretColors={CARET_COLORS}
+      readOnly
+    />
+  </div>
+  <div class="meta" data-testid="snippet-frame-index">{frameIndex}</div>
+  <div class="controls">
+    {#if done}
+      <button type="button" class="replay" onclick={onReplay}>
+        {reducedMotion ? 'Play' : 'Replay'}
+      </button>
+    {/if}
+    <a href={`/${engine}?example=${snippetId}`} class="open-in-editor">
+      Open in editor
+    </a>
+  </div>
+</div>
+
+<style>
+  .snippet-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+    background: var(--editor-bg);
+    border: 1px solid var(--cell-border);
+    border-radius: var(--surface-radius);
+  }
+
+  .caption {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--fg);
+  }
+
+  .graph {
+    /* MachineGraph manages its own height (fixed 360px by default); this
+       wrapper lets snippet-panel control the slot without re-styling the
+       graph card. */
+    min-width: 0;
+  }
+
+  .tapes {
+    min-width: 0;
+    display: flex;
+    justify-content: center;
+  }
+
+  .meta {
+    font-size: 0.75rem;
+    color: color-mix(in srgb, var(--fg) 60%, transparent);
+    font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+  }
+
+  .controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    justify-content: flex-end;
+  }
+
+  .replay {
+    padding: 6px 14px;
+    background: var(--cell-bg);
+    color: var(--fg);
+    border: 1px solid var(--cell-border);
+    border-radius: 6px;
+    cursor: pointer;
+    font: inherit;
+  }
+
+  .replay:hover {
+    background: color-mix(in srgb, var(--cell-bg) 80%, var(--fg));
+  }
+
+  .open-in-editor {
+    color: var(--fg);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in srgb, var(--fg) 40%, transparent);
+    font-size: 0.875rem;
+  }
+
+  .open-in-editor:hover {
+    text-decoration-color: var(--fg);
+  }
+</style>

--- a/src/components/SnippetPanel.test.ts
+++ b/src/components/SnippetPanel.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { flushSync } from 'svelte';
+import SnippetPanel from './SnippetPanel.svelte';
+import type { Snippet } from '@turing-machine-js/visuals';
+
+// Mock mermaid + ELK so the embedded MachineGraph doesn't try to load real
+// renderers in happy-dom (same approach as MachineGraph.test.ts). SnippetPanel
+// tests run at the frame-index / lifecycle level — full SVG rendering is left
+// to the E2E suite per the plan.
+vi.mock('mermaid', () => ({
+  default: {
+    initialize: vi.fn(),
+    registerLayoutLoaders: vi.fn(),
+    render: vi.fn(async (id: string) => ({
+      svg: `<svg data-testid="mock-svg" data-id="${id}"></svg>`,
+      bindFunctions: undefined,
+    })),
+  },
+}));
+
+vi.mock('@mermaid-js/layout-elk', () => ({
+  default: [],
+}));
+
+type SnippetWithMeta = Snippet & {
+  engine: 'turing' | 'post';
+  id: string;
+  description?: string;
+  intervalMs?: number;
+};
+
+function stubSnippet(overrides: Partial<SnippetWithMeta> = {}): SnippetWithMeta {
+  return {
+    version: 1,
+    engine: 'turing',
+    id: 'showcase-1',
+    description: 'A test snippet',
+    graph: { initialId: 0, alphabets: [[' ', 'a', 'b']], nodes: {} } as never,
+    alphabets: [[' ', 'a', 'b']],
+    frames: [
+      { step: 0, tape: [{ symbols: ['a', 'b'], position: 0 }], highlight: null },
+      { step: 1, tape: [{ symbols: ['b', 'b'], position: 1 }], highlight: null },
+      { step: 2, tape: [{ symbols: ['b', 'a'], position: 1 }], highlight: null },
+    ],
+    ...overrides,
+  };
+}
+
+// IntersectionObserver test double: stores the callback on the constructed
+// instance so a test can `instance.fire(true)` to simulate scroll-into-view.
+class FakeIntersectionObserver {
+  static instances: FakeIntersectionObserver[] = [];
+  callback: IntersectionObserverCallback;
+  observed: Element[] = [];
+  disconnected = false;
+  constructor(cb: IntersectionObserverCallback) {
+    this.callback = cb;
+    FakeIntersectionObserver.instances.push(this);
+  }
+  observe(el: Element) { this.observed.push(el); }
+  disconnect() { this.disconnected = true; }
+  unobserve() {}
+  takeRecords() { return []; }
+  root = null;
+  rootMargin = '';
+  thresholds: number[] = [];
+  fire(isIntersecting: boolean) {
+    this.callback(
+      [{ isIntersecting } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
+beforeEach(() => {
+  FakeIntersectionObserver.instances = [];
+  vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver);
+  // Default to motion ON; individual tests can override matchMedia.
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  cleanup();
+});
+
+describe('SnippetPanel', () => {
+  it('S-snippet-panel-renders-caption: renders the snippet description', () => {
+    render(SnippetPanel, { snippet: stubSnippet() });
+    expect(screen.getByText('A test snippet')).toBeInTheDocument();
+  });
+
+  it('S-snippet-panel-renders-caption: falls back to id when description is absent', () => {
+    render(SnippetPanel, {
+      snippet: stubSnippet({ description: undefined, id: 'fallback-id' }),
+    });
+    expect(screen.getByText('fallback-id')).toBeInTheDocument();
+  });
+
+  it('S-snippet-panel-static-on-mount: sits on frame 0 until IO fires', () => {
+    render(SnippetPanel, { snippet: stubSnippet() });
+    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('0');
+  });
+
+  it('S-snippet-panel-autoplay-on-intersect: advances frames after intersect', () => {
+    render(SnippetPanel, { snippet: stubSnippet({ intervalMs: 100 }) });
+    expect(FakeIntersectionObserver.instances).toHaveLength(1);
+    const io = FakeIntersectionObserver.instances[0];
+    io.fire(true);
+    expect(io.disconnected).toBe(true);
+    // Advance interval — should step to frame 1.
+    vi.advanceTimersByTime(100);
+    flushSync();
+    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('1');
+    vi.advanceTimersByTime(100);
+    flushSync();
+    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('2');
+  });
+
+  it('S-snippet-panel-freeze-at-halt: timer stops at the last frame and Replay appears', () => {
+    render(SnippetPanel, { snippet: stubSnippet({ intervalMs: 50 }) });
+    FakeIntersectionObserver.instances[0].fire(true);
+    // 3 frames: index 0 → 1 → 2 (done). 2 ticks reach done.
+    vi.advanceTimersByTime(50);
+    vi.advanceTimersByTime(50);
+    flushSync();
+    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('2');
+    // Extra ticks must not advance past the last frame.
+    vi.advanceTimersByTime(500);
+    flushSync();
+    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('2');
+    // Replay button appears when done.
+    expect(screen.getByRole('button', { name: /Replay/i })).toBeInTheDocument();
+  });
+
+  it('S-snippet-panel-replay-resets: Replay jumps back to frame 0 and replays', async () => {
+    render(SnippetPanel, { snippet: stubSnippet({ intervalMs: 50 }) });
+    FakeIntersectionObserver.instances[0].fire(true);
+    vi.advanceTimersByTime(50);
+    vi.advanceTimersByTime(50);
+    flushSync();
+    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('2');
+    await fireEvent.click(screen.getByRole('button', { name: /Replay/i }));
+    flushSync();
+    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('0');
+    vi.advanceTimersByTime(50);
+    flushSync();
+    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('1');
+  });
+
+  it('S-snippet-panel-reduced-motion: jumps to the final frame on mount, no IO', () => {
+    vi.stubGlobal('matchMedia', (query: string) => ({
+      matches: query.includes('reduce'),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    render(SnippetPanel, { snippet: stubSnippet() });
+    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('2');
+    // No IntersectionObserver should have been created under reduced motion.
+    expect(FakeIntersectionObserver.instances).toHaveLength(0);
+    // Play button shown (instead of Replay) under reduced motion.
+    expect(screen.getByRole('button', { name: /Play/i })).toBeInTheDocument();
+  });
+
+  it('S-snippet-panel-deep-link: Open-in-editor link points at /engine?example=id', () => {
+    render(SnippetPanel, {
+      snippet: stubSnippet({ engine: 'post', id: 'pe-1' }),
+    });
+    const link = screen.getByRole('link', { name: /Open in editor/i });
+    expect(link).toHaveAttribute('href', '/post?example=pe-1');
+  });
+});

--- a/src/components/Tape.svelte
+++ b/src/components/Tape.svelte
@@ -75,6 +75,27 @@
     cellEl.classList.add('write-flash');
   }
 
+  // Render a pre-windowed cell array directly, bypassing `turing.Tape.viewport`.
+  // Used by `SnippetPanel` for prerecorded playback (Frame.tape snapshots are
+  // wire-format `TapeSnapshot`s, not live tapes). `cells.length` is expected
+  // to equal `VIEWPORT_WIDTH`; `headIndex` is the head's position within
+  // `cells` (currently always `MIDDLE_INDEX` for centered viewports, kept as
+  // a parameter for future non-centered layouts). `blank` is the alphabet's
+  // blank symbol — cells matching it render dimmed via `.cell.blank` CSS.
+  // No animation: prerecorded frames don't slide.
+  export function setFromCells(
+    cells: string[],
+    _headIndex: number,
+    blank: string,
+  ): void {
+    const padded: Cell[] = new Array(VIEWPORT_WIDTH).fill(null).map(blankCell);
+    for (let i = 0; i < VIEWPORT_WIDTH && i < cells.length; i++) {
+      const sym = cells[i];
+      padded[i] = { sym, blank: sym === blank };
+    }
+    viewport = padded;
+  }
+
   export function setTransitionsEnabled(on: boolean): void {
     if (!stripEl) return;
     if (on) {

--- a/src/components/TapesStack.svelte
+++ b/src/components/TapesStack.svelte
@@ -45,6 +45,23 @@
     void tapeRefs[i]?.setFromTape(tape, delta, animate, wrote);
   }
 
+  // Render a pre-windowed cell array directly into tape `i`, bypassing
+  // `turing.Tape.viewport`. Used by `SnippetPanel` — Frame.tape snapshots
+  // are wire-format `TapeSnapshot`s, not live tapes; `tapeViewport()` from
+  // `@turing-machine-js/visuals` is called by the caller to derive the
+  // window from the snapshot, then handed in here as `cells`. `headIndex`
+  // is the head's position within `cells` (currently always the center for
+  // centered viewports; kept for future non-centered layouts). `blank` is
+  // the alphabet's blank symbol so cell-dim styling stays correct.
+  export function setTapeViewport(
+    i: number,
+    cells: string[],
+    headIndex: number,
+    blank: string,
+  ): void {
+    tapeRefs[i]?.setFromCells(cells, headIndex, blank);
+  }
+
   export function clearAll(): void {
     tapeRefs.forEach((r) => void r?.setFromTape(null));
   }

--- a/src/components/TapesStack.svelte
+++ b/src/components/TapesStack.svelte
@@ -5,8 +5,15 @@
   type Props = {
     tapeCount: number;
     caretColors: readonly string[];
+    /** When true, user-facing interactive surfaces on the tape stack are
+     *  disabled. Currently `TapesStack` and `Tape` have no interactive
+     *  handlers of their own (caret-edit and copy/paste live on
+     *  `MachineView`), so this prop is a forward-compat marker for Task 7
+     *  (`setTapeViewport`, etc.). The imperative API (`setFromTape`,
+     *  `clearAll`, `setTransitionsEnabled`) is unaffected. */
+    readOnly?: boolean;
   };
-  let { tapeCount, caretColors }: Props = $props();
+  let { tapeCount, caretColors, readOnly: _readOnly = false }: Props = $props();
 
   let tapeRefs = $state<Array<ReturnType<typeof Tape> | undefined>>([]);
 

--- a/src/lib/defaultCode.ts
+++ b/src/lib/defaultCode.ts
@@ -4,6 +4,11 @@ export type Example = {
   id: string;
   title: string;
   code: string;
+  // Phase 1: showcase flag drives the Vite snippet recorder; description appears
+  // as the panel caption; intervalMs overrides the playback default (800ms).
+  showcase?: boolean;
+  description?: string;
+  intervalMs?: number;
 };
 
 const TURING_REPLACE_B = `// Task: replace every 'b' on the tape with '*'.
@@ -187,13 +192,25 @@ return { machine };
 `;
 
 const TURING_EXAMPLES: readonly Example[] = [
-  { id: 'replace-b', title: "Replace 'b' with '*'", code: TURING_REPLACE_B },
+  {
+    id: 'replace-b',
+    title: "Replace 'b' with '*'",
+    code: TURING_REPLACE_B,
+    showcase: true,
+    description: 'Scan right over a mixed tape and replace every "b" with "*", leaving other symbols untouched.',
+  },
   { id: 'copy-two-tapes', title: 'Copy tape (multi-tape)', code: TURING_COPY_TWO_TAPES },
   { id: 'callable-subtree', title: 'Callable subtree (withOverriddenHaltState)', code: TURING_CALLABLE_SUBTREE },
 ];
 
 const POST_EXAMPLES: readonly Example[] = [
-  { id: 'walk-mark', title: 'Walk right; mark first blank', code: POST_WALK_MARK },
+  {
+    id: 'walk-mark',
+    title: 'Walk right; mark first blank',
+    code: POST_WALK_MARK,
+    showcase: true,
+    description: 'Walk right over marked cells and place a mark in the first blank cell found.',
+  },
 ];
 
 export function examples(engine: Engine): readonly Example[] {

--- a/src/lib/routing.test.ts
+++ b/src/lib/routing.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { readRouteFromUrl, readEngineFromLandingQuery, legacyMachineRewrite } from './routing';
+
+describe('routing helpers', () => {
+  it('R-route-landing-from-root', () => {
+    expect(readRouteFromUrl('/')).toEqual({ kind: 'landing' });
+  });
+  it('R-route-landing-from-unknown', () => {
+    expect(readRouteFromUrl('/foo')).toEqual({ kind: 'landing' });
+  });
+  it('R-route-engine-turing', () => {
+    expect(readRouteFromUrl('/turing')).toEqual({ kind: 'engine', engine: 'turing' });
+  });
+  it('R-route-engine-post', () => {
+    expect(readRouteFromUrl('/post')).toEqual({ kind: 'engine', engine: 'post' });
+  });
+  it('R-route-landing-engine-query — defaults to turing', () => {
+    expect(readEngineFromLandingQuery('')).toBe('turing');
+    expect(readEngineFromLandingQuery('?engine=post')).toBe('post');
+    expect(readEngineFromLandingQuery('?engine=bogus')).toBe('turing');
+  });
+  it('R-route-legacy-machine-rewrite', () => {
+    const url = legacyMachineRewrite(new URL('http://x.test/?machine=post'));
+    expect(url.pathname).toBe('/post');
+    expect(url.searchParams.has('machine')).toBe(false);
+  });
+});

--- a/src/lib/routing.ts
+++ b/src/lib/routing.ts
@@ -1,0 +1,26 @@
+import { ENGINES, type Engine, type Route } from './types';
+
+export function readRouteFromUrl(pathname: string): Route {
+  const seg = pathname.replace(/^\/+/, '').split('/')[0];
+  if ((ENGINES as readonly string[]).includes(seg)) {
+    return { kind: 'engine', engine: seg as Engine };
+  }
+  return { kind: 'landing' };
+}
+
+export function readEngineFromLandingQuery(search: string): Engine {
+  const params = new URLSearchParams(search);
+  const raw = params.get('engine');
+  return (ENGINES as readonly string[]).includes(raw ?? '') ? (raw as Engine) : 'turing';
+}
+
+export function legacyMachineRewrite(url: URL): URL {
+  const legacy = url.searchParams.get('machine');
+  if (legacy !== null) {
+    url.searchParams.delete('machine');
+    if ((ENGINES as readonly string[]).includes(legacy)) {
+      url.pathname = '/' + legacy;
+    }
+  }
+  return url;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,6 +8,10 @@ import type { TapeSnapshot } from '@turing-machine-js/visuals';
 export const ENGINES = ['turing', 'post'] as const;
 export type Engine = (typeof ENGINES)[number];
 
+export type Route =
+  | { kind: 'landing' }
+  | { kind: 'engine'; engine: Engine };
+
 export const MOVEMENTS = ['L', 'S', 'R'] as const;
 export type Movement = (typeof MOVEMENTS)[number];
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -12,3 +12,15 @@ declare module 'virtual:lib-versions' {
   export const visualsVersion: string;
   export const appVersion: string;
 }
+
+declare module 'virtual:snippets' {
+  import type { Snippet } from '@turing-machine-js/visuals';
+  type SnippetWithMeta = Snippet & {
+    engine: 'turing' | 'post';
+    id: string;
+    description?: string;
+    intervalMs?: number;
+  };
+  const snippets: { turing: SnippetWithMeta[]; post: SnippetWithMeta[] };
+  export default snippets;
+}

--- a/src/vite-plugins/snippets.test.ts
+++ b/src/vite-plugins/snippets.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { createSnippetsPlugin } from './snippets.ts';
+import type { Example } from '../lib/defaultCode.ts';
+
+// A minimal, self-contained Turing example that returns { machine, initialState, tape }
+// — small enough to record fast, alphabet ordered with blank-first to match the
+// codebase convention.
+const TURING_SHOWCASE_CODE = `
+const {
+  Alphabet, State, Tape, TapeBlock, TuringMachine,
+  haltState, ifOtherSymbol, movements,
+} = imports;
+
+const alphabet = new Alphabet([' ', 'a', 'b']);
+const tape = new Tape({ alphabet, symbols: ['a', 'b', 'a'] });
+const tapeBlock = TapeBlock.fromTapes([tape]);
+const machine = new TuringMachine({ tapeBlock });
+
+const initialState = new State({
+  [tapeBlock.symbol(['b'])]: {
+    command: [{ symbol: 'a', movement: movements.right }],
+  },
+  [tapeBlock.symbol([alphabet.blankSymbol])]: {
+    command: [{ movement: movements.left }],
+    nextState: haltState,
+  },
+  [ifOtherSymbol]: {
+    command: [{ movement: movements.right }],
+  },
+});
+
+return { machine, initialState, tape };
+`;
+
+const POST_SHOWCASE_CODE = `
+const { PostMachine, Tape, mark, right, stop } = imports;
+
+const machine = new PostMachine(
+  {
+    10: right(20),
+    20: mark,
+    30: stop,
+  },
+  { blankSymbol: ' ', markSymbol: '*' },
+);
+
+machine.replaceTapeWith(new Tape({
+  alphabet: machine.tape.alphabet,
+  symbols: [' ', ' '],
+}));
+
+return { machine };
+`;
+
+const stubExamples = (engine: 'turing' | 'post'): readonly Example[] => {
+  if (engine === 'turing') {
+    return [
+      {
+        id: 'showcase-1',
+        title: 'Turing showcase',
+        code: TURING_SHOWCASE_CODE,
+        showcase: true,
+        description: 'desc',
+      },
+      { id: 'not-shown', title: 'Hidden', code: 'return { machine: null };' },
+    ];
+  }
+  return [
+    {
+      id: 'showcase-1',
+      title: 'Post showcase',
+      code: POST_SHOWCASE_CODE,
+      showcase: true,
+      description: 'desc',
+    },
+  ];
+};
+
+describe('snippets vite plugin', () => {
+  it('V-plugin-emits-virtual-module — resolves virtual:snippets', async () => {
+    const plugin = createSnippetsPlugin({ examples: stubExamples });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const resolved = await (plugin.resolveId as any).call({}, 'virtual:snippets');
+    expect(resolved).toBe('\0virtual:snippets');
+  });
+
+  it('V-plugin-only-showcase — non-showcase examples are excluded', async () => {
+    const plugin = createSnippetsPlugin({ examples: stubExamples });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const out = await (plugin.load as any).call({}, '\0virtual:snippets');
+    expect(out).toMatch(/showcase-1/);
+    expect(out).not.toMatch(/not-shown/);
+  });
+
+  it('V-plugin-snippet-shape — emitted artifacts match Snippet schema', async () => {
+    const plugin = createSnippetsPlugin({ examples: stubExamples });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const out: string = await (plugin.load as any).call({}, '\0virtual:snippets');
+    const match = out.match(/^export default (.+);\s*$/);
+    expect(match).toBeTruthy();
+    const data = JSON.parse(match![1]);
+    for (const engine of ['turing', 'post'] as const) {
+      expect(Array.isArray(data[engine])).toBe(true);
+      for (const snippet of data[engine]) {
+        expect(snippet).toMatchObject({
+          version: 1,
+          engine,
+          id: 'showcase-1',
+          graph: expect.any(Object),
+          alphabets: expect.any(Array),
+          frames: expect.any(Array),
+        });
+        expect(snippet.frames.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('V-plugin-error-on-runtime-throw — bad example fails the build', async () => {
+    const examples = (engine: 'turing' | 'post'): readonly Example[] =>
+      engine === 'turing'
+        ? [{ id: 'broken', title: 'X', code: 'throw new Error("nope")', showcase: true }]
+        : [];
+    const plugin = createSnippetsPlugin({ examples });
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (plugin.load as any).call({}, '\0virtual:snippets'),
+    ).rejects.toThrow(/broken/);
+  });
+});

--- a/src/vite-plugins/snippets.ts
+++ b/src/vite-plugins/snippets.ts
@@ -1,0 +1,134 @@
+import type { Plugin } from 'vite';
+import { recordSnippet } from '@turing-machine-js/visuals';
+import * as turing from '@turing-machine-js/machine';
+import * as post from '@post-machine-js/machine';
+import type { Example } from '../lib/defaultCode.ts';
+
+type Engine = 'turing' | 'post';
+
+type Options = {
+  // Inject for testability; default to importing the real `examples()` helper.
+  examples?: (engine: Engine) => readonly Example[] | Promise<readonly Example[]>;
+};
+
+const VIRTUAL_ID = 'virtual:snippets';
+const RESOLVED_VIRTUAL_ID = '\0' + VIRTUAL_ID;
+
+// Mirrors machineWorker.ts:280-341 `build()` — eval user code with the engine's
+// namespace as `imports`, validate the returned shape, derive the tape block.
+// Kept inline (vs extracting to workerHelpers) because the build-time eval
+// surface differs in two ways: no sandbox-stub globals (Node lacks `alert` /
+// `prompt` anyway), and the plugin needs the tape-block handle for graph
+// inspection, not just the per-tape array.
+function evalExampleCode(engine: Engine, code: string) {
+  const imports: Record<string, unknown> =
+    engine === 'post' ? { ...post } : { ...turing };
+  const fn = new Function('imports', code) as (
+    i: Record<string, unknown>,
+  ) => unknown;
+  const r = fn(imports);
+  if (!r || typeof r !== 'object') {
+    throw new Error('example must return { machine, initialState?, tape? }');
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result = r as { machine?: any; initialState?: any; tape?: any };
+  if (!result.machine) throw new Error('example return value missing `machine`');
+  const machine = result.machine;
+  const initialState = result.initialState ?? machine.initialState ?? null;
+  if (!initialState) {
+    throw new Error(
+      'example missing `initialState` (and machine.initialState absent)',
+    );
+  }
+  const tapeBlock = machine.tapeBlock;
+  if (!tapeBlock) throw new Error('example machine has no `tapeBlock`');
+  const blockTapes = tapeBlock.tapes;
+  const tapes =
+    blockTapes && blockTapes.length > 0
+      ? [...blockTapes]
+      : result.tape
+        ? [result.tape]
+        : machine.tape
+          ? [machine.tape]
+          : [];
+  if (tapes.length === 0) throw new Error('example produced no tapes');
+  return { machine, initialState, tapeBlock, tapes };
+}
+
+export function createSnippetsPlugin(opts: Options = {}): Plugin {
+  const examplesFn: (
+    engine: Engine,
+  ) => readonly Example[] | Promise<readonly Example[]> =
+    opts.examples ??
+    (async (engine) => {
+      const mod = await import('../lib/defaultCode.ts');
+      return mod.examples(engine);
+    });
+
+  return {
+    name: 'machines-demo:snippets',
+
+    resolveId(id) {
+      if (id === VIRTUAL_ID) return RESOLVED_VIRTUAL_ID;
+      return null;
+    },
+
+    async load(id) {
+      if (id !== RESOLVED_VIRTUAL_ID) return null;
+
+      const out: Record<Engine, unknown[]> = { turing: [], post: [] };
+
+      for (const engine of ['turing', 'post'] as const) {
+        const examples = await examplesFn(engine);
+        for (const example of examples) {
+          if (!example.showcase) continue;
+          try {
+            const { machine, initialState, tapeBlock, tapes } = evalExampleCode(
+              engine,
+              example.code,
+            );
+            // graph + alphabets shaped to match what MachineView sends in `built`:
+            // engine `State.toGraph(initialState, tapeBlock)`, per-tape alphabet
+            // arrays (blank-first by codebase convention).
+            const graph = turing.State.toGraph(initialState, tapeBlock);
+            const alphabets = tapes.map(
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              (t: any) => [...t.alphabet.symbols] as string[],
+            );
+            const snippet = recordSnippet({
+              machine,
+              initialState,
+              graph,
+              alphabets,
+              name: example.title,
+              maxSteps: 1000,
+            });
+            out[engine].push({
+              ...snippet,
+              engine,
+              id: example.id,
+              description: example.description,
+              intervalMs: example.intervalMs,
+            });
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            throw new Error(
+              `snippets plugin: failed to record "${example.id}" (${engine}): ${msg}`,
+            );
+          }
+        }
+      }
+
+      return `export default ${JSON.stringify(out)};`;
+    },
+
+    handleHotUpdate(ctx) {
+      // Re-record when defaultCode.ts changes.
+      if (ctx.file.endsWith('/defaultCode.ts')) {
+        const mod = ctx.server.moduleGraph.getModuleById(RESOLVED_VIRTUAL_ID);
+        if (mod) ctx.server.moduleGraph.invalidateModule(mod);
+        return [];
+      }
+    },
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, type Plugin } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { readFileSync } from 'node:fs';
+import { createSnippetsPlugin } from './src/vite-plugins/snippets.ts';
 
 const pkgVersion = (pkg: string): string =>
   JSON.parse(readFileSync(`./node_modules/${pkg}/package.json`, 'utf-8')).version;
@@ -30,5 +31,5 @@ export const appVersion = ${JSON.stringify(app)};
 });
 
 export default defineConfig({
-  plugins: [svelte(), libVersions()],
+  plugins: [svelte(), libVersions(), createSnippetsPlugin()],
 });


### PR DESCRIPTION
## Summary

Phase 1 of [#79](https://github.com/mellonis/machines-demo/issues/79) — lands the `/` landing page with prerecorded snippet panels driven by `@turing-machine-js/visuals`'s `recordSnippet` + new `SnippetPlayer` + `tapeViewport`. Ships with one placeholder showcase example per engine (Turing `replace-b`, Post `walk-mark`) to prove the end-to-end pipeline.

`/turing` and `/post` are untouched; DEMO mode continues to run. DEMO retirement (Phase 2) and three curated examples per engine (content sub-PR) are separate follow-ups.

## What landed

- **`/` is a first-class route** — `App.svelte` now uses a `Route = { kind: 'landing' } | { kind: 'engine'; engine }` discriminated union (pure helpers extracted to `src/lib/routing.ts` with 6 unit tests). Unknown paths normalise to `/` (no longer to `/turing`); legacy `?machine=<engine>` rewrite preserved.
- **Vite plugin (`src/vite-plugins/snippets.ts`)** emits `virtual:snippets` at build time. Iterates `examples()` per engine, evaluates each `showcase: true` example via the same `new Function('imports', code)` shape the worker uses, captures frames via `recordSnippet`, returns `{ turing, post }` as a JS module. 4 plugin tests including `V-plugin-error-on-runtime-throw`.
- **`SnippetPanel.svelte`** is pure playback over a `Snippet` artifact — uses `SnippetPlayer` from visuals alpha.7.1 for frame stepping, `tapeViewport` for centered windows, `applyHighlight` for graph highlights. IntersectionObserver auto-play (threshold 0.5) with `prefers-reduced-motion: reduce` opt-out (renders the halt frame statically with a "Play" button). One `AbortController` scopes the timer + IO + replay timer for clean teardown. 8 component tests.
- **`MachineGraph.svelte` + `TapesStack.svelte`** gain a `readOnly?: boolean` prop (gates breakpoint clicks / collapse toggle / pan / zoom / contextmenu in MachineGraph; no-op stub in TapesStack since interactive surface lives on MachineView). MachineGraph also gains imperative `getOps(): HighlightOps | null` / `clearHighlights(): void` + an `onReady` callback prop. TapesStack + Tape gain `setTapeViewport(i, cells, headIndex, blank)` / `setFromCells(...)` for pre-windowed rendering.
- **`Landing.svelte`** — engine switcher (URL state via `?engine=post`), responsive snippet grid, design-system-matching CSS tokens.
- **Example type extension** — `Example.showcase?` / `description?` / `intervalMs?`. `replace-b` (Turing) + `walk-mark` (Post) flagged as placeholders.
- **Visuals dep** bumped `alpha.7` → `alpha.7.1` to consume the new `SnippetPlayer` + `tapeViewport` surfaces (released alongside this PR).

## Out of scope

- **Phase 2** — DEMO mode retirement (`demoLoop.ts` removal, `'DEMO'` `ExecutionMode` variant, related branches in MachineView). Separate plan.
- **Content sub-PR** — three properly curated showcase examples per engine (simple / moderate / composed). Placeholders ship in this PR; replacement is independent content authoring.
- Mobile layout polish, snippet authoring UI, multi-tape Post snippets (gated on [post-machine-js#98](https://github.com/mellonis/post-machine-js/issues/98)), pause/scrub controls on landing — per spec's "Out of scope" section.

## Test plan

- [x] 145 unit tests pass (12 files; +14 since master — `routing.test.ts`, `snippets.test.ts`, `SnippetPanel.test.ts`)
- [x] 13 E2E tests pass (8 cold-start + 5 new landing)
- [x] `npm run check` clean (616 files, 0 errors / 0 warnings)
- [x] `npm run build` succeeds; `dist/` builds for production
- [x] `npm run dev` boots cleanly; visited `/`, `/turing`, `/?engine=post`, `/turing?example=replace-b` — all render
- [ ] Reviewer manually verifies on the deployed preview (if available) that the placeholder snippet auto-plays smoothly on first visit

## Spec + plan

- Spec: [`docs/superpowers/specs/2026-05-27-landing-page-design.md`](docs/superpowers/specs/2026-05-27-landing-page-design.md) (merged via #83)
- Plan: [`docs/superpowers/plans/2026-05-30-landing-page-phase-1.md`](docs/superpowers/plans/2026-05-30-landing-page-phase-1.md)

## Visuals dependency

Requires `@turing-machine-js/visuals@^7.0.0-alpha.7.1` — published 2026-05-30 alongside this PR (engine + libs stay at `7.0.0-alpha.7`).