### PR TITLE
chore(release): 1.0.0-alpha.23 — v7.0.0 stable + a11y baseline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "machines-demo",
-  "version": "1.0.0-alpha.22",
+  "version": "1.0.0-alpha.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "machines-demo",
-      "version": "1.0.0-alpha.22",
+      "version": "1.0.0-alpha.23",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machines-demo",
   "private": true,
-  "version": "1.0.0-alpha.22",
+  "version": "1.0.0-alpha.23",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Cuts \`v1.0.0-alpha.23\` after three batches landed on master:

| PR | scope |
|---|---|
| [#97](https://github.com/mellonis/machines-demo/pull/97) | v7.0.0 stable deps (engine + visuals + post 7.0.0-alpha.{7,8} → 7.0.0 on \`latest\`) |
| [#98](https://github.com/mellonis/machines-demo/pull/98) | a11y quick wins — Log + status mirror as live regions, interval label, \`aria-current\` on tabs, \`:focus-visible\` policy, heading hierarchy, reduced-motion gates |
| [#99](https://github.com/mellonis/machines-demo/pull/99) | a11y structural batch — graph text alternative (B1), graph modal as \`<dialog>\` (B2), save popover as \`<dialog>\` with CSS anchor positioning (M4) |

Closes #96. Closes #95.

## Test plan

Inherits CI from the three feeder PRs. This PR is package-version only (2 files: package.json + package-lock.json).

## After merge

1. \`gh release create v1.0.0-alpha.23 --target master --prerelease --title v1.0.0-alpha.23 --notes-file …\`
2. CI \`main.yml\` auto-deploys to \`demo.machines.mellonis.ru\` on push to master (the merge itself triggers it)

I'll prep the GH release notes draft separately.