### PR TITLE
fix(machine-graph): showcase viewport — follow, fit, recenter, restore zoom (#110)

### DIFF
--- a/src/components/MachineGraph.svelte
+++ b/src/components/MachineGraph.svelte
@@ -16,7 +16,7 @@
   import { theme } from '../lib/theme.svelte.ts';
   import { icons } from '../lib/icons.ts';
   import { summariseGraph } from '../lib/graphSummary.ts';
-  import { computeCenterScroll } from '../lib/scrollCenter.ts';
+  import { computeCenterScroll, computeFitZoom } from '../lib/scrollCenter.ts';
 
   type Props = {
     graph: Graph | null;
@@ -794,20 +794,50 @@
     });
   });
 
-  // After each new render: reset zoom to 1, then scroll the `idle`
-  // entry node into view so the user lands on the diagram's start
-  // (LR: leftmost; TD: top). Without the zoom reset, a previously
-  // zoomed view of one machine could carry into the next build.
-  // Awaits `tick()` so both the cache-build effect (svg → nodeCache)
-  // and the layout flush (zoom: 1 → resized .svg-host) have applied
-  // before we measure for centering.
+  // After each new render: pick a zoom that keeps ≥60% of the SVG's area
+  // visible inside the body, then center the `idle` entry node so the user
+  // lands on the diagram's start (machines-demo#110).
+  //
+  // Why both passes share an effect:
+  //   - The zoom adjustment changes `.svg-host`'s laid-out width / height,
+  //     which moves every node's bounding rect — centering before the
+  //     zoom settles would aim at stale coordinates.
+  //   - Resetting to 1 first gives `getBoundingClientRect` a known scale
+  //     to read the SVG's intrinsic viewBox dimensions against the body's
+  //     padding-deducted content box.
+  //
+  // Sequence: zoom = 1 → await tick (cache-build + layout) → measure +
+  // computeFitZoom → set zoom if smaller than 1 → await tick → center.
+  // The same idle-centered initial view applies to engine pages and
+  // readOnly showcase panels — earlier the showcase opened on the SVG's
+  // content centroid (which on callable-subtree graphs landed between the
+  // main flow and the subgraph, looking empty).
   $effect(() => {
     void svg;
     if (!svg || !svgHostEl) return;
     zoom = 1;
-    void tick().then(() => {
+    void tick().then(async () => {
       const body = svgHostEl?.closest<HTMLElement>('.body');
-      if (!body) return;
+      const svgEl = svgHostEl?.querySelector('svg');
+      if (!body || !svgEl) return;
+      // viewBox is the intrinsic SVG size at zoom = 1; body's clientWidth /
+      // clientHeight reflect the scroll-area box. Padding is excluded so
+      // the fit math compares "visible area" against "true SVG area".
+      const vb = svgEl.viewBox.baseVal;
+      const cs = window.getComputedStyle(body);
+      const padH = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight);
+      const padV = parseFloat(cs.paddingTop) + parseFloat(cs.paddingBottom);
+      const fitZoom = computeFitZoom(
+        vb.width,
+        vb.height,
+        Math.max(0, body.clientWidth - padH),
+        Math.max(0, body.clientHeight - padV),
+      );
+      const clamped = clampZoom(fitZoom);
+      if (clamped !== zoom) {
+        zoom = clamped;
+        await tick();
+      }
       const idle = nodeCache.get('idle');
       if (idle) {
         centerInScroller(body, idle, 'auto');
@@ -832,22 +862,6 @@
       if (!body) { canPan = false; return; }
       canPan = body.scrollWidth > body.clientWidth + 1
         || body.scrollHeight > body.clientHeight + 1;
-    });
-  });
-
-  // Showcase context (readOnly) opens centered. Engine pages keep the
-  // default (0, 0) origin so the entry node is visible at first paint —
-  // there the user is about to step / run and orientation matters more
-  // than centroid. Triggered on SVG change only (not zoom), so the
-  // initial frame lands centered without fighting subsequent applies.
-  $effect(() => {
-    void svg;
-    if (!readOnly || !svg || !svgHostEl) return;
-    void tick().then(() => {
-      const body = svgHostEl?.closest<HTMLElement>('.body');
-      if (!body) return;
-      body.scrollLeft = (body.scrollWidth - body.clientWidth) / 2;
-      body.scrollTop = (body.scrollHeight - body.clientHeight) / 2;
     });
   });
 
@@ -893,6 +907,24 @@
     root.querySelectorAll('.mg-frame-active').forEach((el) => {
       el.classList.remove('mg-frame-active');
     });
+  }
+
+  /**
+   * Imperative API: scroll the synthetic `idle` entry node to the center of
+   * the body viewport (machines-demo#110). Called by `SnippetPanel.onReplay`
+   * so a Replay-clicked panel rewinds the scroll position to the same view
+   * the user got on first mount, instead of resuming from wherever the last
+   * frame's highlight had pushed the viewport. No-op when the SVG / cache
+   * isn't ready or `idle` was somehow stripped. Honors
+   * `prefers-reduced-motion` via `preferredScrollBehavior`.
+   */
+  export function recenterOnIdle(): void {
+    if (!svgHostEl) return;
+    const body = svgHostEl.closest<HTMLElement>('.body');
+    if (!body) return;
+    const idle = nodeCache.get('idle');
+    if (!idle) return;
+    centerInScroller(body, idle, preferredScrollBehavior());
   }
 
   /**

--- a/src/components/MachineGraph.svelte
+++ b/src/components/MachineGraph.svelte
@@ -16,6 +16,7 @@
   import { theme } from '../lib/theme.svelte.ts';
   import { icons } from '../lib/icons.ts';
   import { summariseGraph } from '../lib/graphSummary.ts';
+  import { computeCenterScroll } from '../lib/scrollCenter.ts';
 
   type Props = {
     graph: Graph | null;
@@ -541,35 +542,36 @@
     });
   }
 
-  // Scroll an element into the scrollable ancestor's visible box if it's
-  // currently fully outside on either axis (margin: 16px). Centers per
-  // axis only if that axis was the one out-of-view, so a horizontally-
-  // out-of-view element doesn't have its vertical scroll yanked too.
-  // Used by the highlight op so paused / stepped nodes are revealed
-  // without disturbing the user's scroll when they're already visible.
-  function scrollIntoViewIfNeeded(scroller: HTMLElement, el: Element, behavior: ScrollBehavior = 'smooth'): void {
-    const containerRect = scroller.getBoundingClientRect();
-    const elRect = el.getBoundingClientRect();
-    const margin = 16;
-    const outsideV =
-      elRect.bottom < containerRect.top + margin
-      || elRect.top > containerRect.bottom - margin;
-    const outsideH =
-      elRect.right < containerRect.left + margin
-      || elRect.left > containerRect.right - margin;
-    if (!outsideV && !outsideH) return;
-    const opts: ScrollToOptions = { behavior };
-    if (outsideV) {
-      const elCenterY = elRect.top + elRect.height / 2;
-      const containerCenterY = containerRect.top + containerRect.height / 2;
-      opts.top = scroller.scrollTop + (elCenterY - containerCenterY);
-    }
-    if (outsideH) {
-      const elCenterX = elRect.left + elRect.width / 2;
-      const containerCenterX = containerRect.left + containerRect.width / 2;
-      opts.left = scroller.scrollLeft + (elCenterX - containerCenterX);
-    }
-    scroller.scrollTo(opts);
+  // Center an element inside the scrollable ancestor when it isn't sitting
+  // comfortably inside the viewport (machines-demo#110). "Comfortable" means
+  // fully inside the inner 80% of the body (10% inset on each side); a node
+  // that drifts into the edge band or off-screen gets pulled back to the
+  // center on that axis. Per-axis check is independent — a node fine
+  // vertically but slipping past the right edge gets a horizontal-only
+  // recenter, leaving the user's vertical scroll alone. Pure math lives in
+  // `lib/scrollCenter.ts`; this is the DOM-touching wrapper.
+  //
+  // Previous policy (`scrollIntoViewIfNeeded`) only fired when the node was
+  // FULLY outside the body — a node sitting at the edge with a sliver still
+  // visible never triggered, so showcase snippet playback "looked frozen"
+  // for big graphs (#110).
+  function centerIfNeeded(scroller: HTMLElement, el: Element, behavior: ScrollBehavior = 'smooth'): void {
+    const target = computeCenterScroll(
+      scroller.getBoundingClientRect(),
+      { left: scroller.scrollLeft, top: scroller.scrollTop },
+      el.getBoundingClientRect(),
+    );
+    if (target === null) return;
+    scroller.scrollTo({ ...target, behavior });
+  }
+
+  // Resolve the scroll behavior honoring `prefers-reduced-motion`. Users who
+  // opt out of animation get an instant jump instead of a sliding viewport,
+  // matching the rest of the demo (SnippetPanel's playback already gates on
+  // the same media query).
+  function preferredScrollBehavior(): ScrollBehavior {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return 'smooth';
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'instant' : 'smooth';
   }
 
   // Replace mermaid's `width="100%"` + inline `max-width: <intrinsic>px`
@@ -947,7 +949,7 @@
         void tick().then(() => {
           const scrollContainer = svgHostEl?.closest<HTMLElement>('.body');
           if (!scrollContainer) return;
-          scrollIntoViewIfNeeded(scrollContainer, el, 'smooth');
+          centerIfNeeded(scrollContainer, el, preferredScrollBehavior());
         });
       },
     };
@@ -1066,16 +1068,18 @@
       scrollIntoView(id) {
         const el = nodeCache.get(id);
         if (!el) return;
-        // Delegates to `scrollIntoViewIfNeeded` (defined above), which
-        // handles both axes — the panel is now horizontally scrollable
-        // too for graphs wider than the viewport (e.g. Brainfuck UTM).
-        // Manual offset math (vs Element.scrollIntoView) preserves the
-        // existing margin threshold + smooth-scroll behavior and avoids
-        // any browser quirks around scrolling SVG-contained elements.
+        // Delegates to `centerIfNeeded` (defined above) so a paused state
+        // sitting in the edge band gets pulled back to the center
+        // (machines-demo#110) — the previous "fully outside" policy left
+        // partially-visible nodes alone, which read as a frozen viewport
+        // on long subroutine chains. Manual offset math (vs
+        // `Element.scrollIntoView`) avoids browser quirks around scrolling
+        // SVG-contained elements and respects `prefers-reduced-motion` via
+        // `preferredScrollBehavior`.
         void tick().then(() => {
           const scrollContainer = svgHostEl?.closest<HTMLElement>('.body');
           if (!scrollContainer) return;
-          scrollIntoViewIfNeeded(scrollContainer, el, 'smooth');
+          centerIfNeeded(scrollContainer, el, preferredScrollBehavior());
         });
       },
     });

--- a/src/components/MachineGraph.svelte
+++ b/src/components/MachineGraph.svelte
@@ -1185,14 +1185,23 @@
           title="Zoom in (Ctrl/Cmd + scroll up)"
           aria-label="Zoom in"
         >{@html icons.zoomIn}</button>
-        <button
-          type="button"
-          class="action"
-          onclick={aim}
-          disabled={!svg}
-          title="Scroll to current state (or entry if none)"
-          aria-label="Scroll to current state"
-        >{@html icons.target}</button>
+        {#if !readOnly}
+          <!-- "Scroll to current state" reads the `highlight` prop to find
+               the target. Showcase panels (SnippetPanel) drive the
+               highlight imperatively via `getOps` instead of passing the
+               prop, so the button would always fall back to scrolling to
+               idle — misleading given the label. The Replay-time
+               `recenterOnIdle()` call already covers the "back to entry"
+               UX for those panels; the aim affordance is engine-only. -->
+          <button
+            type="button"
+            class="action"
+            onclick={aim}
+            disabled={!svg}
+            title="Scroll to current state (or entry if none)"
+            aria-label="Scroll to current state"
+          >{@html icons.target}</button>
+        {/if}
         {#if onExpand}
           <button
             type="button"

--- a/src/components/MachineGraph.svelte
+++ b/src/components/MachineGraph.svelte
@@ -33,12 +33,14 @@
     stepsApplied?: number;
     collapsed: boolean;
     onToggleCollapsed: () => void;
-    /** When true, all user-facing interactive surfaces are disabled: the
-     *  collapse toggle, zoom/aim/expand header buttons, pan+wheel gestures,
-     *  and the breakpoint context menu on graph nodes. The imperative render
-     *  pipeline (highlight, applyIndicator, scroll-into-view) is unaffected.
-     *  Default `false` preserves the full interactive behaviour for
-     *  `MachineView`. */
+    /** When true, the demo-shaped affordances disappear: the collapse
+     *  chevron is hidden (showcase panels always stay open), and the
+     *  breakpoint right-click context menu is suppressed (no debugger
+     *  flow in a prerecorded panel). Zoom / aim / pan / wheel-zoom stay
+     *  available — the user still wants to look around big showcase
+     *  graphs (machines-demo#110). The imperative render pipeline is
+     *  unaffected. Default `false` preserves the full interactive
+     *  behaviour for `MachineView`. */
     readOnly?: boolean;
     /** When true, the panel detaches into a fixed-position 80vw×80vh
      *  overlay (single-instance: same mermaid render, no DOM move).
@@ -242,7 +244,6 @@
   let panStartScrollTop = 0;
 
   function onBodyPointerDown(e: PointerEvent): void {
-    if (readOnly) return;
     if (e.button !== 0) return; // left mouse only; right is reserved for the BP context menu
     if (!canPan) return; // nothing to scroll → ignore drag (cursor reflects this too)
     if (panActive) return;
@@ -293,7 +294,6 @@
   // content under the pointer stays put (clamping at ZOOM_MIN /
   // ZOOM_MAX absorbs any single-event overshoot).
   function onBodyWheel(e: WheelEvent): void {
-    if (readOnly) return;
     if (!(e.ctrlKey || e.metaKey)) return;
     e.preventDefault();
     const factor = Math.exp(-e.deltaY * 0.012);
@@ -1159,7 +1159,7 @@
         <span class="title">Machine graph</span>
       </button>
     {/if}
-    {#if !collapsed && !readOnly}
+    {#if !collapsed}
       <div class="header-actions">
         <button
           type="button"
@@ -1248,10 +1248,10 @@
     <div
       class="body"
       class:panning={panActive}
-      class:can-pan={!readOnly && canPan}
+      class:can-pan={canPan}
       data-testid="machine-graph-body"
-      role={readOnly ? 'img' : 'application'}
-      aria-label={readOnly ? 'Machine graph' : 'Machine graph viewport (drag to pan, Ctrl+scroll to zoom)'}
+      role="application"
+      aria-label="Machine graph viewport (drag to pan, Ctrl+scroll to zoom)"
       onpointerdown={onBodyPointerDown}
       onpointermove={onBodyPointerMove}
       onpointerup={onBodyPointerUp}

--- a/src/components/SnippetPanel.svelte
+++ b/src/components/SnippetPanel.svelte
@@ -141,6 +141,12 @@
   }
 
   function onReplay(): void {
+    // Recenter on the idle node BEFORE applying frame 0 so the viewport
+    // rewinds to the same anchor the user got on first mount, instead of
+    // staying parked at wherever the last halt-iter highlight had pushed
+    // it (machines-demo#110). applyFrame() then clears the residual
+    // highlight; the timer starts after.
+    machineGraphRef?.recenterOnIdle();
     player.reset();
     prevStrongId = null;
     applyFrame();

--- a/src/components/SnippetPanel.svelte
+++ b/src/components/SnippetPanel.svelte
@@ -299,14 +299,21 @@
     background: color-mix(in srgb, var(--cell-bg) 80%, var(--fg));
   }
 
+  /* Sibling-to-Replay button styling (machines-demo#110): the link sits
+     next to the .replay <button> when playback is done, so the underline-
+     link look read as mismatched. Keep it an <a> for keyboard / right-click
+     / open-in-new-tab semantics — just match the button's surface. */
   .open-in-editor {
+    padding: 6px 14px;
+    background: var(--cell-bg);
     color: var(--fg);
-    text-decoration: underline;
-    text-decoration-color: color-mix(in srgb, var(--fg) 40%, transparent);
-    font-size: 0.875rem;
+    border: 1px solid var(--cell-border);
+    border-radius: 6px;
+    font: inherit;
+    text-decoration: none;
   }
 
   .open-in-editor:hover {
-    text-decoration-color: var(--fg);
+    background: color-mix(in srgb, var(--cell-bg) 80%, var(--fg));
   }
 </style>

--- a/src/lib/scrollCenter.test.ts
+++ b/src/lib/scrollCenter.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { computeCenterScroll, type Rect } from './scrollCenter.ts';
+
+// Container is a 400×360 box pinned at viewport (0,0) — matches MachineGraph's
+// fixed-height `.body` shape closely enough for the math to read like the
+// real call site. Scroll origin (0,0) so all returned values are absolute
+// pixel offsets, easy to read.
+const CONTAINER: Rect = {
+  top: 0, left: 0, bottom: 360, right: 400, width: 400, height: 360,
+};
+const ZERO_SCROLL = { left: 0, top: 0 };
+
+function rect(top: number, left: number, height = 30, width = 60): Rect {
+  return { top, left, height, width, bottom: top + height, right: left + width };
+}
+
+describe('computeCenterScroll', () => {
+  it('S-scroll-comfortable: returns null when el sits inside the comfort zone on both axes', () => {
+    // Default 10% inset on 400×360 → comfort zone is x∈[40,360], y∈[36,324].
+    // A 60×30 el at (200, 180) is well inside.
+    const result = computeCenterScroll(CONTAINER, ZERO_SCROLL, rect(180, 200));
+    expect(result).toBeNull();
+  });
+
+  it('S-scroll-edge-band-vertical: el at top edge band triggers vertical recenter', () => {
+    // Top edge of comfort zone is y=36. El at y=20 is in the upper 10% band
+    // (still fully visible inside container, but past comfort).
+    const el = rect(20, 200);
+    const result = computeCenterScroll(CONTAINER, ZERO_SCROLL, el);
+    expect(result).not.toBeNull();
+    expect(result?.top).toBe((20 + 15) - 180); // el center 35, container center 180
+    // Horizontal was fine — should not appear in target.
+    expect(result).not.toHaveProperty('left');
+  });
+
+  it('S-scroll-edge-band-horizontal: el at right edge band triggers horizontal recenter only', () => {
+    // Right edge of comfort zone is x=360. El.right=370 → past comfort.
+    const el = rect(180, 310, 30, 60);
+    const result = computeCenterScroll(CONTAINER, ZERO_SCROLL, el);
+    expect(result).not.toBeNull();
+    expect(result?.left).toBe((310 + 30) - 200); // el center 340, container center 200
+    expect(result).not.toHaveProperty('top');
+  });
+
+  it('S-scroll-both-axes: el clipped on both axes returns left + top', () => {
+    // El's top-left corner is at (-20, -10) — overlaps the upper-left corner.
+    const el = rect(-10, -20);
+    const result = computeCenterScroll(CONTAINER, ZERO_SCROLL, el);
+    expect(result).not.toBeNull();
+    expect(result?.left).toBe((-20 + 30) - 200);
+    expect(result?.top).toBe((-10 + 15) - 180);
+  });
+
+  it('S-scroll-respects-current-scroll: deltas add to the existing scrollLeft/scrollTop', () => {
+    // Container is conceptually scrolled (250, 80). El's rect is in viewport
+    // coords (so it already reflects the current scroll). The target value
+    // is the absolute new scrollLeft / scrollTop — old + delta.
+    const result = computeCenterScroll(
+      CONTAINER,
+      { left: 250, top: 80 },
+      rect(-10, -20),
+    );
+    expect(result?.left).toBe(250 + ((-20 + 30) - 200));
+    expect(result?.top).toBe(80 + ((-10 + 15) - 180));
+  });
+
+  it('S-scroll-custom-inset-ratio: a 25% inset shrinks the comfort zone', () => {
+    // At ratio 0.25, comfort zone on 400×360 is x∈[100,300], y∈[90,270]. A
+    // node at (50, 50) — comfortable under the 10% default — now triggers.
+    const el = rect(50, 50);
+    const defaultResult = computeCenterScroll(CONTAINER, ZERO_SCROLL, el);
+    expect(defaultResult).toBeNull();
+    const tightResult = computeCenterScroll(CONTAINER, ZERO_SCROLL, el, 0.25);
+    expect(tightResult).not.toBeNull();
+  });
+
+  it('S-scroll-larger-than-comfort-zone: huge el always returns a center target', () => {
+    // El is wider than the comfort zone (400 wide). By the "fully inside"
+    // rule it can never be comfortable horizontally, so we always emit a
+    // horizontal target that puts its center at container center.
+    const huge: Rect = { top: 180, left: -20, height: 30, width: 400, bottom: 210, right: 380 };
+    const result = computeCenterScroll(CONTAINER, ZERO_SCROLL, huge);
+    expect(result).not.toBeNull();
+    // El center is at x=180, container center at x=200 → delta -20.
+    expect(result?.left).toBe(-20);
+  });
+
+  it('S-scroll-non-zero-container-origin: rects in viewport coords still produce correct deltas', () => {
+    // Container is shifted in the viewport (e.g., MachineGraph's body lives
+    // below a header). Math should be coord-system-agnostic since we only
+    // use rect coords relative to each other.
+    const offsetContainer: Rect = {
+      top: 100, left: 50, bottom: 460, right: 450, width: 400, height: 360,
+    };
+    const el: Rect = {
+      top: 110, left: 60, height: 30, width: 60, bottom: 140, right: 120,
+    };
+    const result = computeCenterScroll(offsetContainer, ZERO_SCROLL, el);
+    expect(result).not.toBeNull();
+    // El center (125, 90), container center (250, 280) → deltas (-125, -190).
+    // El is in the top-left corner of the container's viewport.
+    expect(result?.left).toBeCloseTo(60 + 30 - 250);
+    expect(result?.top).toBeCloseTo(110 + 15 - 280);
+  });
+});

--- a/src/lib/scrollCenter.test.ts
+++ b/src/lib/scrollCenter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeCenterScroll, type Rect } from './scrollCenter.ts';
+import { computeCenterScroll, computeFitZoom, type Rect } from './scrollCenter.ts';
 
 // Container is a 400×360 box pinned at viewport (0,0) — matches MachineGraph's
 // fixed-height `.body` shape closely enough for the math to read like the
