### PR TITLE
chore(release): 1.0.0-alpha.24 — smart editor completions (#103)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,27 @@ src/
     ├── initialBoot.ts          pure helper computing engine-page initial state from URL params + localStorage — 4-tier priority (?example=<id> > ?snippet=<id> > localStorage > first bundled example), with badExampleId/badUrlId for not-found logging
     ├── initialBoot.test.ts     Vitest suite for initialBoot — M-boot-example-query / M-boot-example-unknown / M-boot-priority-example-over-snippet / M-boot-priority-snippet-over-localstorage / M-boot-priority-localstorage-over-default / M-execution-mode-union
     ├── interval.ts             parseInterval + MIN_AUTO_INTERVAL_MS for the RUNNING_AUTO throttle
-    ├── completions.ts          CodeMirror autocomplete: machine namespace + locals
+    ├── completions/            context-aware, schema-driven CodeMirror autocomplete (#103)
+    │   ├── index.ts              completionExtensions(engine) — composes the layers below
+    │   ├── schema/               typed const describing engine + post API surface
+    │   │   ├── types.ts            EngineSchema / NamespaceEntry / ClassSpec / ShapeSpec / TypeRef / ParamSpec / MemberSpec
+    │   │   ├── turing.ts           TURING_SCHEMA (namespace, classes, shapes, constants)
+    │   │   ├── post.ts             POST_SCHEMA (post-instruction flattened kind for mark/erase/call/check/$tag/...)
+    │   │   ├── index.ts            getSchema(engine)
+    │   │   └── engine.test.ts      drift guard against `* as turingNs` / `* as postNs` + TypeRef closure
+    │   ├── scan/                 Lezer walker over the editor buffer
+    │   │   ├── types.ts            InferredType / InferredLocals / ImportsBinding / ScannerResult
+    │   │   ├── locals.ts           scanLocals + inferLocalsFor + localsField (StateField cache, schema-keyed)
+    │   │   └── locals.test.ts      Phase 1 + Phase 2 inference rules (cites S-scan-...)
+    │   ├── contexts/             five per-context CompletionSource factories, composed in priority order
+    │   │   ├── types.ts            Env, CompletionSourceFactory
+    │   │   ├── memberAccess.ts     after `<ident>.` — instance members / namespace classes / constants (movements/symbolCommands)
+    │   │   ├── debugAssignment.ts  `<state>.debug = ▮` RHS + `{ before, after }` keys; haltState boolean-only
+    │   │   ├── optionsBag.ts       inside `new <Class>({ ▮ })` — top-level + nested shape-path walk (State dictionary-ctor entry)
+    │   │   ├── destructureBag.ts   inside `const { ▮ } = imports;` or `const { ▮ } = <local-class>;`
+    │   │   └── namespaceIdentifier.ts  bare word at expression position — ranked by destructure status; snippet expand in `new` callee + post-instruction with params; rename emits two entries (original-name applies the alias)
+    │   └── apply/
+    │       └── import.ts           applyAutoImport + computeDestructureChange — inserts not-yet-destructured names into the top `const { … } = imports;` block; format-aware single/multi-line; rename suppression
     ├── syntaxLinter.ts         Lezer-based syntax-error markers
     ├── persist.ts              localStorage helpers per engine — code, example, snippets (UUID-keyed)
     ├── tapeSnapshot.ts         serialize/parse for tape-block copy+paste snapshots — JSON with `format`/`version` discriminator, categorized ParseError, no DOM/clipboard knowledge
@@ -210,7 +230,7 @@ Save UX (Toolbar.svelte):
 ## Editor
 
 - `svelte-codemirror-editor` (Svelte-5-native wrapper around CodeMirror 6) with `bind:value`.
-- Extensions: `javascript()` lang, `oneDark` theme, our `importsCompletion(engine)` (boost-99 machine identifiers + local-identifier completion source from `@codemirror/lang-javascript`), and a Lezer-based `syntaxLinter` for syntax-error markers before Build.
+- Extensions: `javascript()` lang, `oneDark` theme, our `completionExtensions(engine)` (the smart-completions layer at `src/lib/completions/` — schema-driven, context-aware; surfaces namespace identifiers ranked by destructure status, member access on user-typed locals, `state.debug` RHS shapes, options-bag keys for known constructors, and auto-import into the top `const { … } = imports;` block; see #103 + the spec at `docs/superpowers/specs/2026-06-07-44-smart-completions-design.md`), and a Lezer-based `syntaxLinter` for syntax-error markers before Build.
 - A small reset-to-selected-example button overlays the editor's top-right corner; the log's clear button uses the same shared `IconButton.svelte` (corner-overlay variant) — both are absolutely positioned within their `position: relative` parent (`.editor` / `.log-panel`).
 
 ## Deploy

--- a/README.md
+++ b/README.md
@@ -106,7 +106,11 @@ src/
     ├── logStore.test.ts        # Vitest suite for LogStore
     ├── initialBoot.ts          # pure helper — engine-page boot priority (?example > ?snippet > localStorage > default)
     ├── initialBoot.test.ts     # Vitest suite for initialBoot
-    ├── completions.ts          # CodeMirror autocomplete from machine namespace
+    ├── completions/            # context-aware, schema-driven CodeMirror autocomplete
+    │   ├── schema/               # typed const describing engine + post API surface
+    │   ├── scan/                 # Lezer walker — infers user-local types + tracks imports destructure
+    │   ├── contexts/             # 5 CompletionSource factories (memberAccess, debugAssignment, optionsBag, destructureBag, namespaceIdentifier)
+    │   └── apply/                # auto-import — inserts undestructured names into the top `const {…} = imports;` block
     ├── syntaxLinter.ts         # Lezer-based syntax-error markers
     ├── persist.ts              # localStorage helpers per engine
     ├── tapeSnapshot.ts         # serialize/parse tape-block snapshots for copy+paste

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "machines-demo",
-  "version": "1.0.0-alpha.23",
+  "version": "1.0.0-alpha.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "machines-demo",
-      "version": "1.0.0-alpha.23",
+      "version": "1.0.0-alpha.24",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machines-demo",
   "private": true,
-  "version": "1.0.0-alpha.23",
+  "version": "1.0.0-alpha.24",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Cycle since alpha.23 is a single feature.

## Shipped

- **Smart editor completions** ([#103](https://github.com/mellonis/machines-demo/issues/103), PR [#104](https://github.com/mellonis/machines-demo/pull/104)) — context-aware, schema-driven CodeMirror autocomplete layer at \`src/lib/completions/\`. Replaces the flat-list \`completions.ts\` with five composable \`CompletionSource\`s (\`memberAccess\`, \`debugAssignment\`, \`optionsBag\`, \`destructureBag\`, \`namespaceIdentifier\`), a Lezer-walker scanner that infers typed locals, a hand-rolled engine + post schema with drift guard against runtime exports, and an auto-import helper that inserts not-yet-destructured names into the top \`const { … } = imports;\` block (alphabetical, single/multi-line aware, rename-suppressing). Snippet expansion in \`new <Class>\` callee position and for parameterized post-instructions (\`call\`/\`check\`/\`$tag\`). Renamed exports emit two entries (original-name applies the alias) for discoverability. Closes #44 (the original member-completion ask for \`movements.*\` / \`symbolCommands.*\`).

## Docs audit folded in

The audit from #103's spec — touched alongside the version bump to avoid an extra round-trip:

- \`CLAUDE.md\` — *Editor* section + \`src/lib/\` tree reflect the new \`completions/\` subdirectory.
- \`README.md\` — \`src/lib/\` tree update.

## Verification

- 255/255 unit tests, 18/18 E2E (incl. \`E-completions-*\`), \`npm run check\` clean, \`npm run lint\` clean, \`npm run build\` clean.
- Bundle delta vs alpha.23: +~20 KB minified on the main chunk (schema + scanner + 5 sources + apply helper). Well under the spec's 30 KB ceiling.

## Test plan

- [ ] CI passes on the smart-completions specs.
- [ ] Demo reachable at \`demo.machines.mellonis.ru\` after the post-merge GHA deploy.