### PR TITLE
content(landing): three curated showcase examples per engine (#79 follow-up)

### DIFF
--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -4,19 +4,21 @@ test.describe('landing', () => {
   test('renders snippet panels on /', async ({ page }) => {
     await page.goto('/');
     await expect(page.getByRole('heading', { name: /Turing & Post machines/ })).toBeVisible();
-    await expect(page.locator('.snippet-panel')).toHaveCount(1); // one placeholder per engine; phase-1 default = turing
+    // Three curated showcase examples per engine (simple / moderate / composed); default = turing.
+    await expect(page.locator('.snippet-panel')).toHaveCount(3);
   });
 
   test('engine switch updates URL and panels', async ({ page }) => {
     await page.goto('/');
     await page.getByRole('button', { name: /Post snippets/ }).click();
     await expect(page).toHaveURL(/\?engine=post/);
-    await expect(page.locator('.snippet-panel')).toHaveCount(1);
+    await expect(page.locator('.snippet-panel')).toHaveCount(3);
   });
 
   test('deep link to editor opens the example', async ({ page }) => {
     await page.goto('/');
-    const link = page.getByRole('link', { name: /Open in editor/ });
+    // Use the first panel's deep-link explicitly — there are now 3 per engine.
+    const link = page.getByRole('link', { name: /Open in editor/ }).first();
     await link.click();
     await expect(page).toHaveURL(/\/turing\?example=/);
     // MachineView visible

--- a/src/lib/defaultCode.ts
+++ b/src/lib/defaultCode.ts
@@ -159,6 +159,81 @@ const initialState = walkToBlank.withOverriddenHaltState(writeMarker);
 return { machine, initialState };
 `;
 
+const TURING_TOGGLE_BITS = `// Task: toggle every bit on the tape (0 ↔ 1) until blank.
+
+/*
+ * Available imports (named exports of @turing-machine-js/machine):
+ *   Alphabet, State, Tape, TapeBlock, TuringMachine,
+ *   haltState, ifOtherSymbol, movements, ...
+ *
+ * Return: { machine, initialState, tape }
+ *
+ * Note: the demo runs the machine; do not call .run() or .runStepByStep() yourself.
+ */
+
+const {
+  Alphabet, State, Tape, TapeBlock, TuringMachine,
+  haltState, ifOtherSymbol, movements,
+} = imports;
+
+const alphabet = new Alphabet([' ', '0', '1']);
+const tape = new Tape({ alphabet, symbols: ['0', '1', '1', '0', '1'] });
+const tapeBlock = TapeBlock.fromTapes([tape]);
+const machine = new TuringMachine({ tapeBlock });
+
+// Two literal patterns flip each cell; ifOtherSymbol matches the blank
+// and halts. The State returns the first matching key, so the literals
+// listed before ifOtherSymbol win when they match.
+const initialState = new State({
+  [tapeBlock.symbol(['0'])]: {
+    command: [{ symbol: '1', movement: movements.right }],
+  },
+  [tapeBlock.symbol(['1'])]: {
+    command: [{ symbol: '0', movement: movements.right }],
+  },
+  [ifOtherSymbol]: {
+    command: [{ movement: movements.stay }],
+    nextState: haltState,
+  },
+});
+
+return { machine, initialState, tape };
+`;
+
+const POST_MARK_AND_STEP = `// Task: mark the current cell, step right, mark again, step right. Halt.
+// Pure-sequential program — no branching. The simplest interesting
+// Post-machine pattern: mutate the tape, advance the head, repeat.
+
+/*
+ * Available imports (named exports of @post-machine-js/machine):
+ *   PostMachine, Tape, alphabet, blankSymbol, markSymbol,
+ *   call, check, erase, left, mark, noop, right, stop, ...
+ *
+ * Return: { machine } — initialState and tape default from the machine.
+ */
+
+const { PostMachine, Tape, mark, right, stop } = imports;
+
+const machine = new PostMachine(
+  {
+    10: mark,
+    20: right,
+    30: mark,
+    40: right,
+    50: mark,
+    60: stop,
+  },
+  { blankSymbol: '␣', markSymbol: '•' },
+);
+
+machine.replaceTapeWith(new Tape({
+  alphabet: machine.tape.alphabet,
+  symbols: ['␣', '␣', '␣'],
+}));
+
+return { machine };
+`;
+
 const POST_WALK_MARK = `// Task: walk right while marked; mark the first blank cell found.
 
 /*
@@ -191,25 +266,89 @@ machine.replaceTapeWith(new Tape({
 return { machine };
 `;
 
+const POST_CALL_SUBROUTINE = `// Task: walk to the first blank and mark it; step past; walk to the
+// next blank and mark it. Halt.
+// Demonstrates 'call' — a string-keyed subroutine reused from main.
+// 'stop' inside the subroutine = return to caller's continuation.
+// In the rendered graph, 'walkToBlank' sits inside a dashed subgraph
+// frame; the frame's border lights up while execution is inside it.
+
+/*
+ * Available imports (named exports of @post-machine-js/machine):
+ *   PostMachine, Tape, alphabet, blankSymbol, markSymbol,
+ *   call, check, erase, left, mark, noop, right, stop, ...
+ */
+
+const { PostMachine, Tape, call, check, mark, right, stop } = imports;
+
+const machine = new PostMachine({
+  walkToBlank: {
+    1: check(2, 3),  // marked? continue walking, else return
+    2: right(1),     // walk right, loop
+    3: stop,         // blank reached → return to caller
+  },
+  10: call('walkToBlank'),
+  20: mark,
+  30: right,         // step past the just-marked cell
+  40: call('walkToBlank'),
+  50: mark,
+  60: stop,
+}, { blankSymbol: '␣', markSymbol: '•' });
+
+machine.replaceTapeWith(new Tape({
+  alphabet: machine.tape.alphabet,
+  symbols: ['•', '•', '␣', '•', '•', '␣', '␣'],
+}));
+
+return { machine };
+`;
+
 const TURING_EXAMPLES: readonly Example[] = [
   {
     id: 'replace-b',
     title: "Replace 'b' with '*'",
     code: TURING_REPLACE_B,
     showcase: true,
-    description: 'Scan right over a mixed tape and replace every "b" with "*", leaving other symbols untouched.',
+    description: "Replace each 'b' with '*'; halt at blank.",
+  },
+  {
+    id: 'toggle-bits',
+    title: 'Toggle bits (0 ↔ 1)',
+    code: TURING_TOGGLE_BITS,
+    showcase: true,
+    description: 'Flip each bit (0↔1); halt at blank.',
+  },
+  {
+    id: 'callable-subtree',
+    title: 'Callable subtree (withOverriddenHaltState)',
+    code: TURING_CALLABLE_SUBTREE,
+    showcase: true,
+    description: 'Subroutine: walk to blank, then mark; the subgraph frame highlights during the call.',
   },
   { id: 'copy-two-tapes', title: 'Copy tape (multi-tape)', code: TURING_COPY_TWO_TAPES },
-  { id: 'callable-subtree', title: 'Callable subtree (withOverriddenHaltState)', code: TURING_CALLABLE_SUBTREE },
 ];
 
 const POST_EXAMPLES: readonly Example[] = [
   {
+    id: 'mark-and-step',
+    title: 'Mark, step, mark, step, mark',
+    code: POST_MARK_AND_STEP,
+    showcase: true,
+    description: 'Mark, step right, repeat — pure sequential, no branches.',
+  },
+  {
     id: 'walk-mark',
-    title: 'Walk right; mark first blank',
+    title: 'Walk past marks; mark first blank',
     code: POST_WALK_MARK,
     showcase: true,
-    description: 'Walk right over marked cells and place a mark in the first blank cell found.',
+    description: 'Skip past marks; mark the first blank cell.',
+  },
+  {
+    id: 'call-subroutine',
+    title: 'Subroutine: walk-to-blank, called twice',
+    code: POST_CALL_SUBROUTINE,
+    showcase: true,
+    description: 'Subroutine: walk to a blank and mark it; called twice from main.',
   },
 ];
 


### PR DESCRIPTION
## Summary

Phase 1 ([PR #87](https://github.com/mellonis/machines-demo/pull/87)) shipped one placeholder showcase example per engine to prove the `recordSnippet` pipeline. This sub-PR replaces / extends them with **three curated examples per engine**, ordered simple → moderate → composed per the spec's selection criteria.

### Turing

| Tier | Example | What it shows |
|---|---|---|
| Simple | \`replace-b\` (existing) | Iterate right, replace each \`b\` with \`*\`. Halt at blank. |
| Moderate | \`toggle-bits\` (new) | Two literal patterns + \`ifOtherSymbol\` flip each 0/1 cell. Demonstrates branching. |
| Composed | \`callable-subtree\` (existing, flagged) | \`walkToBlank.withOverriddenHaltState(writeMarker)\` — subgraph frame lights up during the subroutine call. The v7 callable-subtree emit's reason to exist. |

### Post

| Tier | Example | What it shows |
|---|---|---|
| Simple | \`mark-and-step\` (new) | Pure sequential \`mark; right; mark; right; mark; stop\` — no branching, just tape mutation + head advance. |
| Moderate | \`walk-mark\` (existing) | Uses \`check(then, else)\` to loop while marked, then \`mark\` at the first blank. |
| Composed | \`call-subroutine\` (new) | String-keyed \`walkToBlank\` subroutine called twice from main. Subgraph frame highlights once per call. |

All six descriptions are terse one-liners (per the design choice locked in at brainstorm).

## Test plan

- [x] \`npm run check\` — clean
- [x] \`npm test\` — 145/145 pass
- [x] \`npm run build\` — succeeds; snippets plugin records all 6 examples without error
- [x] \`npm run test:e2e -- e2e/landing.spec.ts\` — 5/5 pass with updated panel-count assertions
- [ ] Reviewer manually visits \`/\` on the deployed preview and confirms all three Turing panels auto-play to halt cleanly + switches to Post and confirms the same

## Out of scope

- Mobile layout polish for the 3-panel grid (existing \`grid-template-columns: repeat(auto-fill, minmax(min(100%, 400px), 1fr))\` should stack cleanly)
- Phase 2 (DEMO mode retirement)