@@ -101,5 +101,55 @@ describe('computeCenterScroll', () => {
     // El is in the top-left corner of the container's viewport.
     expect(result?.left).toBeCloseTo(60 + 30 - 250);
     expect(result?.top).toBeCloseTo(110 + 15 - 280);
+  });
+});
+
+describe('computeFitZoom', () => {
+  it('Z-fit-already-fits: SVG smaller than body keeps zoom at 1', () => {
+    expect(computeFitZoom(200, 150, 400, 360)).toBe(1);
+  });
+
+  it('Z-fit-exact: SVG that exactly matches body still keeps zoom 1', () => {
+    expect(computeFitZoom(400, 360, 400, 360)).toBe(1);
+  });
+
+  it('Z-fit-default-60-both-axes: big graph scales so ≥60% area visible', () => {
+    // 800×500 SVG in 400×360 body — both axes overflow at z=1.
+    const z = computeFitZoom(800, 500, 400, 360);
+    expect(z).toBeLessThan(1);
+    expect(z).toBeGreaterThan(0);
+    // At the returned z, visibleRatio = (400/(800z)) * (360/(500z)) =
+    // 144000 / (400000 * z²); for ratio ≥ 0.6, z ≤ sqrt(0.6) ≈ 0.7746.
+    expect(z).toBeLessThanOrEqual(Math.sqrt(0.6) + 1e-3);
+    expect(z).toBeGreaterThan(Math.sqrt(0.6) - 1e-3);
+  });
+
+  it('Z-fit-mixed-overflow: SVG wide but short still scaled to hit ≥60%', () => {
+    // 1200×100 SVG in 400×360 body — only width overflows at z=1.
+    // At z=1: visibleRatio = (400/1200) * 1 = 0.333 — needs scaling.
+    const z = computeFitZoom(1200, 100, 400, 360);
+    expect(z).toBeLessThan(1);
+    // At target z, visibleRatio = (400/(1200z)) * min(1, 360/(100z))
+    //   - If z < 3.6, vertical fits → ratio = 400/(1200z) = 1/(3z)
+    //   - Solve 1/(3z) = 0.6 → z = 1/1.8 ≈ 0.555
+    expect(z).toBeCloseTo(1 / 1.8, 4);
+  });
+
+  it('Z-fit-custom-ratio: lower target lets zoom stay higher', () => {
+    // Same big SVG, target 30% instead of 60%.
+    const z60 = computeFitZoom(800, 500, 400, 360, 0.6);
+    const z30 = computeFitZoom(800, 500, 400, 360, 0.3);
+    expect(z30).toBeGreaterThan(z60);
+  });
+
+  it('Z-fit-degenerate-zero: zero / negative inputs short-circuit to 1', () => {
+    expect(computeFitZoom(0, 500, 400, 360)).toBe(1);
+    expect(computeFitZoom(800, 0, 400, 360)).toBe(1);
+    expect(computeFitZoom(800, 500, 0, 360)).toBe(1);
+    expect(computeFitZoom(800, 500, 400, 0)).toBe(1);
+  });
+
+  it('Z-fit-degenerate-zero-ratio: a 0% target also short-circuits to 1', () => {
+    expect(computeFitZoom(800, 500, 400, 360, 0)).toBe(1);
   });
 });

