### PR TITLE
fix: clear snippet graph highlights when playback ends (#108)

### DIFF
--- a/src/components/SnippetPanel.svelte
+++ b/src/components/SnippetPanel.svelte
@@ -120,10 +120,19 @@
     if (graphReady) applyGraph();
   }
 
+  function clearGraphHighlights(): void {
+    machineGraphRef?.clearHighlights();
+    prevStrongId = null;
+  }
+
   function startTimer(): void {
     clearReplayTimer();
     replayTimerId = window.setInterval(() => {
       if (!player.forward()) {
+        // Playback reached the last frame on the previous tick. Clear the
+        // residual highlight from that frame so the graph returns to neutral
+        // before the Replay control sits idle on it (#108).
+        clearGraphHighlights();
         clearReplayTimer();
         return;
       }


### PR DESCRIPTION
Closes #108.

## Symptom

Landing-page snippet playback reached the last frame and stopped, but the residual highlight from that frame stayed on the graph — source state strong, arrow pointing toward halt. The Replay control appeared on top of a graph that visually still looked mid-execution. Read as \"stops one step before halt; the halt animation never plays.\"

## Cause

`SnippetPlayer` is a pure index-advancing driver — it has no opinion about what to draw between frames. `SnippetPanel.startTimer`'s callback advanced the index, applied the frame's highlight via `applyHighlight`, and stopped the timer on the first failed \`forward()\`. The clear step that runs on every successful frame transition (inside \`applyGraph\`) never fires on the stop tick, so the last frame's highlight is left on the graph indefinitely.

## Fix

In the timer's \`forward()\`-returns-false branch, call \`machineGraphRef.clearHighlights()\` and reset the panel's \`prevStrongId\` before clearing the timer. The graph returns to neutral the moment playback ends; the Replay control sits on a clean canvas.

```diff
 function startTimer(): void {
   clearReplayTimer();
   replayTimerId = window.setInterval(() => {
     if (!player.forward()) {
+      clearGraphHighlights();
       clearReplayTimer();
       return;
     }
     applyFrame();
   }, intervalMs);
 }
```

Reduced-motion path is intentionally unchanged: it jumps straight to the final frame and stays there as a static \"result\" snapshot — that's its existing semantic.

## Rejected alternatives

- **Add a final \`highlight: null\` frame to \`recordSnippet\`** ([visuals package](https://github.com/mellonis/turing-machine-js/tree/master/packages/visuals)). Cleaner upstream, but requires a visuals patch bump + npm publish + bump the demo's dep + re-record bundled snippets. Heavy for a small consumer-side issue.
- **Mutate the halt iter's existing \`strong: 'from'\` → \`'to'\` so halt becomes the prominent state on the final frame.** Was the original proposal but the user pointed out the symptom is \"stuck highlights\" rather than \"halt under-styled,\" so the simpler clear-on-stop is the right framing.

## Verification

- 255/255 unit tests, \`npm run check\` clean (643 files, 0 errors), \`npm run lint\` clean.
- Manual: \`npm run dev\`, scroll a snippet panel into view, watch playback reach the end — graph clears, Replay sits on a neutral canvas. \`prefers-reduced-motion\` users still see the static last-frame snapshot.

## Test plan

- [ ] CI green.
- [ ] Visual check on \`localhost:5173/\` after merge + deploy: each of the six showcase panels ends with a clean graph + Replay control.