### PR TITLE
chore(release): 1.0.0-alpha.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "machines-demo",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-alpha.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "machines-demo",
-      "version": "1.0.0-alpha.19",
+      "version": "1.0.0-alpha.20",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machines-demo",
   "private": true,
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-alpha.20",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Version bump `1.0.0-alpha.19` → `1.0.0-alpha.20`. Covers the content sub-PR merged via [#89](https://github.com/mellonis/machines-demo/pull/89): six curated showcase examples replacing the alpha.19 placeholders, ordered simple → moderate → composed per engine.

- Turing: `replace-b` / `toggle-bits` (new) / `callable-subtree`
- Post: `mark-and-step` (new) / `walk-mark` / `call-subroutine` (new)

No infra / runtime changes — pure content + spec updates + E2E count assertions adjusted to 3-per-engine.

## Test plan

- [x] Phase 1 work landed via [#89](https://github.com/mellonis/machines-demo/pull/89) (145 unit + 5 E2E pass at merge)
- [ ] After merge: `gh release create v1.0.0-alpha.20 --prerelease --notes-file …`; deploy ride-along via `.github/workflows/main.yml` on master push