--- a/src/lib/scrollCenter.ts
+++ b/src/lib/scrollCenter.ts
@@ -1,14 +1,18 @@
-// Pure scroll-math helper for the machine-graph "follow the highlight"
-// behaviour (machines-demo#110). Computes where to scroll a container so a
-// target element sits at the visible center, but only when the element has
-// drifted outside a "comfort zone" inset of the container's viewport. Lets
-// the previous "fully off-screen by 16px" policy go — a target sitting at
-// the edge band counts as needing recentering.
+// Pure viewport-math helpers for the machine-graph panel (machines-demo#110).
+//
+// - `computeCenterScroll` decides where to scroll a container so a target
+//   element sits at the visible center, but only when the element has
+//   drifted outside a "comfort zone" inset of the container's viewport.
+//   Replaces the prior "fully off-screen by 16px" policy.
+// - `computeFitZoom` picks the largest zoom ≤ 1 such that at least
+//   `minVisibleAreaRatio` of the SVG's area fits inside the body. Used as
+//   the initial zoom on each (re)render so big graphs (callable-subtree,
+//   Brainfuck UTM) don't open as a sliver of the diagram.
 //
 // Lives next to other pure boot-time helpers (initialBoot.ts) so the math
 // can be unit-tested without happy-dom layout (`getBoundingClientRect` in
 // happy-dom returns zeros — no real layout engine — so the component-level
