### PR TITLE
a11y: structural batch — graph text alt + native <dialog> swaps (#95 B1 + B2 + M4)

### DIFF
--- a/src/components/MachineGraph.svelte
+++ b/src/components/MachineGraph.svelte
@@ -1179,7 +1179,7 @@
     <section class="sr-only" aria-label="Machine graph text representation">
       <p>
         State diagram with {summary.stateCount}
-        {summary.stateCount === 1 ? 'state' : 'states'}{#if summary.haltCount > 0}, {summary.haltCount} halt {summary.haltCount === 1 ? 'marker' : 'markers'}{/if}.
+        {summary.stateCount === 1 ? 'state' : 'states'}{#if summary.hasHalt}, ending at halt{/if}.
       </p>
       {#if summary.states.length > 0}
         <ol>

--- a/src/components/MachineGraph.svelte
+++ b/src/components/MachineGraph.svelte
@@ -15,6 +15,7 @@
   import type { BreakpointKind } from '../lib/types.ts';
   import { theme } from '../lib/theme.svelte.ts';
   import { icons } from '../lib/icons.ts';
+  import { summariseGraph } from '../lib/graphSummary.ts';
 
   type Props = {
     graph: Graph | null;
@@ -91,6 +92,12 @@
     readOnly = false,
     onReady,
   }: Props = $props();
+
+  // Screen-reader-friendly summary of the graph (machines-demo#95 B1).
+  // The rendered SVG carries no text alternative; this is the parallel
+  // structural view AT users get. Rendered into the `.sr-only` block
+  // below — visible UI unchanged.
+  const summary = $derived(graph ? summariseGraph(graph) : null);
 
   const instanceId = `mg-${nextInstanceCounter()}`;
   let mermaidModule: typeof import('mermaid').default | null = $state(null);
@@ -1162,6 +1169,42 @@
       </div>
     {/if}
   </header>
+
+  {#if summary}
+    <!-- a11y: text alternative for the rendered SVG (machines-demo#95 B1).
+         Always rendered when a graph exists — must remain available when
+         visually collapsed, since the rendered SVG is the only path for
+         sighted users and this is the only path for AT users. Derived
+         purely from the engine `Graph` snapshot via `summariseGraph`. -->
+    <section class="sr-only" aria-label="Machine graph text representation">
+      <p>
+        State diagram with {summary.stateCount}
+        {summary.stateCount === 1 ? 'state' : 'states'}{#if summary.haltCount > 0}, {summary.haltCount} halt {summary.haltCount === 1 ? 'marker' : 'markers'}{/if}.
+      </p>
+      {#if summary.states.length > 0}
+        <ol>
+          {#each summary.states as state (state.id)}
+            <li>
+              <strong>{state.name}</strong>{#if state.isWrapper}
+                — wrapper, calls subroutine
+              {/if}
+              {#if state.transitions.length === 0}
+                <span> — no outgoing transitions</span>
+              {:else}
+                <ul>
+                  {#each state.transitions as t, ix (ix)}
+                    <li>
+                      On {t.readsPhrase}: {t.commandsPhrase}, then goes to <strong>{t.targetName}</strong>.
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            </li>
+          {/each}
+        </ol>
+      {/if}
+    </section>
+  {/if}
 
   {#if !collapsed}
     <!-- role="application" tells AT this region has its own keyboard /

--- a/src/components/MachineGraph.svelte
+++ b/src/components/MachineGraph.svelte
@@ -1346,24 +1346,12 @@
     overflow: hidden;
   }
 
-  /* Expanded ("modal") mode: same DOM node, fixed-positioned over the
-     viewport. Single MachineGraph instance — no second mermaid render,
-     no DOM move, no duplicate effect pipelines (machines-demo#9 +
-     post-#37 follow-up). The inline slot the panel normally occupies
-     goes empty during expansion; the parent renders a dimmed backdrop
-     under this z-index so the rest of the app reads as modal. */
-  .machine-graph.expanded {
-    position: fixed;
-    top: 10vh;
-    left: 10vw;
-    width: 80vw;
-    height: 80vh;
-    z-index: 50;
-    box-shadow: 0 8px 32px rgb(0 0 0 / 0.3);
-  }
-  /* Let the body fill the remaining card height in expanded mode so the
-     graph uses the modal's full visible area (default `.body` is a
-     fixed 360px). */
+  /* Expanded ("modal") mode: the parent renders this component inside a
+     native <dialog> (machines-demo#9 → #95 B2). The dialog provides the
+     centered 80vw × 80vh box, focus trap, Escape, and ::backdrop dimmer;
+     all this component does in expanded mode is fill its container and
+     drop the inline 360px body cap so the graph uses the modal's full
+     height. */
   .machine-graph.expanded .body {
     height: auto;
     flex: 1 1 auto;

--- a/src/components/MachineGraph.svelte
+++ b/src/components/MachineGraph.svelte
@@ -1179,7 +1179,7 @@
     <section class="sr-only" aria-label="Machine graph text representation">
       <p>
         State diagram with {summary.stateCount}
-        {summary.stateCount === 1 ? 'state' : 'states'}{#if summary.hasHalt}, ending at halt{/if}.
+        {summary.stateCount === 1 ? 'state' : 'states'}{#if summary.haltCount > 0}, {summary.haltCount} halt {summary.haltCount === 1 ? 'node' : 'nodes'}{/if}.
       </p>
       {#if summary.states.length > 0}
         <ol>

--- a/src/components/MachineGraph.test.ts
+++ b/src/components/MachineGraph.test.ts
@@ -29,6 +29,48 @@ const STUB_GRAPH = {
   nodes: {},
 } as never; // structural-cast — the component only forwards to toMermaid
 
+// Minimal two-state graph for the text-alternative test (#95 B1). Shape
+// mirrors the engine's `Graph` type — see `@turing-machine-js/machine`'s
+// `utilities/graph.d.ts`. `pattern` / `command[].symbol` / `.movement`
+// strings are the engine's pre-decoded edge-label vocabulary.
+const SUMMARY_GRAPH = {
+  initialId: 1,
+  alphabets: [[' ', 'a', 'b']],
+  nodes: {
+    1: {
+      id: 1,
+      name: 'q0',
+      isHalt: false,
+      isHaltMarker: false,
+      isWrapper: false,
+      bareStateId: null,
+      frameId: null,
+      overriddenHaltStateId: null,
+      tags: [],
+      transitions: [
+        {
+          id: '1.0',
+          pattern: "'a'",
+          command: [{ symbol: "'b'", movement: 'R' }],
+          nextStateId: 2,
+        },
+      ],
+    },
+    2: {
+      id: 2,
+      name: 'q1',
+      isHalt: false,
+      isHaltMarker: false,
+      isWrapper: false,
+      bareStateId: null,
+      frameId: null,
+      overriddenHaltStateId: null,
+      tags: [],
+      transitions: [],
+    },
+  },
+} as never;
+
 describe('MachineGraph (component smoke)', () => {
   afterEach(() => cleanup());
 
@@ -94,5 +136,32 @@ describe('MachineGraph (component smoke)', () => {
       onExpand: () => {},
     });
     expect(screen.queryByLabelText('Open machine graph in modal')).not.toBeInTheDocument();
+  });
+
+  it('C-graph-sr-summary: renders the screen-reader text alternative', () => {
+    render(MachineGraph, {
+      graph: SUMMARY_GRAPH,
+      collapsed: false,
+      onToggleCollapsed: () => {},
+      onExpand: () => {},
+    });
+    const summary = screen.getByLabelText('Machine graph text representation');
+    expect(summary).toBeInTheDocument();
+    expect(summary).toHaveTextContent(/2 states/);
+    expect(summary).toHaveTextContent(/q0/);
+    expect(summary).toHaveTextContent(/q1/);
+  });
+
+  it('C-graph-sr-summary-collapsed: text alternative stays available when visually collapsed', () => {
+    render(MachineGraph, {
+      graph: SUMMARY_GRAPH,
+      collapsed: true,
+      onToggleCollapsed: () => {},
+      onExpand: () => {},
+    });
+    // The visual body is hidden (covered by C-graph-collapsed-hides-body
+    // above), but the text alternative must remain — for AT users the
+    // collapsed state shouldn't drop the entire structural view.
+    expect(screen.getByLabelText('Machine graph text representation')).toBeInTheDocument();
   });
 });

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -79,6 +79,19 @@
   let graph = $state<Graph | null>(null);
   let graphCollapsed = $state(untrack(() => initialGraphCollapsed(engine)));
   let graphModalOpen = $state(false);
+  // Native <dialog> ref for the expanded-graph modal (machines-demo#95 B2).
+  // Replaces the previous `<div role="presentation">` backdrop + manual
+  // Escape / outside-click handlers — `showModal()` gives focus trap,
+  // Escape, return-focus to the opener, and scroll-lock for free, and
+  // the browser's `cancel`/`close` events keep `graphModalOpen` in sync
+  // with user-driven closes (Escape, ::backdrop click).
+  let graphDialog = $state<HTMLDialogElement | null>(null);
+  $effect(() => {
+    const dialog = graphDialog;
+    if (!dialog) return;
+    if (graphModalOpen && !dialog.open) dialog.showModal();
+    else if (!graphModalOpen && dialog.open) dialog.close();
+  });
   // Monotonic iter counter, mirrored from worker responses (idle / paused /
   // ran). Passed to MachineGraph purely as a reactivity tick: when two
   // consecutive paused events have identical currentStateId / nextStateId /
@@ -1009,20 +1022,38 @@
   <div class="panel-tape">
     <TapesStack bind:this={tapesStackRef} {tapeCount} caretColors={CARET_COLORS} />
 
-    {#if graphModalOpen}
-      <!-- Single-instance expanded mode (machines-demo#9 + post-#37
-           follow-up): the same inline `<MachineGraph>` below detaches
-           via `expanded` prop into a fixed-positioned panel. This div
-           is just the dimmed backdrop + click-out / Esc close affordance.
-           The graph itself sits at z-index 50 above this backdrop. -->
-      <div
-        class="graph-modal-backdrop"
-        role="presentation"
-        onclick={() => { graphModalOpen = false; }}
-        onkeydown={(e) => { if (e.key === 'Escape') graphModalOpen = false; }}
-        tabindex="-1"
-      ></div>
-    {/if}
+    <!-- Expanded ("modal") graph (machines-demo#9 + post-#37, reshaped
+         for #95 B2). Native <dialog> opened via `showModal()` — browser
+         provides focus trap, Escape, return-focus to the opener, and
+         scroll-lock. `oncancel`/`onclose` mirror user-driven closes
+         (Escape, ::backdrop programmatic close) back to `graphModalOpen`
+         so the component state stays the source of truth. When closed,
+         the inline `<MachineGraph>` below renders normally; when open,
+         it renders inside the dialog instead (single instance at a time,
+         re-render on toggle is the cost of the focus-trap a11y win). -->
+    <dialog
+      bind:this={graphDialog}
+      class="graph-dialog"
+      aria-label="Machine graph"
+      onclose={() => { graphModalOpen = false; }}
+      oncancel={() => { graphModalOpen = false; }}
+    >
+      {#if graphModalOpen}
+        <MachineGraph
+          {graph}
+          highlight={graphHighlight}
+          {stepsApplied}
+          breakpoints={breakpointIndicatorSet}
+          breakpointKinds={breakpoints}
+          {onToggleBreakpoint}
+          collapsed={graphCollapsed}
+          onToggleCollapsed={() => { graphCollapsed = !graphCollapsed; }}
+          expanded={true}
+          onExpand={() => { graphModalOpen = false; }}
+          onRenderError={(msg: string) => log.report(msg, 'error')}
+        />
+      {/if}
+    </dialog>
 
     <div class="panel-enter-clip">
       <ControlPanel
@@ -1065,19 +1096,21 @@
     </div>
 
     <div class="machine-graph-row">
-      <MachineGraph
-        {graph}
-        highlight={graphHighlight}
-        {stepsApplied}
-        breakpoints={breakpointIndicatorSet}
-        breakpointKinds={breakpoints}
-        {onToggleBreakpoint}
-        collapsed={graphCollapsed}
-        onToggleCollapsed={() => { graphCollapsed = !graphCollapsed; }}
-        expanded={graphModalOpen}
-        onExpand={() => { graphModalOpen = !graphModalOpen; }}
-        onRenderError={(msg: string) => log.report(msg, 'error')}
-      />
+      {#if !graphModalOpen}
+        <MachineGraph
+          {graph}
+          highlight={graphHighlight}
+          {stepsApplied}
+          breakpoints={breakpointIndicatorSet}
+          breakpointKinds={breakpoints}
+          {onToggleBreakpoint}
+          collapsed={graphCollapsed}
+          onToggleCollapsed={() => { graphCollapsed = !graphCollapsed; }}
+          expanded={false}
+          onExpand={() => { graphModalOpen = true; }}
+          onRenderError={(msg: string) => log.report(msg, 'error')}
+        />
+      {/if}
     </div>
 
     <Log entries={log.entries} onClear={() => log.clear()} />
@@ -1169,16 +1202,33 @@
     margin-top: 12px;
   }
 
-  /* Backdrop for the expanded MachineGraph panel (#9 — single-instance
-     redesign). The graph itself is rendered by MachineGraph at z-index
-     50; this sits just below at 49 so clicks outside the graph land
-     here and trigger close. No flex / no padding — the backdrop just
-     dims the viewport. */
-  .graph-modal-backdrop {
-    position: fixed;
-    inset: 0;
+  /* Native <dialog> for the expanded MachineGraph (#9 → #95 B2). Sized
+     to mirror the previous fixed-positioned panel (80vw × 80vh, centered).
+     `<dialog>` opened via `showModal()` is placed in the browser's top
+     layer with implicit aria-modal + focus trap + Escape; the centering
+     comes from the UA stylesheet (`margin: auto`). Override the UA's
+     default padding so the inner MachineGraph fills the dialog and its
+     own border + radius show as the modal surface. `::backdrop` is the
+     dimmer — replaces the previous `.graph-modal-backdrop` div. */
+  .graph-dialog {
+    width: 80vw;
+    height: 80vh;
+    max-width: none;
+    max-height: none;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    overflow: visible;
+    box-shadow: 0 8px 32px rgb(0 0 0 / 0.3);
+  }
+
+  .graph-dialog::backdrop {
     background: rgba(0, 0, 0, 0.5);
-    z-index: 49;
+  }
+
+  .graph-dialog :global(.machine-graph) {
+    width: 100%;
+    height: 100%;
   }
 
   /* Clips the control-panel's enter animation so translateY(20px) can't

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -93,8 +93,22 @@
   let saveOpen = $state(false);
   let saveName = $state('');
   let pendingOverwrite = $state(false);
-  let saveMenuEl: HTMLDivElement | undefined;
   let nameInputEl = $state<HTMLInputElement | undefined>(undefined);
+  // Native <dialog> ref for the save popover (machines-demo#95 M4).
+  // Opened via showModal() so the browser handles focus trap, native
+  // Escape (via the cancel event), return-focus to the save button on
+  // close, and scroll-lock. Positioning uses CSS anchor positioning
+  // (Baseline newly available — Chrome 125+, Safari 18+); Firefox
+  // without anchor support falls back to UA-centered <dialog> default,
+  // which still functions correctly (just not anchored under the save
+  // button).
+  let saveDialogEl = $state<HTMLDialogElement | null>(null);
+  $effect(() => {
+    const dialog = saveDialogEl;
+    if (!dialog) return;
+    if (saveOpen && !dialog.open) dialog.showModal();
+    else if (!saveOpen && dialog.open) dialog.close();
+  });
 
   const loadedSnippet = $derived(
     loadedSnippetId !== null ? snippets[loadedSnippetId] ?? null : null,
@@ -103,22 +117,6 @@
   const snippetTitles = $derived(new Set(Object.values(snippets).map((s) => s.title)));
   const saveNameExists = $derived(trimmedName !== '' && snippetTitles.has(trimmedName));
   const saveEnabled = $derived(trimmedName !== '');
-
-  $effect(() => {
-    if (!saveOpen) return;
-    const onPointer = (e: MouseEvent): void => {
-      if (!saveMenuEl?.contains(e.target as Node)) closeSavePopover();
-    };
-    const onKey = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') closeSavePopover();
-    };
-    document.addEventListener('mousedown', onPointer);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onPointer);
-      document.removeEventListener('keydown', onKey);
-    };
-  });
 
   $effect(() => {
     if (saveOpen && nameInputEl) nameInputEl.focus();
@@ -367,7 +365,7 @@
     {/if}
   </div>
 
-  <div class="save-menu" bind:this={saveMenuEl}>
+  <div class="save-menu">
     <button
       type="button"
       class="icon-only"
@@ -380,43 +378,53 @@
     >
       {@html icons.saveFloppy}
     </button>
-    {#if saveOpen}
-      <div class="save-popover" role="dialog" aria-label="Save snippet">
-        {#if loadedSnippet !== null}
-          <button
-            type="button"
-            class="save-changes"
-            disabled={!dirty}
-            onclick={() => { onSaveChanges(); closeSavePopover(); }}
-          >
-            Save changes to "{loadedSnippet.title}"
-          </button>
-          <div class="popover-section-label">or save as new</div>
-        {/if}
-        <input
-          type="text"
-          bind:this={nameInputEl}
-          bind:value={saveName}
-          placeholder="Snippet name"
-          maxlength="80"
-          onkeydown={(e) => {
-            if (e.key === 'Enter') doSave();
-            if (e.key === 'Escape') closeSavePopover();
-          }}
-        />
-        {#if pendingOverwrite}
-          <div class="overwrite-confirm">
-            <span>Overwrite "{trimmedName}"?</span>
-            <button type="button" class="confirm-yes" onclick={doSave}>Yes</button>
-            <button type="button" onclick={() => (pendingOverwrite = false)}>No</button>
-          </div>
-        {:else}
-          <button type="button" disabled={!saveEnabled} onclick={doSave}>
-            {loadedSnippet !== null ? 'Save as new' : 'Save'}
-          </button>
-        {/if}
-      </div>
-    {/if}
+    <!-- Native <dialog> with showModal() — focus trap, return-focus to the
+         save button, and native Escape handling are all UA-provided.
+         Backdrop click closes via the onclick handler (e.target is the
+         dialog itself when the click hits the ::backdrop, not when it
+         hits content inside the dialog). Positioning is anchored to the
+         save button via CSS anchor positioning; Firefox without anchor
+         support falls back to UA-centered dialog placement. -->
+    <dialog
+      bind:this={saveDialogEl}
+      class="save-popover"
+      aria-label="Save snippet"
+      oncancel={(e) => { e.preventDefault(); closeSavePopover(); }}
+      onclick={(e) => { if (e.target === saveDialogEl) closeSavePopover(); }}
+    >
+      {#if loadedSnippet !== null}
+        <button
+          type="button"
+          class="save-changes"
+          disabled={!dirty}
+          onclick={() => { onSaveChanges(); closeSavePopover(); }}
+        >
+          Save changes to "{loadedSnippet.title}"
+        </button>
+        <div class="popover-section-label">or save as new</div>
+      {/if}
+      <input
+        type="text"
+        bind:this={nameInputEl}
+        bind:value={saveName}
+        placeholder="Snippet name"
+        maxlength="80"
+        onkeydown={(e) => {
+          if (e.key === 'Enter') doSave();
+        }}
+      />
+      {#if pendingOverwrite}
+        <div class="overwrite-confirm">
+          <span>Overwrite "{trimmedName}"?</span>
+          <button type="button" class="confirm-yes" onclick={doSave}>Yes</button>
+          <button type="button" onclick={() => (pendingOverwrite = false)}>No</button>
+        </div>
+      {:else}
+        <button type="button" disabled={!saveEnabled} onclick={doSave}>
+          {loadedSnippet !== null ? 'Save as new' : 'Save'}
+        </button>
+      {/if}
+    </dialog>
   </div>
 
   <button type="button" disabled={loadDisabled} onclick={onBuild}>
@@ -793,15 +801,31 @@
   }
 
   .save-menu {
-    position: relative;
     display: inline-flex;
+
+    /* Anchor target for the save popover dialog (machines-demo#95 M4).
+       The popover is a native <dialog> opened via showModal(), so it
+       renders in the top layer and uses CSS anchor positioning to
+       attach below the save button. Firefox without anchor-positioning
+       support falls back to UA-centered dialog placement. */
+    > button:first-child {
+      anchor-name: --save-button-anchor;
+    }
   }
 
   .save-popover {
-    position: absolute;
-    top: calc(100% + 4px);
-    left: 0;
-    z-index: 20;
+    /* Override the UA-default <dialog> styling: borderless container
+       (border re-added below), no default padding/margin, no max-width
+       constraint. The element renders in the top layer when opened via
+       showModal(); anchor positioning attaches it to the save button. */
+    position: fixed;
+    position-anchor: --save-button-anchor;
+    top: anchor(bottom);
+    left: anchor(start);
+    margin: 4px 0 0 0;
+    max-width: none;
+    max-height: none;
+    inset: auto;
     display: flex;
     flex-direction: column;
     gap: 6px;
@@ -811,6 +835,13 @@
     border: 1px solid var(--surface-border);
     border-radius: 6px;
     box-shadow: 0 8px 24px var(--shadow);
+
+    /* Hide ::backdrop — anchored popover shouldn't dim the page behind
+       it. Click on the (transparent) backdrop still closes via the
+       onclick handler on the <dialog>. */
+    &::backdrop {
+      background: transparent;
+    }
 
     input[type='text'] {
       background: var(--cell-bg);

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -843,6 +843,13 @@
       background: transparent;
     }
 
+    /* Restore the UA-default `dialog:not([open]) { display: none }` that
+       the `display: flex` rule above would otherwise override. Without
+       this the popover stays rendered (and visible) even when closed. */
+    &:not([open]) {
+      display: none;
+    }
+
     input[type='text'] {
       background: var(--cell-bg);
       border: 1px solid var(--cell-border);

--- a/src/lib/graphSummary.test.ts
+++ b/src/lib/graphSummary.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { summariseGraph } from './graphSummary';
+
+// Minimal Graph fixture builder — mirrors `@turing-machine-js/machine`'s
+// `Graph` shape (see `utilities/graph.d.ts`). String fields use the
+// engine's pre-decoded edge-label vocabulary so the summariser's input
+// shape matches what `toGraph` actually emits at runtime.
+function makeGraph(nodes: Record<number, unknown>): never {
+  return {
+    initialId: Object.keys(nodes).map(Number)[0] ?? 0,
+    alphabets: [[' ', 'a', 'b']],
+    nodes,
+  } as never;
+}
+
+describe('summariseGraph', () => {
+  it('R-summary-counts: counts regular states and groups halt markers', () => {
+    const g = makeGraph({
+      1: {
+        id: 1, name: 'q0', isHalt: false, isHaltMarker: false, isWrapper: false,
+        bareStateId: null, frameId: null, overriddenHaltStateId: null, tags: [],
+        transitions: [],
+      },
+      2: {
+        id: 2, name: 'q1', isHalt: false, isHaltMarker: false, isWrapper: false,
+        bareStateId: null, frameId: null, overriddenHaltStateId: null, tags: [],
+        transitions: [],
+      },
+      [-1]: {
+        id: -1, name: 'halt', isHalt: false, isHaltMarker: true, isWrapper: false,
+        bareStateId: null, frameId: null, overriddenHaltStateId: null, tags: [],
+        transitions: [],
+      },
+    });
+    const summary = summariseGraph(g);
+    expect(summary.stateCount).toBe(2);
+    expect(summary.haltCount).toBe(1);
+    expect(summary.states.map((s) => s.name)).toEqual(['q0', 'q1']);
+  });
+
+  it('R-summary-literal: decodes literal read + literal write + move', () => {
+    const g = makeGraph({
+      1: {
+        id: 1, name: 'q0', isHalt: false, isHaltMarker: false, isWrapper: false,
+        bareStateId: null, frameId: null, overriddenHaltStateId: null, tags: [],
+        transitions: [
+          {
+            id: '1.0',
+            pattern: "'a'",
+            command: [{ symbol: "'b'", movement: 'R' }],
+            nextStateId: 2,
+          },
+        ],
+      },
+      2: {
+        id: 2, name: 'q1', isHalt: false, isHaltMarker: false, isWrapper: false,
+        bareStateId: null, frameId: null, overriddenHaltStateId: null, tags: [],
+        transitions: [],
+      },
+    });
+    const [q0] = summariseGraph(g).states;
+    expect(q0.transitions[0].readsPhrase).toBe("'a'");
+    expect(q0.transitions[0].commandsPhrase).toBe("writes 'b', moves right");
+    expect(q0.transitions[0].targetName).toBe('q1');
+  });
+
+  it('R-summary-wildcard-and-blank-and-keep: read shortcuts and write sentinels', () => {
+    const g = makeGraph({
+      1: {
+        id: 1, name: 'q0', isHalt: false, isHaltMarker: false, isWrapper: false,
+        bareStateId: null, frameId: null, overriddenHaltStateId: null, tags: [],
+        transitions: [
+          { id: '1.0', pattern: '*', command: [{ symbol: 'K', movement: 'S' }], nextStateId: 1 },
+          { id: '1.1', pattern: 'B', command: [{ symbol: 'E', movement: 'L' }], nextStateId: 1 },
+          { id: '1.2', pattern: "*='c'", command: [{ symbol: "K='c'", movement: 'R' }], nextStateId: 1 },
+        ],
+      },
+    });
+    const [q0] = summariseGraph(g).states;
+    expect(q0.transitions[0].readsPhrase).toBe('any symbol');
+    expect(q0.transitions[0].commandsPhrase).toBe('keeps current symbol, stays');
+    expect(q0.transitions[1].readsPhrase).toBe('blank');
+    expect(q0.transitions[1].commandsPhrase).toBe('erases, moves left');
+    expect(q0.transitions[2].readsPhrase).toBe("any symbol (matched 'c')");
+    expect(q0.transitions[2].commandsPhrase).toBe("keeps current symbol ('c'), moves right");
+  });
+
+  it('R-summary-target-halt: halt target rendered as "halt"', () => {
+    const g = makeGraph({
+      1: {
+        id: 1, name: 'q0', isHalt: false, isHaltMarker: false, isWrapper: false,
+        bareStateId: null, frameId: null, overriddenHaltStateId: null, tags: [],
+        transitions: [
+          { id: '1.0', pattern: "'a'", command: [{ symbol: 'K', movement: 'S' }], nextStateId: -1 },
+        ],
+      },
+      [-1]: {
+        id: -1, name: 'halt', isHalt: false, isHaltMarker: true, isWrapper: false,
+        bareStateId: null, frameId: null, overriddenHaltStateId: null, tags: [],
+        transitions: [],
+      },
+    });
+    const [q0] = summariseGraph(g).states;
+    expect(q0.transitions[0].targetName).toBe('halt');
+  });
+
+  it('R-summary-multi-tape: per-tape labels in reads + commands', () => {
+    const g = makeGraph({
+      1: {
+        id: 1, name: 'q0', isHalt: false, isHaltMarker: false, isWrapper: false,
+        bareStateId: null, frameId: null, overriddenHaltStateId: null, tags: [],
+        transitions: [
+          {
+            id: '1.0',
+            pattern: "'a','b'",
+            command: [
+              { symbol: "'b'", movement: 'R' },
+              { symbol: "'a'", movement: 'L' },
+            ],
+            nextStateId: 1,
+          },
+        ],
+      },
+    });
+    const [q0] = summariseGraph(g).states;
+    expect(q0.transitions[0].readsPhrase).toBe("'a' on tape 1, 'b' on tape 2");
+    expect(q0.transitions[0].commandsPhrase).toBe("tape 1: writes 'b', moves right; tape 2: writes 'a', moves left");
+  });
+});

--- a/src/lib/graphSummary.test.ts
+++ b/src/lib/graphSummary.test.ts
@@ -14,7 +14,7 @@ function makeGraph(nodes: Record<number, unknown>): never {
 }
 
 describe('summariseGraph', () => {
-  it('R-summary-counts: counts regular states and groups halt markers', () => {
+  it('R-summary-counts: counts regular states and excludes halt markers', () => {
     const g = makeGraph({
       1: {
         id: 1, name: 'q0', isHalt: false, isHaltMarker: false, isWrapper: false,
@@ -34,8 +34,40 @@ describe('summariseGraph', () => {
     });
     const summary = summariseGraph(g);
     expect(summary.stateCount).toBe(2);
-    expect(summary.haltCount).toBe(1);
+    expect(summary.hasHalt).toBe(true);
     expect(summary.states.map((s) => s.name)).toEqual(['q0', 'q1']);
+  });
+
+  it('R-summary-halt-singleton: excludes the haltState singleton (isHalt: true) from states', () => {
+    const g = makeGraph({
+      0: {
+        id: 0, name: 'id:0', isHalt: true, isHaltMarker: false, isWrapper: false,
+        bareStateId: null, frameId: null, overriddenHaltStateId: null, tags: [],
+        transitions: [],
+      },
+      1: {
+        id: 1, name: 'q0', isHalt: false, isHaltMarker: false, isWrapper: false,
+        bareStateId: null, frameId: null, overriddenHaltStateId: null, tags: [],
+        transitions: [],
+      },
+    });
+    const summary = summariseGraph(g);
+    expect(summary.stateCount).toBe(1);
+    expect(summary.hasHalt).toBe(true);
+    expect(summary.states.map((s) => s.name)).toEqual(['q0']);
+  });
+
+  it('R-summary-no-halt: hasHalt false when no halt node present', () => {
+    const g = makeGraph({
+      1: {
+        id: 1, name: 'q0', isHalt: false, isHaltMarker: false, isWrapper: false,
+        bareStateId: null, frameId: null, overriddenHaltStateId: null, tags: [],
+        transitions: [],
+      },
+    });
+    const summary = summariseGraph(g);
+    expect(summary.stateCount).toBe(1);
+    expect(summary.hasHalt).toBe(false);
   });
 
   it('R-summary-literal: decodes literal read + literal write + move', () => {

--- a/src/lib/graphSummary.test.ts
+++ b/src/lib/graphSummary.test.ts
@@ -34,7 +34,7 @@ describe('summariseGraph', () => {
     });
     const summary = summariseGraph(g);
     expect(summary.stateCount).toBe(2);
-    expect(summary.hasHalt).toBe(true);
+    expect(summary.haltCount).toBe(1);
     expect(summary.states.map((s) => s.name)).toEqual(['q0', 'q1']);
   });
 
@@ -53,11 +53,11 @@ describe('summariseGraph', () => {
     });
     const summary = summariseGraph(g);
     expect(summary.stateCount).toBe(1);
-    expect(summary.hasHalt).toBe(true);
+    expect(summary.haltCount).toBe(1);
     expect(summary.states.map((s) => s.name)).toEqual(['q0']);
   });
 
-  it('R-summary-no-halt: hasHalt false when no halt node present', () => {
+  it('R-summary-no-halt: haltCount 0 when no halt node present', () => {
     const g = makeGraph({
       1: {
         id: 1, name: 'q0', isHalt: false, isHaltMarker: false, isWrapper: false,
@@ -67,7 +67,7 @@ describe('summariseGraph', () => {
     });
     const summary = summariseGraph(g);
     expect(summary.stateCount).toBe(1);
-    expect(summary.hasHalt).toBe(false);
+    expect(summary.haltCount).toBe(0);
   });
 
   it('R-summary-literal: decodes literal read + literal write + move', () => {

--- a/src/lib/graphSummary.ts
+++ b/src/lib/graphSummary.ts
@@ -1,0 +1,166 @@
+// Pure-function helper that turns an engine v7 `Graph` snapshot into a
+// readable, screen-reader-friendly summary. Used by `MachineGraph.svelte`'s
+// `.sr-only` text alternative (machines-demo#95 B1) — the rendered SVG
+// carries no `<title>`/`<desc>`/text alternative, so without this the
+// central simulator artifact is opaque to assistive tech.
+//
+// Output is plain prose, not Mermaid notation: e.g. "moves right" instead
+// of the engine's `R` letter, "writes 'a'" instead of `'a'`. The rendered
+// graph remains the source of truth for sighted users; this summary is
+// the parallel structural view AT users get.
+
+import type { Graph, GraphNode, GraphTransition } from '@turing-machine-js/machine';
+
+export type GraphSummary = {
+  stateCount: number;
+  haltCount: number;
+  states: SummaryState[];
+};
+
+export type SummaryState = {
+  id: number;
+  name: string;
+  isWrapper: boolean;
+  /** When `isWrapper` is true, the bare State id this wrapper delegates
+   *  to. Useful for prose like "calls subroutine X". */
+  bareStateId: number | null;
+  transitions: SummaryTransition[];
+};
+
+export type SummaryTransition = {
+  /** Decoded transition pattern as readable prose — e.g. `'a'`,
+   *  `any symbol`, multi-tape `'a' on tape 1, blank on tape 2`. */
+  readsPhrase: string;
+  /** Per-tape write+move list, e.g. `writes 'b', moves right`. */
+  commandsPhrase: string;
+  /** Display name of the target State, or `halt` for halt markers. */
+  targetName: string;
+};
+
+/** Build a screen-reader-friendly structural summary of the engine graph.
+ *  Pure — no DOM, no engine instances, no side effects. */
+export function summariseGraph(graph: Graph): GraphSummary {
+  const nodes = Object.values(graph.nodes);
+  // Sort by id so the summary order is stable across renders.
+  const sorted = [...nodes].sort((a, b) => a.id - b.id);
+
+  // Halt markers are emitted by the engine as separate sentinel nodes
+  // (one per call site that reaches halt). For AT prose we group them
+  // into a single "N halt markers" stat — listing each individually
+  // adds noise without information.
+  const regular = sorted.filter((n) => !n.isHaltMarker);
+  const haltCount = sorted.length - regular.length;
+
+  return {
+    stateCount: regular.length,
+    haltCount,
+    states: regular.map((node) => summariseNode(node, graph)),
+  };
+}
+
+function summariseNode(node: GraphNode, graph: Graph): SummaryState {
+  return {
+    id: node.id,
+    name: node.name,
+    isWrapper: node.isWrapper,
+    bareStateId: node.bareStateId,
+    transitions: node.transitions.map((t) => summariseTransition(t, graph)),
+  };
+}
+
+function summariseTransition(
+  transition: GraphTransition,
+  graph: Graph,
+): SummaryTransition {
+  return {
+    readsPhrase: formatReadsPhrase(transition.pattern),
+    commandsPhrase: formatCommandsPhrase(transition.command),
+    targetName: targetNameFor(transition.nextStateId, graph),
+  };
+}
+
+function targetNameFor(id: number, graph: Graph): string {
+  const target = graph.nodes[id];
+  if (!target) return `state ${id}`;
+  if (target.isHaltMarker || target.isHalt) return 'halt';
+  return target.name;
+}
+
+/** Reformat the engine's pre-decoded pattern as readable prose. The engine
+ *  emits Mermaid-style cells (`'a'`, `B`, `*`, `*='a'`) — `B` for blank,
+ *  `*` for `ifOtherSymbol`, `*='X'` for wildcard with concrete match,
+ *  `'X'` for literals. Multi-pattern alternations are `|`-joined,
+ *  multi-tape cells `,`-joined. */
+function formatReadsPhrase(pattern: string): string {
+  if (!pattern) return 'any symbol';
+  return pattern
+    .split('|')
+    .map((alt) => formatReadAlternative(alt.trim()))
+    .join(' or ');
+}
+
+function formatReadAlternative(alt: string): string {
+  const cells = alt.split(',').map((c) => c.trim());
+  if (cells.length === 1) return readCellToPhrase(cells[0]);
+  return cells.map((c, i) => `${readCellToPhrase(c)} on tape ${i + 1}`).join(', ');
+}
+
+function readCellToPhrase(cell: string): string {
+  if (cell === '*' || cell === '?') return 'any symbol';
+  if (cell === 'B') return 'blank';
+  // Wildcard with a concrete match: engine renders as `*='X'` — preserve
+  // that information in prose form.
+  const wildcardMatch = /^\*='(.*)'$/.exec(cell);
+  if (wildcardMatch) return `any symbol (matched ${quote(wildcardMatch[1])})`;
+  const literalMatch = /^'(.*)'$/.exec(cell);
+  if (literalMatch) return quote(literalMatch[1]);
+  return cell;
+}
+
+function quote(symbol: string): string {
+  return `'${symbol}'`;
+}
+
+function formatCommandsPhrase(
+  commands: readonly { symbol: string; movement: string }[],
+): string {
+  return commands
+    .map((cmd, i) => {
+      const tapeLabel = commands.length > 1 ? `tape ${i + 1}: ` : '';
+      const writePhrase = formatWritePhrase(cmd.symbol);
+      const movePhrase = formatMovePhrase(cmd.movement);
+      const parts = [writePhrase, movePhrase].filter((p) => p.length > 0);
+      return tapeLabel + parts.join(', ');
+    })
+    .join('; ');
+}
+
+/** `GraphCommand.symbol` is already `decodeWriteSymbol`-d by the engine:
+ *  `'X'` for literals, `K` (keep), `E` (erase), `K='X'` / `K=B` for keep
+ *  with the engine-resolved current symbol. */
+function formatWritePhrase(decoded: string): string {
+  if (!decoded) return '';
+  if (decoded === 'K') return 'keeps current symbol';
+  if (decoded === 'E') return 'erases';
+  // `K='X'` / `K=B` — keep with concrete read context.
+  const keepMatch = /^K=(.+)$/.exec(decoded);
+  if (keepMatch) {
+    const read = keepMatch[1];
+    if (read === 'B') return 'keeps current symbol (blank)';
+    const lit = /^'(.*)'$/.exec(read);
+    if (lit) return `keeps current symbol (${quote(lit[1])})`;
+    return `keeps current symbol (${read})`;
+  }
+  const literal = /^'(.*)'$/.exec(decoded);
+  if (literal) return `writes ${quote(literal[1])}`;
+  return `writes ${decoded}`;
+}
+
+/** `GraphCommand.movement` is already `decodeMovement`-d: `L` / `R` / `S`. */
+function formatMovePhrase(decoded: string): string {
+  if (!decoded) return '';
+  if (decoded === 'L') return 'moves left';
+  if (decoded === 'R') return 'moves right';
+  if (decoded === 'S') return 'stays';
+  return `moves ${decoded}`;
+}

--- a/src/lib/graphSummary.ts
+++ b/src/lib/graphSummary.ts
@@ -13,7 +13,7 @@ import type { Graph, GraphNode, GraphTransition } from '@turing-machine-js/machi
 
 export type GraphSummary = {
   stateCount: number;
-  haltCount: number;
+  hasHalt: boolean;
   states: SummaryState[];
 };
 
@@ -44,16 +44,19 @@ export function summariseGraph(graph: Graph): GraphSummary {
   // Sort by id so the summary order is stable across renders.
   const sorted = [...nodes].sort((a, b) => a.id - b.id);
 
-  // Halt markers are emitted by the engine as separate sentinel nodes
-  // (one per call site that reaches halt). For AT prose we group them
-  // into a single "N halt markers" stat — listing each individually
-  // adds noise without information.
-  const regular = sorted.filter((n) => !n.isHaltMarker);
-  const haltCount = sorted.length - regular.length;
+  // Halt nodes are the engine's universal `haltState` singleton (id 0,
+  // `isHalt: true`) and per-call-site halt markers (`isHaltMarker: true`,
+  // one per call site that reaches halt). Both are excluded from the
+  // states list — they have no outgoing transitions and listing them as
+  // separate entries adds noise without information. Their presence is
+  // surfaced once via `hasHalt` so the SR summary can say "ending at
+  // halt" rather than emitting an empty "no outgoing transitions" line.
+  const regular = sorted.filter((n) => !n.isHaltMarker && !n.isHalt);
+  const hasHalt = regular.length < sorted.length;
 
   return {
     stateCount: regular.length,
-    haltCount,
+    hasHalt,
     states: regular.map((node) => summariseNode(node, graph)),
   };
 }

--- a/src/lib/graphSummary.ts
+++ b/src/lib/graphSummary.ts
@@ -13,7 +13,7 @@ import type { Graph, GraphNode, GraphTransition } from '@turing-machine-js/machi
 
 export type GraphSummary = {
   stateCount: number;
-  hasHalt: boolean;
+  haltCount: number;
   states: SummaryState[];
 };
 
@@ -48,15 +48,16 @@ export function summariseGraph(graph: Graph): GraphSummary {
   // `isHalt: true`) and per-call-site halt markers (`isHaltMarker: true`,
   // one per call site that reaches halt). Both are excluded from the
   // states list — they have no outgoing transitions and listing them as
-  // separate entries adds noise without information. Their presence is
-  // surfaced once via `hasHalt` so the SR summary can say "ending at
-  // halt" rather than emitting an empty "no outgoing transitions" line.
+  // separate entries would surface engine-internal sentinels as "no
+  // outgoing transitions" entries. Their total is surfaced via
+  // `haltCount` so the SR summary can announce "N halt nodes" alongside
+  // the regular state count.
   const regular = sorted.filter((n) => !n.isHaltMarker && !n.isHalt);
-  const hasHalt = regular.length < sorted.length;
+  const haltCount = sorted.length - regular.length;
 
   return {
     stateCount: regular.length,
-    hasHalt,
+    haltCount,
     states: regular.map((node) => summariseNode(node, graph)),
   };
 }


### PR DESCRIPTION
## Summary

Lands the structural a11y changes from #95 in four commits (B1 + B2 + a halt-node fix on B1 + M4):

- **B1** (commit \`f99b2f4\`) — machine graph text alternative. SR-only summary inside MachineGraph derived from the \`Graph\` snapshot via \`src/lib/graphSummary.ts\`. State count + per-state outgoing transitions in plain prose. The headline AT change — the central simulator artifact was previously opaque to assistive tech.
- **fixup on B1** (commits \`397bc6e\`, \`021b2be\`) — exclude the \`haltState\` singleton (\`isHalt: true\`) from the regular states list and restore a halt-node count in the prose. Output reads \`State diagram with N states, M halt nodes.\` rather than \`id:0 — no outgoing transitions\` for the singleton.
- **B2** (commit \`7510fd3\`) — graph modal as native \`<dialog>\`. MachineView graph-expand modal swaps from \`<div role=\"presentation\">\` backdrop + \`<section>\` to a real \`<dialog>\` opened via \`showModal()\`. Browser handles focus trap, Escape, return-focus, scroll-lock.
- **M4** (commit \`553e735\`) — save popover as native \`<dialog>\`. Toolbar save popover swaps similarly. Positioning uses CSS anchor positioning (Baseline newly available — Chrome 125+, Safari 18+); Firefox without anchor support falls back to UA-centered \`<dialog>\` placement, which still functions (just not anchored under the save button). Backdrop click closes via dialog \`onclick\` handler (\`e.target === dialog\` when the click hits the \`::backdrop\`).

## Test plan

- [x] \`npm run check\` — 619 files, 0 errors, 0 warnings
- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 160/160 pass (graphSummary tests cover the halt-singleton exclusion + no-halt cases)
- [x] \`npm run build\` — clean (chunk-size warnings pre-existing)
- [ ] CI green
- [ ] Manual smoke: \`/turing\` and \`/post\` — expand graph (Escape closes, return-focus to expand button), SR hears the state/transition summary; Toolbar save popover opens (anchored in Chrome/Safari, centered in Firefox), Escape + backdrop-click + Save action all close, ⌘S shortcut still triggers

## After this merges

Cuts \`chore(release): 1.0.0-alpha.23\` folding:
- v7.0.0 stable deps bump (#97, already merged)
- a11y quick wins (#98, already merged)
- this PR (B1 + B2 + M4)

Refs #95.