### PR TITLE
chore(release): 1.0.0-alpha.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "machines-demo",
-  "version": "1.0.0-alpha.20",
+  "version": "1.0.0-alpha.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "machines-demo",
-      "version": "1.0.0-alpha.20",
+      "version": "1.0.0-alpha.21",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machines-demo",
   "private": true,
-  "version": "1.0.0-alpha.20",
+  "version": "1.0.0-alpha.21",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Version bump \`1.0.0-alpha.20\` → \`1.0.0-alpha.21\`. Covers the upstream-alpha catchup merged via [#92](https://github.com/mellonis/machines-demo/pull/92).

- \`@turing-machine-js/machine\`: alpha.6 → alpha.8 (CallFrame + #223 toMermaid fix + TapeSnapshot/tapeViewport move)
- \`@turing-machine-js/visuals\`: alpha.7.1 → alpha.8 (lockstep re-align; SnippetPlayer + tapeViewport surface unchanged)
- \`@post-machine-js/machine\`: alpha.6 → alpha.7 (stepInstruction(); not yet consumed by the demo UI)

No source changes — pure dep catchup.

## Test plan

- [x] All work landed via [#92](https://github.com/mellonis/machines-demo/pull/92) (145 unit + 13 E2E pass at merge)
- [ ] After merge: \`gh release create v1.0.0-alpha.21 --prerelease --notes-file …\`; deploy ride-along via \`.github/workflows/main.yml\` on master push