-// scrollIntoView path is not directly testable there).
+// scroll / zoom paths are not directly testable there).
 
 export type Rect = {
   top: number;
@@ -68,4 +72,44 @@ export function computeCenterScroll(
     target.left = scroll.left + (elCenterX - containerCenterX);
   }
   return target;
+}
+
+/**
+ * Pick the largest zoom ≤ 1 such that at least `minVisibleAreaRatio` of the
+ * SVG's intrinsic area fits inside the body's content box (machines-demo#110).
+ * Returns `1` when the SVG already fits comfortably at full size.
+ *
+ * The visible-area ratio is a strictly decreasing function of zoom — larger
+ * zoom shows a smaller fraction of the SVG — so a 30-step binary search
+ * converges to ~1e-9 precision. Closed-form would need a piecewise case
+ * analysis around the "one axis fits while the other overflows" transition;
+ * the search keeps the math obvious.
+ *
+ * Caller is responsible for clamping the result to `ZOOM_MIN` — when even
+ * the minimum zoom doesn't reach the target ratio, we accept "less than the
+ * target visible" rather than zoom out further.
+ */
+export function computeFitZoom(
+  svgWidth: number,
+  svgHeight: number,
+  bodyWidth: number,
+  bodyHeight: number,
+  minVisibleAreaRatio = 0.6,
+): number {
+  if (svgWidth <= 0 || svgHeight <= 0 || bodyWidth <= 0 || bodyHeight <= 0) return 1;
+  if (minVisibleAreaRatio <= 0) return 1;
+  const visibleRatio = (z: number): number => {
+    const sw = svgWidth * z;
+    const sh = svgHeight * z;
+    return Math.min(1, bodyWidth / sw) * Math.min(1, bodyHeight / sh);
+  };
+  if (visibleRatio(1) >= minVisibleAreaRatio) return 1;
+  let lo = 1e-6;
+  let hi = 1;
+  for (let i = 0; i < 30; i++) {
+    const mid = (lo + hi) / 2;
+    if (visibleRatio(mid) >= minVisibleAreaRatio) lo = mid;
+    else hi = mid;
+  }
+  return lo;
 }

