### PR TITLE
chore(release): 1.0.0-alpha.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "machines-demo",
-  "version": "1.0.0-alpha.18",
+  "version": "1.0.0-alpha.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "machines-demo",
-      "version": "1.0.0-alpha.18",
+      "version": "1.0.0-alpha.19",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machines-demo",
   "private": true,
-  "version": "1.0.0-alpha.18",
+  "version": "1.0.0-alpha.19",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Version bump from `1.0.0-alpha.18` → `1.0.0-alpha.19`. Covers the Phase 1 landing-page work merged via [#87](https://github.com/mellonis/machines-demo/pull/87) plus the visuals dep bump to alpha.7.1 (turing-machine-js [#226](https://github.com/mellonis/turing-machine-js/pull/226)).

### Highlights

- `/` is a first-class landing route with prerecorded snippet panels (`SnippetPanel` consumes `visuals.SnippetPlayer` + `tapeViewport`; IntersectionObserver auto-play + reduced-motion opt-out).
- Header "machines demo" title is now a clickable link back to `/`.
- One placeholder showcase example per engine (`replace-b` Turing, `walk-mark` Post). Three properly curated examples per engine ship in a content sub-PR.
- `MachineGraph` + `TapesStack` gain `readOnly` + new imperative APIs (`getOps()` / `clearHighlights()` / `setTapeViewport()`).

### Out of scope

- **Phase 2** (DEMO mode retirement) — separate plan.
- **Content sub-PR** (three curated examples per engine) — independent content authoring follow-up.

## Test plan

- [x] All Phase 1 work landed via [#87](https://github.com/mellonis/machines-demo/pull/87) (145 unit tests + 13 E2E tests all green at merge)
- [ ] After merge: `gh release create v1.0.0-alpha.19 --prerelease --notes-file …` (deploy ride-along happens automatically via `.github/workflows/main.yml` on push to master)