### PR TITLE
a11y: quick-wins batch (#95)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -56,7 +56,9 @@
 </script>
 
 <header>
-  <h1>
+  <!-- a11y: the brand title is a persistent navigation control (returns to /),
+       not a page heading. The per-page <h1> lives in Landing or MachineView. -->
+  <div class="brand">
     <button
       type="button"
       class="home-link"
@@ -64,11 +66,12 @@
       title="Back to landing"
       aria-label="Back to landing"
     ><span class="title-prefix">machines&nbsp;</span>demo</button>
-  </h1>
+  </div>
   <nav class="tabs">
     <button
       type="button"
       class:active={route.kind === 'engine' && route.engine === 'turing'}
+      aria-current={route.kind === 'engine' && route.engine === 'turing' ? 'page' : undefined}
       onclick={() => selectRoute({ kind: 'engine', engine: 'turing' })}
     >
       Turing
@@ -76,6 +79,7 @@
     <button
       type="button"
       class:active={route.kind === 'engine' && route.engine === 'post'}
+      aria-current={route.kind === 'engine' && route.engine === 'post' ? 'page' : undefined}
       onclick={() => selectRoute({ kind: 'engine', engine: 'post' })}
     >
       Post
@@ -147,7 +151,7 @@
     padding: 12px 24px;
     border-bottom: 1px solid var(--cell-border);
 
-    h1 {
+    .brand {
       font-size: 16px;
       margin: 0;
       font-weight: 500;

--- a/src/app.css
+++ b/src/app.css
@@ -167,6 +167,31 @@
   box-sizing: border-box;
 }
 
+/* Global keyboard-focus indicator. Applies to every focusable element by
+   default so keyboard navigation is always visible. Components that already
+   render their own keyboard cue (e.g. a border-color swap on inputs) opt
+   out of the mouse-only path via `:focus:not(:focus-visible) { outline:
+   none }` — keyboard users keep the global ring, mouse clicks stay clean. */
+*:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Visually hidden, but exposed to assistive tech. Standard sr-only pattern
+   used for the per-page <h1> in MachineView (the engine name is obvious
+   visually from the active tab + brand, but needs a programmatic heading). */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 html,
 body {
   margin: 0;

--- a/src/components/ControlPanel.svelte
+++ b/src/components/ControlPanel.svelte
@@ -187,7 +187,11 @@
     border: 1px solid var(--surface-border);
     border-radius: var(--surface-radius);
     background: var(--surface-bg);
-    animation: enter var(--anim-belt-enter-ms) ease-out var(--anim-belt-enter-delay-panel-ms) backwards;
+
+    /* prefers-reduced-motion: skip the enter slide-in. */
+    @media not (prefers-reduced-motion: reduce) {
+      animation: enter var(--anim-belt-enter-ms) ease-out var(--anim-belt-enter-delay-panel-ms) backwards;
+    }
 
     /* Pointer-event suppression now lives on the `inert` attribute (see
        the .interactive div). CSS only owns the visual dim. */

--- a/src/components/Editor.svelte
+++ b/src/components/Editor.svelte
@@ -73,9 +73,8 @@
       font-size: 13px;
     }
 
-    :global(.cm-editor.cm-focused) {
-      outline: none;
-    }
+    /* CodeMirror's default focus outline removed; keyboard users still get
+       the global `:focus-visible` ring from app.css on the focused element. */
 
     :global(.cm-scroller) {
       font-family: ui-monospace, 'SF Mono', Consolas, monospace;

--- a/src/components/Landing.svelte
+++ b/src/components/Landing.svelte
@@ -36,11 +36,13 @@
     <button
       type="button"
       class:active={engine === 'turing'}
+      aria-current={engine === 'turing' ? 'page' : undefined}
       onclick={() => setEngine('turing')}
     >Turing snippets</button>
     <button
       type="button"
       class:active={engine === 'post'}
+      aria-current={engine === 'post' ? 'page' : undefined}
       onclick={() => setEngine('post')}
     >Post snippets</button>
   </nav>

--- a/src/components/Log.svelte
+++ b/src/components/Log.svelte
@@ -22,7 +22,13 @@
   {#if entries.length > 0}
     <IconButton icon="eraser" title="Clear log" onClick={onClear} />
   {/if}
-  <div class="content" bind:this={scrollEl}>
+  <div
+    class="content"
+    bind:this={scrollEl}
+    role="log"
+    aria-live="polite"
+    aria-atomic="false"
+  >
     {#each entries as entry, i (i)}
       {#if entry.separator}
         <hr class="sep" />

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -1003,6 +1003,9 @@
 </script>
 
 <section class="tab">
+  <!-- a11y: per-page <h1>. Visually hidden because the engine identity is
+       already obvious from the active tab + the visible app brand. -->
+  <h1 class="sr-only">{engine === 'turing' ? 'Turing machine demo' : 'Post machine demo'}</h1>
   <div class="panel-tape">
     <TapesStack bind:this={tapesStackRef} {tapeCount} caretColors={CARET_COLORS} />
 
@@ -1108,6 +1111,8 @@
     />
     <div
       class="status"
+      role="status"
+      aria-live="polite"
       class:error={latestEntry?.kind === 'error'}
       class:warn={latestEntry?.kind === 'warn'}
       class:ok={latestEntry?.kind === 'ok'}

--- a/src/components/SnippetPanel.svelte
+++ b/src/components/SnippetPanel.svelte
@@ -182,7 +182,8 @@
 </script>
 
 <div class="snippet-panel" bind:this={panelEl} data-testid="snippet-panel">
-  <h3 class="caption">{caption}</h3>
+  <!-- a11y: page heading hierarchy is <h1> (Landing) → <h2> (per snippet panel). -->
+  <h2 class="caption">{caption}</h2>
   <div class="graph">
     <MachineGraph
       bind:this={machineGraphRef}

--- a/src/components/Tape.svelte
+++ b/src/components/Tape.svelte
@@ -225,8 +225,12 @@
     height: 100%;
     transform: translateX(0);
 
-    &.transitions-on {
-      transition: transform var(--anim-belt-slide-ms) ease;
+    /* prefers-reduced-motion: drop the strip-slide transition; the strip
+       still translates, but the move is instant. */
+    @media not (prefers-reduced-motion: reduce) {
+      &.transitions-on {
+        transition: transform var(--anim-belt-slide-ms) ease;
+      }
     }
   }
 

--- a/src/components/TapesStack.svelte
+++ b/src/components/TapesStack.svelte
@@ -95,7 +95,11 @@
     display: flex;
     flex-direction: column;
     gap: var(--tape-gap);
-    animation: enter var(--anim-belt-enter-ms) ease-out backwards;
+
+    /* prefers-reduced-motion: skip the enter slide-in. */
+    @media not (prefers-reduced-motion: reduce) {
+      animation: enter var(--anim-belt-enter-ms) ease-out backwards;
+    }
 
     @media (max-width: 768px) { --cell-h: 36px; }
     @media (max-width: 480px) { --cell-h: 34px; }

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -444,6 +444,7 @@
         class:invalid={!intervalIsValid}
         bind:value={intervalText}
         placeholder="1s"
+        aria-label="Step interval (e.g. 1s, 250ms)"
       />
     {/if}
     <label class="checkbox" title="When on, breaks set via state.debug pause execution at a Continue/Step prompt.">
@@ -688,8 +689,13 @@
       border-radius: 4px;
 
       &:focus {
-        outline: none;
         border-color: var(--accent);
+      }
+
+      /* Mouse-only focus suppression — border-color swap is enough cue for
+         mouse users. Keyboard focus keeps the global `:focus-visible` ring. */
+      &:focus:not(:focus-visible) {
+        outline: none;
       }
 
       &.conflict {
@@ -818,8 +824,13 @@
       box-sizing: border-box;
 
       &:focus {
-        outline: none;
         border-color: var(--accent);
+      }
+
+      /* Mouse-only focus suppression — border-color swap is enough cue for
+         mouse users. Keyboard focus keeps the global `:focus-visible` ring. */
+      &:focus:not(:focus-visible) {
+        outline: none;
       }
     }
 
@@ -956,8 +967,13 @@
     border-radius: 4px;
 
     &:focus {
-      outline: none;
       border-color: var(--accent);
+    }
+
+    /* Mouse-only focus suppression — border-color swap is enough cue for
+       mouse users. Keyboard focus keeps the global `:focus-visible` ring. */
+    &:focus:not(:focus-visible) {
+      outline: none;
     }
 
     &.invalid {


### PR DESCRIPTION
First of three PRs decomposing the a11y audit baseline (#95). Six low-risk quick wins; no structural state changes.

## Changes

- **M1 — Log + status mirror as live regions.** `role="log" aria-live="polite" aria-atomic="false"` on the Log content container; `role="status" aria-live="polite"` on the mobile `.status` mirror in `MachineView`. Errors/halts now announce.
- **M2 — Interval input accessible name.** `aria-label="Step interval (e.g. 1s, 250ms)"` on the with-pause interval input (the `"1s"` placeholder isn't announced).
- **M3 — `aria-current="page"` on active engine tab.** Both `App.svelte` header tabs and `Landing.svelte` engine switcher; mirrors the existing `.active` styling cue programmatically.
- **M5 — Global `:focus-visible` policy.** Added `*:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px }` in `app.css`. Removed the explicit `outline: none` suppressions in `Editor` (CodeMirror) and `Toolbar` inputs. Mouse-only suppression preserved via `&:focus:not(:focus-visible)` on the three Toolbar inputs that already swap `border-color` on focus.
- **M6 — Heading hierarchy.** Demoted App's brand `<h1>` to a `<div class="brand">` (it's a persistent navigation control, not a page heading); promoted/added a per-page `<h1>` in MachineView (visually hidden via new `.sr-only` utility — engine identity is already obvious from the active tab + brand); kept Landing's `<h1>`; bumped `SnippetPanel <h3>` → `<h2>` so the landing hierarchy reads `h1` → `h2`.
- **`prefers-reduced-motion` gates.** Added on `Tape.svelte` strip-slide transition, `TapesStack.svelte` enter keyframes, `ControlPanel.svelte` enter keyframes. Joins the existing gates on `Tape` write-flash and `SnippetPanel` auto-play.

## Verification

- [x] `npm run check` — svelte-check 0 errors, 0 warnings (617 files)
- [x] `npm run lint` — clean
- [x] `npm test` — 151/151 pass (no test updates needed — `SnippetPanel` tests use `getByText`, not heading-role queries)
- [x] `npm run build` — production build clean (chunk-size warning pre-existing)

## Out of scope (follow-up PRs under #95)

- **B1 — Graph text-alt surface** — PR 2.
- **B2 — Graph expanded panel as `<dialog>`** + **M4 — Save popover as `<dialog>`** — PR 3 (both need structural state-management changes; bundled together because they share the `<dialog>` pattern).

Refs #95.