--- a/src/lib/scrollCenter.ts
+++ b/src/lib/scrollCenter.ts
@@ -1,0 +1,71 @@
+// Pure scroll-math helper for the machine-graph "follow the highlight"
+// behaviour (machines-demo#110). Computes where to scroll a container so a
+// target element sits at the visible center, but only when the element has
+// drifted outside a "comfort zone" inset of the container's viewport. Lets
+// the previous "fully off-screen by 16px" policy go — a target sitting at
+// the edge band counts as needing recentering.
+//
+// Lives next to other pure boot-time helpers (initialBoot.ts) so the math
+// can be unit-tested without happy-dom layout (`getBoundingClientRect` in
+// happy-dom returns zeros — no real layout engine — so the component-level
+// scrollIntoView path is not directly testable there).
+
+export type Rect = {
+  top: number;
+  left: number;
+  bottom: number;
+  right: number;
+  width: number;
+  height: number;
+};
+
+export type ScrollOffset = { left: number; top: number };
+
+export type ScrollTarget = { left?: number; top?: number };
+
+/**
+ * Decide whether `el` needs to be scrolled within `container`, and if so,
+ * to what absolute `scrollLeft` / `scrollTop` values.
+ *
+ * The element is considered "comfortable" on an axis when its bounding
+ * rect on that axis sits fully inside the container rect minus
+ * `comfortInsetRatio * size` on each side. With the default ratio of
+ * `0.1`, the inner comfort zone is the middle 80% of the container's
+ * width/height — so a node has to drift into the outer 10% band on
+ * either side before we recenter it.
+ *
+ * The per-axis check is independent: a node that's drifted off the right
+ * edge but is vertically centered gets a horizontal-only recentering
+ * (the returned `ScrollTarget` omits `top` in that case). This matches
+ * the prior `scrollIntoViewIfNeeded` shape so callers can fold the
+ * result into a single `scrollTo({...target, behavior})`.
+ *
+ * Returns `null` when no scroll is needed (both axes comfortable). The
+ * caller can short-circuit on that.
+ */
+export function computeCenterScroll(
+  containerRect: Rect,
+  scroll: ScrollOffset,
+  elRect: Rect,
+  comfortInsetRatio = 0.1,
+): ScrollTarget | null {
+  const insetV = containerRect.height * comfortInsetRatio;
+  const insetH = containerRect.width * comfortInsetRatio;
+  const comfortableV = elRect.top >= containerRect.top + insetV
+    && elRect.bottom <= containerRect.bottom - insetV;
+  const comfortableH = elRect.left >= containerRect.left + insetH
+    && elRect.right <= containerRect.right - insetH;
+  if (comfortableV && comfortableH) return null;
+  const target: ScrollTarget = {};
+  if (!comfortableV) {
+    const elCenterY = elRect.top + elRect.height / 2;
+    const containerCenterY = containerRect.top + containerRect.height / 2;
+    target.top = scroll.top + (elCenterY - containerCenterY);
+  }
+  if (!comfortableH) {
+    const elCenterX = elRect.left + elRect.width / 2;
+    const containerCenterX = containerRect.left + containerRect.width / 2;
+    target.left = scroll.left + (elCenterX - containerCenterX);
+  }
+  return target;
+}


