### PR TITLE
deps: bump engine + visuals + post to v7.0.0 stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
         "@codemirror/lint": "^6.9.6",
         "@codemirror/theme-one-dark": "^6.1.3",
         "@mermaid-js/layout-elk": "^0.2.1",
-        "@post-machine-js/machine": "^7.0.0-alpha.7",
+        "@post-machine-js/machine": "^7.0.0",
         "@tabler/icons": "^3.44.0",
-        "@turing-machine-js/machine": "^7.0.0-alpha.8",
-        "@turing-machine-js/visuals": "^7.0.0-alpha.8",
+        "@turing-machine-js/machine": "^7.0.0",
+        "@turing-machine-js/visuals": "^7.0.0",
         "codemirror": "^6.0.2",
         "mermaid": "^11.15.0",
         "svelte-codemirror-editor": "^2.1.0"
@@ -645,15 +645,15 @@
       }
     },
     "node_modules/@post-machine-js/machine": {
-      "version": "7.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@post-machine-js/machine/-/machine-7.0.0-alpha.7.tgz",
-      "integrity": "sha512-VkXNfWc+nj7WmdqcIDl9YFDjuq3nNqt04Ccs+kfNA/G/59Ws+oLO8eCAFXSSzAY6HAlwqhsavTfD9rV2I5FFCQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@post-machine-js/machine/-/machine-7.0.0.tgz",
+      "integrity": "sha512-dkA9hjsCr0GoP6kioE35mIDbMQ/lJC/pqHcNXdCGlNUW8y9mop80eQ+8uSJ9e5SZTpi8Fz5m4U7B2J8Cro/l9Q==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.8"
+        "@turing-machine-js/machine": "^7.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1071,24 +1071,24 @@
       "license": "MIT"
     },
     "node_modules/@turing-machine-js/machine": {
-      "version": "7.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-7.0.0-alpha.8.tgz",
-      "integrity": "sha512-/h+Wdy63+siJlEj8jEiNVIiO84cOVaDufPmMHZJUf8LaGIJYjkttqfNkOv0fGOlUYQmDic/+D81w1OZygriuFQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-7.0.0.tgz",
+      "integrity": "sha512-6W/uCgrX//pf5epUihgpMAKAr9wIdlEISTYjO/SvaDpOwatcZu/3tDUeyb9kvgZAvQdNLF9JRhZm5N2IpqCM8g==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@turing-machine-js/visuals": {
-      "version": "7.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@turing-machine-js/visuals/-/visuals-7.0.0-alpha.8.tgz",
-      "integrity": "sha512-8wt5h8YofOIv+w/HuzoWEb7r7Hfy4iDcBw93B+zzxCIlWE4J4kN7TySTrqfnAZuQ0ICFdhKXNeSdHljl8PfMiA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/visuals/-/visuals-7.0.0.tgz",
+      "integrity": "sha512-m3R6upJSXIQHXtMBdr1Nq0wg7GNoFR2jbj0F3K0G9mqW6IEF8mKMxJET1A+Bqkf6dGQqtqs+IgTF/aQRoEyDqA==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.8"
+        "@turing-machine-js/machine": "^7.0.0"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "@codemirror/lint": "^6.9.6",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@mermaid-js/layout-elk": "^0.2.1",
-    "@post-machine-js/machine": "^7.0.0-alpha.7",
+    "@post-machine-js/machine": "^7.0.0",
     "@tabler/icons": "^3.44.0",
-    "@turing-machine-js/machine": "^7.0.0-alpha.8",
-    "@turing-machine-js/visuals": "^7.0.0-alpha.8",
+    "@turing-machine-js/machine": "^7.0.0",
+    "@turing-machine-js/visuals": "^7.0.0",
     "codemirror": "^6.0.2",
     "mermaid": "^11.15.0",
     "svelte-codemirror-editor": "^2.1.0"


### PR DESCRIPTION
## Summary

Bumps the three upstream library packages from their final v7 alphas to v7.0.0 stable (npm `latest` dist-tag, published 2026-06-03):

- `@turing-machine-js/machine` 7.0.0-alpha.8 → **7.0.0** ([release](https://github.com/mellonis/turing-machine-js/releases/tag/v7.0.0))
- `@turing-machine-js/visuals` 7.0.0-alpha.8 → **7.0.0** (lockstep with engine)
- `@post-machine-js/machine` 7.0.0-alpha.7 → **7.0.0** ([release](https://github.com/mellonis/post-machine-js/releases/tag/v7.0.0))

Drop-in version bump. Each stable cut was functionally identical to its final alpha:
- engine `alpha.8 → 7.0.0` was a version-only cut (no API changes since alpha.8)
- visuals `alpha.8 → 7.0.0` was a version-only cut (lockstep with engine)
- post `alpha.7 → 7.0.0` only widened its own peer dep (no API changes)

The demo's existing imports against alpha.7/.8 continue to work byte-identically against 7.0.0. No source changes needed.

## Test plan

- [x] `npm install` resolves all three at `7.0.0` in the lockfile
- [x] `npm run check` — svelte-check 617 files, 0 errors, 0 warnings
- [x] `npm run lint` — clean
- [x] `npm test` — vitest 151/151 pass
- [x] `npm run build` — production build clean (chunk-size warnings pre-existing; mermaid bundle)
- [ ] CI green
- [ ] Manual smoke in `npm run preview`: `/`, `/turing`, `/post`, error path, persisted-code path

## Notes

- The footer `virtual:lib-versions` plugin reads each package's version dynamically at build time, so the footer will reflect `7.0.0` automatically after this merge.
- A separate `chore(release): 1.0.0-alpha.23` cut follows on its own PR per the repo's release pattern (PR #93 / PR #94 precedent).
- An unrelated `ws` advisory (moderate, transitive, pre-existing) surfaced in `npm audit` — not part of this PR's scope.

Closes #96.