### PR TITLE
chore(release): 1.0.0-alpha.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "machines-demo",
-  "version": "1.0.0-alpha.21",
+  "version": "1.0.0-alpha.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "machines-demo",
-      "version": "1.0.0-alpha.21",
+      "version": "1.0.0-alpha.22",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machines-demo",
   "private": true,
-  "version": "1.0.0-alpha.21",
+  "version": "1.0.0-alpha.22",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Version bump \`1.0.0-alpha.21\` → \`1.0.0-alpha.22\`. Ships Phase 2 of [#79](https://github.com/mellonis/machines-demo/issues/79) — the DEMO mode retirement merged via [#91](https://github.com/mellonis/machines-demo/pull/91).

- Engine pages (\`/turing\`, \`/post\`) boot to MANUAL — no auto-running random-command loop on first paint.
- New 4-tier boot priority: \`?example=<id>\` > \`?snippet=<id>\` > localStorage > first bundled example.
- \`demoLoop.ts\` deleted; \`'DEMO'\` removed from \`ExecutionMode\` (canonical + 2 local mirrors); \`userTookControl\` flag removed; \`ControlPanel.flashApply()\` deleted.
- New \`computeInitialBoot()\` pure helper in \`src/lib/initialBoot.ts\` with 6 unit tests; 2 new E2E tests (\`M-boot-no-demo\`, \`E-boot-example-query\`).
- \`docs/execution-model.md\` rewritten — 5-mode state machine (was 7); DEMO + IDLE sections deleted; \`userTookControl\` flag entry deleted.

With this release, **machines-demo#79 is fully done** — landing page (alpha.19, Phase 1) + curated content (alpha.20) + DEMO retirement (alpha.22, Phase 2).

## Test plan

- [x] All work landed via [#91](https://github.com/mellonis/machines-demo/pull/91) (151 unit + 15 E2E pass at merge against rebased master)
- [ ] After merge: \`gh release create v1.0.0-alpha.22 --prerelease …\`; deploy ride-along via \`.github/workflows/main.yml\` on master push
- [ ] Reviewer manually verifies on the deployed preview: \`/turing\` loads with a static tape (no animation); clicking Step advances; \`/turing?example=toggle-bits\` loads the toggle-bits example