### PR DESCRIPTION
Closes #110.

Bundles all six scope items captured on the issue thread:

## Scope

1. **Highlight follow during playback** — `SnippetPanel`'s per-frame `ops.scrollIntoView` already fires via `applyHighlight` (the issue's "this never happens" framing was off); the actual gap was `scrollIntoViewIfNeeded`'s "fully outside by 16px" policy. Replaced with `centerIfNeeded`: a node has to sit inside the inner 80% of the body to skip; otherwise we center it on the failing axis. Per-axis check stays independent. Pure math extracted to `lib/scrollCenter.ts::computeCenterScroll`.
2. **Reduced-motion-aware scroll behavior** — both `scrollIntoView` op sites (apply-highlight effect + `getOps`) route through a new `preferredScrollBehavior` helper that returns `'instant'` when `prefers-reduced-motion: reduce`.
3. **`Open in editor` styled as a button** — sits next to `.replay` when playback is done; restyled the `<a>` to match the `.replay` surface. Kept as `<a>` for keyboard / right-click / open-in-new-tab semantics.
4. **Auto-fit initial zoom** — pick the largest zoom ≤ 1 such that ≥60% of the SVG's intrinsic area sits inside the body, clamped to `ZOOM_MIN`. For big graphs (callable-subtree, Brainfuck UTM) the user no longer opens to a sliver. Pure math in `lib/scrollCenter.ts::computeFitZoom` (binary search — monotone, closed-form needs a piecewise case analysis that the search sidesteps).
5. **Initial center on idle for showcase** — the readOnly-specific content-centroid effect (which on callable-subtree graphs landed between the main flow and the subgraph) is dropped; the existing engine-side `centerInScroller(body, idle)` pass runs for both modes. Merged with the auto-fit pass into one explicit sequence (`zoom = 1 → tick → measure → zoom = fitZoom → tick → center`) instead of the prior implicit-race-then-overwrite of two effects.
6. **Recenter on idle on Replay** — new `MachineGraph.recenterOnIdle()` imperative method, sibling to `getOps` / `clearHighlights`. Called by `SnippetPanel.onReplay` before `player.reset()` so a Replay-clicked panel rewinds to the same anchor the user got on first mount, not wherever the last halt-iter highlight had pushed the viewport.
7. **Zoom controls + pan + wheel-zoom available in readOnly** — `readOnly` originally locked the whole interactive surface; narrowed it to "no collapse chevron + no BP context menu" so the showcase still has zoom buttons, drag-to-pan, ctrl/cmd-wheel zoom (and pinch on trackpads). Expand button stays hidden because SnippetPanel doesn't pass `onExpand`.

