### PR TITLE
deps: bump upstream alphas — engine alpha.8, visuals alpha.8, post alpha.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
         "@codemirror/lint": "^6.9.6",
         "@codemirror/theme-one-dark": "^6.1.3",
         "@mermaid-js/layout-elk": "^0.2.1",
-        "@post-machine-js/machine": "^7.0.0-alpha.6",
+        "@post-machine-js/machine": "^7.0.0-alpha.7",
         "@tabler/icons": "^3.44.0",
-        "@turing-machine-js/machine": "^7.0.0-alpha.6",
-        "@turing-machine-js/visuals": "^7.0.0-alpha.7.1",
+        "@turing-machine-js/machine": "^7.0.0-alpha.8",
+        "@turing-machine-js/visuals": "^7.0.0-alpha.8",
         "codemirror": "^6.0.2",
         "mermaid": "^11.15.0",
         "svelte-codemirror-editor": "^2.1.0"
@@ -645,15 +645,15 @@
       }
     },
     "node_modules/@post-machine-js/machine": {
-      "version": "7.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@post-machine-js/machine/-/machine-7.0.0-alpha.6.tgz",
-      "integrity": "sha512-oXUIdfQnrEGOmiNXkSKm3gzLLvWwGjQZONzsomJSeF3Mr7Q7GvAOv+uFUUhg5lvfNYN8wqSHAB4XfTlqBA5w8A==",
+      "version": "7.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/@post-machine-js/machine/-/machine-7.0.0-alpha.7.tgz",
+      "integrity": "sha512-VkXNfWc+nj7WmdqcIDl9YFDjuq3nNqt04Ccs+kfNA/G/59Ws+oLO8eCAFXSSzAY6HAlwqhsavTfD9rV2I5FFCQ==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.6"
+        "@turing-machine-js/machine": "^7.0.0-alpha.8"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1071,24 +1071,24 @@
       "license": "MIT"
     },
     "node_modules/@turing-machine-js/machine": {
-      "version": "7.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-7.0.0-alpha.7.tgz",
-      "integrity": "sha512-HW2qEyjFmZbantxDguG1k8+FpjRSUk0vXNGXXVCgxCQeEMNJCndHAyOvLxp5VSk25/g8a+Q1rKwxpsc8z140UA==",
+      "version": "7.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-7.0.0-alpha.8.tgz",
+      "integrity": "sha512-/h+Wdy63+siJlEj8jEiNVIiO84cOVaDufPmMHZJUf8LaGIJYjkttqfNkOv0fGOlUYQmDic/+D81w1OZygriuFQ==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@turing-machine-js/visuals": {
-      "version": "7.0.0-alpha.7.1",
-      "resolved": "https://registry.npmjs.org/@turing-machine-js/visuals/-/visuals-7.0.0-alpha.7.1.tgz",
-      "integrity": "sha512-JgwQkHipLc1e95RNKpXZ+yPamG3JtGRqtfwHxZT0V74CKp9KnfbXBZVeaqrJvR9tyjWZbodhztLIIZWX/wjcew==",
+      "version": "7.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/visuals/-/visuals-7.0.0-alpha.8.tgz",
+      "integrity": "sha512-8wt5h8YofOIv+w/HuzoWEb7r7Hfy4iDcBw93B+zzxCIlWE4J4kN7TySTrqfnAZuQ0ICFdhKXNeSdHljl8PfMiA==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.7"
+        "@turing-machine-js/machine": "^7.0.0-alpha.8"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "@codemirror/lint": "^6.9.6",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@mermaid-js/layout-elk": "^0.2.1",
-    "@post-machine-js/machine": "^7.0.0-alpha.6",
+    "@post-machine-js/machine": "^7.0.0-alpha.7",
     "@tabler/icons": "^3.44.0",
-    "@turing-machine-js/machine": "^7.0.0-alpha.6",
-    "@turing-machine-js/visuals": "^7.0.0-alpha.7.1",
+    "@turing-machine-js/machine": "^7.0.0-alpha.8",
+    "@turing-machine-js/visuals": "^7.0.0-alpha.8",
     "codemirror": "^6.0.2",
     "mermaid": "^11.15.0",
     "svelte-codemirror-editor": "^2.1.0"


### PR DESCRIPTION
## Summary

Bump all three upstream library versions to the latest published alphas.

| Dep | From | To |
|---|---|---|
| \`@turing-machine-js/machine\` | \`^7.0.0-alpha.6\` | \`^7.0.0-alpha.8\` |
| \`@turing-machine-js/visuals\` | \`^7.0.0-alpha.7.1\` | \`^7.0.0-alpha.8\` |
| \`@post-machine-js/machine\` | \`^7.0.0-alpha.6\` | \`^7.0.0-alpha.7\` |

### What changed upstream

- **Engine alpha.7** ([turing#225](https://github.com/mellonis/turing-machine-js/pull/225)) — \`CallFrame extends State\` (additive; \`instanceof State\` preserved); \`toMermaid\` framed-wrapper emit fix ([#223](https://github.com/mellonis/turing-machine-js/issues/223), regenerated \`library-binary-numbers/states.md\`).
- **Engine alpha.8** ([turing#228](https://github.com/mellonis/turing-machine-js/pull/228)) — \`TapeSnapshot\` type + \`tapeViewport\` helper moved into the engine (was visuals; [#227](https://github.com/mellonis/turing-machine-js/issues/227)); visuals re-exports both, so existing imports keep working. \`Tape.viewport\` getter shares its centering loop with \`tapeViewport\` via an internal core.
- **Visuals alpha.8** — re-aligned to lockstep with engine alpha.8. \`SnippetPlayer\` + \`tapeViewport\` consumer surface unchanged; \`TapeSnapshot\` now re-exported from engine for backward-compat.
- **Post alpha.7** ([post#106](https://github.com/mellonis/post-machine-js/pull/106) + nested-call fix [post#107](https://github.com/mellonis/post-machine-js/pull/107)) — \`PostDebugSession.stepInstruction()\` ([#101](https://github.com/mellonis/post-machine-js/issues/101)): the Post-level program-counter step; advance to the next numbered Post instruction in the current scope. Position-independent across atomic instructions, call entries, group entries, mid-group sub-steps, inside callees, and nested calls.

### Compatibility

- No source changes in this repo. All existing imports continue to resolve via visuals's re-exports (\`TapeSnapshot\` / \`tapeViewport\`).
- \`SnippetPlayer\` from visuals alpha.7.1 still exported at alpha.8 — no breaking changes to the Snippet playback surface used by \`SnippetPanel.svelte\`.

### Test plan

- [x] \`npm run check\` — clean (616 files, 0 errors / 0 warnings)
- [x] \`npm test\` — 145/145 unit tests pass
- [x] \`npm run build\` — succeeds
- [x] \`npm run test:e2e\` — 13/13 E2E tests pass (cold-start + landing)
- [ ] Reviewer briefly verifies on the deployed preview that the showcase snippet panels still play correctly (the engine alpha.7's \`toMermaid\` framed-wrapper fix could in principle reshape the \`callable-subtree\` Turing example's rendered diagram — visual diff worth a glance)

### Sequencing with Phase 2

Phase 2 PR ([#91](https://github.com/mellonis/machines-demo/pull/91)) is still open. After this lands, [#91](https://github.com/mellonis/machines-demo/pull/91) rebases onto the updated master.