## Why one PR

Six items, all on the same `MachineGraph.svelte` + `SnippetPanel.svelte` + `lib/scrollCenter.ts` surface, all driven by the same #110 thread. Splitting into six branches would touch the same lines repeatedly and not save review effort. Three commits on the branch group the work for readers; squash-merge produces a single coherent commit on master.

## Verification

- 270/270 unit tests pass (15 new in `src/lib/scrollCenter.test.ts` covering `computeCenterScroll` and `computeFitZoom` edge cases — happy-dom can't exercise the component-level scroll/zoom paths because `getBoundingClientRect` returns zeros, so the pure-math extraction is what carries verification).
- `npm run check` (svelte-check): 0 errors, 0 warnings across 645 files.
- `npm run lint`: clean.

## Test plan

- [ ] CI green.
- [ ] Local dev (`npm run dev`) — landing page, all six showcase panels:
  - Initial view shows ≥60% of the graph (sliver-on-callable-subtree gone).
  - Idle node is in the center on first paint.
  - Highlight follows playback even into the callable subgraph / outside the initial fit window.
  - Replay rewinds viewport back to idle anchor.
  - Zoom in / out / reset buttons in the panel header work; ctrl/cmd + scroll zooms; drag pans.
  - `Open in editor` reads as a button at the same height as Replay.
- [ ] Engine pages (`/turing`, `/post`) — Build + Step + Run + pause:
  - Paused highlight sitting in the edge band now recenters (previously only fully-outside triggered).
  - Manual pan choices are still respected on pauses that fall inside the comfort zone.
- [ ] `prefers-reduced-motion: reduce` — scroll-into-view becomes instant in both modes.