### PR TITLE
feat: showcase panel overhaul — execution-trace table, lesson notes, single-snippet orchestration (#112)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,9 @@ src/
 ├── app.css                  global tokens + base styles
 ├── components/
 │   ├── MachineView.svelte   per-engine orchestrator (state + handlers)
+│   ├── Landing.svelte       `/` route — engine switcher + snippet-grid; owns the single IntersectionObserver across all panels and dispatches an `active: boolean` to the most-visible SnippetPanel (one snippet plays at a time)
+│   ├── SnippetPanel.svelte  showcase tile — two-column layout (player + lesson notes; stacks under 768px); 4-state playback machine (`idle | playing | paused | done`) driven by the `active` prop; `done` is sticky (no auto-replay on re-activation, Replay only). Reduced-motion pins to final frame on mount, IO orchestration is skipped.
+│   ├── ExecutionTraceTable.svelte  read-only 6-column trace (Step | State | Head reads | Write | Move | Goto); sticky thead inside `max-height` scroll, `aria-current="step"` + accent row, manual `scrollTop` math (no `Element.scrollIntoView`, which would yank the page)
 │   ├── TapesStack.svelte    multi-tape stack with shared head-thread
 │   ├── Tape.svelte          single horizontal belt (renders a turing.Tape)
 │   ├── ControlPanel.svelte  L/S/R + alphabet chips + Apply
@@ -74,8 +77,9 @@ src/
     ├── persist.ts              localStorage helpers per engine — code, example, snippets (UUID-keyed)
     ├── tapeSnapshot.ts         serialize/parse for tape-block copy+paste snapshots — JSON with `format`/`version` discriminator, categorized ParseError, no DOM/clipboard knowledge
     ├── tapeSnapshot.test.ts    Vitest suite for tapeSnapshot — roundtrip / parse-not-json / wrong-format / unsupported-version / wrong-shape-* / length-mismatch (cites R-snapshot-...)
-    ├── defaultCode.ts          starter Turing / Post snippets
+    ├── defaultCode.ts          starter Turing / Post snippets — `Example` type carries optional `lessonNotes` (markdown subset) authored per showcase for the SnippetPanel right column
     ├── format.ts               LogEntry assemblers: commandsEntry / tapesEntry / CommandsApplication; per-step string rendering (`formatStepNotation`, `formatTape`) is consumed from `@turing-machine-js/visuals`
+    ├── lessonMarkdown.ts       tiny markdown renderer for `Example.lessonNotes` — HTML-escapes input, then handles paragraphs (blank-line split), bullet lists (`- ` prefix), and inline `` `code` ``. Build-time author content only; injected via `{@html}` in `SnippetPanel.svelte` (same policy as the SVG-icon `{@html}` use).
     ├── icons.ts                Tabler icon namespace (?raw imports)
     └── theme.svelte.ts         theme (light / dark) state + matchMedia watcher (Svelte 5 .svelte.ts module)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Interactive in-browser playground for **Turing** and **Post** machines.
 
 **Live demo:** [demo.machines.mellonis.ru](https://demo.machines.mellonis.ru)
 
-Two tabs (Turing, Post) where you write JavaScript that builds a machine — using the published [`@turing-machine-js/machine`](https://www.npmjs.com/package/@turing-machine-js/machine), [`@post-machine-js/machine`](https://www.npmjs.com/package/@post-machine-js/machine), and [`@turing-machine-js/visuals`](https://www.npmjs.com/package/@turing-machine-js/visuals) (highlight + graph-indexing surface) libraries — and watch it execute on an animated tape. Auto-running demo on first load, manual control of the tape head via a movement/symbol/Apply panel, single-step and paused-auto-step execution, a log of every command applied, and clipboard copy/paste of the tape-block state for sharing or restoring snapshots.
+A landing page (`/`) introduces both engines through a column of showcase panels — each panel auto-plays a prerecorded run of one small program, with the state graph, tape, and a step-by-step execution-trace table laid out beside human-readable lesson notes that describe what the program is doing. From there, two engine tabs (`/turing`, `/post`) drop you into an editor where you write JavaScript that builds a machine — using the published [`@turing-machine-js/machine`](https://www.npmjs.com/package/@turing-machine-js/machine), [`@post-machine-js/machine`](https://www.npmjs.com/package/@post-machine-js/machine), and [`@turing-machine-js/visuals`](https://www.npmjs.com/package/@turing-machine-js/visuals) (highlight + graph-indexing surface) libraries — and watch it execute on an animated tape. Manual control of the tape head via a movement/symbol/Apply panel, single-step and paused-auto-step execution, a log of every command applied, and clipboard copy/paste of the tape-block state for sharing or restoring snapshots.
 
 ## Running locally
 
@@ -84,6 +84,9 @@ src/
 ├── app.css                     # global tokens + base styles
 ├── components/
 │   ├── MachineView.svelte      # per-engine orchestrator (one $state, derived disabled flags)
+│   ├── Landing.svelte          # `/` route — engine switcher + showcase grid; owns the single IntersectionObserver and dispatches `active: boolean` so only one snippet plays at a time
+│   ├── SnippetPanel.svelte     # showcase tile — two-column layout (player + lesson notes); 4-state playback machine driven by `active`
+│   ├── ExecutionTraceTable.svelte  # 6-column read-only execution trace inside the player column
 │   ├── TapesStack.svelte       # multi-tape stack with shared head-thread
 │   ├── Tape.svelte             # virtualized belt with prep-shift slide trick
 │   ├── ControlPanel.svelte     # L/S/R + alphabet chips + Apply
@@ -115,13 +118,16 @@ src/
     ├── persist.ts              # localStorage helpers per engine
     ├── tapeSnapshot.ts         # serialize/parse tape-block snapshots for copy+paste
     ├── tapeSnapshot.test.ts    # Vitest suite for tapeSnapshot
-    ├── defaultCode.ts          # starter Turing / Post snippets
+    ├── defaultCode.ts          # starter Turing / Post snippets — Example.lessonNotes carries the showcase prose
     ├── format.ts               # LogEntry assemblers (commandsEntry / tapesEntry); per-step string rendering from @turing-machine-js/visuals
+    ├── lessonMarkdown.ts       # tiny markdown subset (paragraphs / bullets / inline code) for SnippetPanel lesson prose
     ├── icons.ts                # Tabler icon namespace
     └── theme.svelte.ts         # theme (light / dark) state + matchMedia watcher
 
 e2e/
-└── cold-start.spec.ts            # Playwright E2E — 4 cold-start scenarios
+├── cold-start.spec.ts            # Playwright E2E — cold-start scenarios for engine pages
+├── completions.spec.ts           # Playwright E2E — smart completions roundtrip
+└── landing.spec.ts               # Playwright E2E — landing page panels + engine switch + deep-link to editor
 
 playwright.config.ts              # Chromium project; webServer = vite preview
 ```

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -44,6 +44,10 @@ stateDiagram-v2
     note right of HALTED : Error, timeout, truncation, or cold-start build error from any non-resting state lands HALTED.
 ```
 
+### 1.1 Scope: engine pages only
+
+This document describes the **engine pages** (`/turing`, `/post`) — `MachineView.svelte` driving a real `DebugSession` over a live machine in a worker. The landing page (`/`) renders showcase **`SnippetPanel`** tiles instead: those play back prerecorded `Snippet` artifacts produced at build time by `recordSnippet` (via the `src/vite-plugins/snippets.ts` Vite plugin). No worker, no `DebugSession`, no breakpoints — just a `SnippetPlayer` reading frames from an in-memory artifact, driven by its own playback state machine (`idle` / `playing` / `paused` / `done`) and orchestrated by Landing's IntersectionObserver. See `Landing.svelte` and `SnippetPanel.svelte` for the playback model; it's orthogonal to everything below.
+
 ## 2. Mode reference
 
 Three lines per mode: what it means, how it's entered, how it's exited. UI / log detail belongs in §6 Action matrix and §8 walk-throughs.

--- a/docs/machine-graph-palette.md
+++ b/docs/machine-graph-palette.md
@@ -42,6 +42,7 @@ A swap between any two adjacent tiers should be visually obvious without squinti
 | Highlight: to node | `--graph-highlight-soft-fill` + `--graph-highlight` stroke | Successor of just-fired |
 | Highlight: strong (m.state) | `--graph-highlight-strong-fill` + thicker `--graph-highlight` stroke + glow | "You are here" |
 | Highlight: edge (just-fired) | `--graph-highlight` | Thicker stroke than default |
+| Snippet trace: current row bg | `--graph-highlight-soft-fill` | `ExecutionTraceTable.svelte` reuses the same accent so the live-graph "you are here" feel carries over to the trace table sitting beside it — tune both surfaces together when revisiting this token. |
 
 ## Proposed values
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "machines-demo",
-  "version": "1.0.0-alpha.24",
+  "version": "1.0.0-alpha.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "machines-demo",
-      "version": "1.0.0-alpha.24",
+      "version": "1.0.0-alpha.25",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machines-demo",
   "private": true,
-  "version": "1.0.0-alpha.24",
+  "version": "1.0.0-alpha.25",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -242,6 +242,11 @@
 
   main {
     flex: 1;
+    /* min-height:0 lets Landing's internal overflow-y:auto actually scroll
+       its content instead of pushing main beyond its flex allotment — the
+       flex-item min-height:auto default would otherwise let tall snippet
+       grids spill into the body's scroll. */
+    min-height: 0;
     overflow: hidden;
     display: flex;
 

--- a/src/app.css
+++ b/src/app.css
@@ -203,6 +203,12 @@ body {
 body {
   display: flex;
   flex-direction: column;
+  /* Body never scrolls — internal containers (`.landing` on desktop,
+     `<main>` on narrow viewports) own all scroll, so the body / page
+     itself stays pinned at 100vh. Without this, Safari's rubber-band
+     overscroll exposes empty space below the footer when content is
+     short. */
+  overflow: hidden;
 }
 
 #app {

--- a/src/components/ExecutionTraceTable.svelte
+++ b/src/components/ExecutionTraceTable.svelte
@@ -1,0 +1,222 @@
+<script lang="ts">
+  import type { Frame, GraphHighlight, Snippet } from '@turing-machine-js/visuals';
+
+  type Props = {
+    frames: Frame[];
+    /**
+     * Step number to highlight. `null` clears the highlight entirely —
+     * used by SnippetPanel to mirror the graph's neutral state after
+     * playback finishes naturally (parallels #108).
+     */
+    frameIndex: number | null;
+    graph: Snippet['graph'];
+    blanks: string[];
+  };
+  let { frames, frameIndex, graph, blanks }: Props = $props();
+
+  // Frame 0 is the initial state — no transition fired, no row. Each row maps
+  // 1:1 to one engine iter (frames.slice(1)).
+  const rows = $derived(frames.slice(1));
+  const tapeCount = $derived(rows[0]?.tape.length ?? 1);
+
+  function nodeName(id: number | 'idle' | null): string {
+    // Halt is always id 0 in the engine's Graph. The literal node name there
+    // is an implementation detail (defaults like `id:0`); the table renders
+    // the affordance, not the internals.
+    if (id === null || id === 0) return 'halt';
+    if (id === 'idle') return 'idle';
+    return graph.nodes[id]?.name ?? `#${id}`;
+  }
+
+  function gotoName(highlight: GraphHighlight | null): string {
+    if (!highlight) return '';
+    // toId === 0 is the halt singleton; recordSnippet stamps it for halting
+    // transitions. graph.nodes[0].name is 'halt' by engine convention.
+    return nodeName(highlight.toId);
+  }
+
+  function stateName(highlight: GraphHighlight | null): string {
+    if (!highlight) return '';
+    return nodeName(highlight.fromId);
+  }
+
+  // Per-cell rendering. Returns the literal symbol (no UI substitution per
+  // CLAUDE.md "No UI substitution of alphabet symbols"); the `blank` flag
+  // drives a CSS dim class so blank cells stay visually distinct without
+  // overloading a specific glyph (matches Tape.svelte's `.cell.blank` policy).
+  type CellPart = { text: string; blank: boolean };
+
+  function readPart(read: string, blank: string): CellPart {
+    return { text: read, blank: read === blank };
+  }
+
+  function writePart(write: string, read: string, blank: string): CellPart {
+    // README convention: 'keep' when write === read. Not blank-flagged — a
+    // literal keep is informative on its own.
+    if (write === read) return { text: 'keep', blank: false };
+    return { text: write, blank: write === blank };
+  }
+
+  function movePart(movement: 'L' | 'R' | 'S'): CellPart {
+    return { text: movement, blank: false };
+  }
+
+  let wrapEl: HTMLDivElement | undefined = $state();
+  let tableEl: HTMLTableElement | undefined = $state();
+
+  // Keep the highlighted row inside the trace-wrap viewport — but only
+  // scroll the wrap container, never propagate to ancestor scrollers.
+  // `Element.scrollIntoView` walks up every overflow ancestor (page included),
+  // so a partially-visible panel would yank the whole landing layout each
+  // time frameIndex ticked. Manual `scrollTop` adjustment on `.trace-wrap`
+  // stays scoped to the table.
+  $effect(() => {
+    const step = frameIndex;
+    if (!wrapEl || !tableEl || step === null || step === 0) return;
+    const row = tableEl.querySelector<HTMLTableRowElement>(
+      `tr[data-step="${step}"]`,
+    );
+    if (!row) return;
+    const rowRect = row.getBoundingClientRect();
+    const wrapRect = wrapEl.getBoundingClientRect();
+    if (rowRect.top < wrapRect.top) {
+      wrapEl.scrollTop += rowRect.top - wrapRect.top;
+    } else if (rowRect.bottom > wrapRect.bottom) {
+      wrapEl.scrollTop += rowRect.bottom - wrapRect.bottom;
+    }
+  });
+</script>
+
+<div class="trace-wrap" bind:this={wrapEl} data-testid="snippet-execution-trace">
+  <table bind:this={tableEl}>
+    <thead>
+      <tr>
+        <th scope="col">Step</th>
+        <th scope="col">State</th>
+        <th scope="col">Head reads</th>
+        <th scope="col">Write</th>
+        <th scope="col">Move</th>
+        <th scope="col">Goto</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each rows as row (row.step)}
+        {@const isCurrent = row.step === frameIndex}
+        {@const cmds = row.commands ?? []}
+        <tr
+          class:current={isCurrent}
+          aria-current={isCurrent ? 'step' : undefined}
+          data-testid="trace-row"
+          data-step={row.step}
+        >
+          <td class="num">{row.step}</td>
+          <td class="name">{stateName(row.highlight)}</td>
+          <td>
+            {#if tapeCount > 1}<span class="brace">[</span>{/if}
+            {#each cmds as cmd, i (i)}
+              {#if i > 0}<span class="sep">, </span>{/if}
+              {@const p = readPart(cmd.read, blanks[i] ?? ' ')}
+              <span class="cell" class:blank={p.blank}>{p.text}</span>
+            {/each}
+            {#if tapeCount > 1}<span class="brace">]</span>{/if}
+          </td>
+          <td>
+            {#if tapeCount > 1}<span class="brace">[</span>{/if}
+            {#each cmds as cmd, i (i)}
+              {#if i > 0}<span class="sep">, </span>{/if}
+              {@const p = writePart(cmd.write, cmd.read, blanks[i] ?? ' ')}
+              <span class="cell" class:blank={p.blank}>{p.text}</span>
+            {/each}
+            {#if tapeCount > 1}<span class="brace">]</span>{/if}
+          </td>
+          <td>
+            {#if tapeCount > 1}<span class="brace">[</span>{/if}
+            {#each cmds as cmd, i (i)}
+              {#if i > 0}<span class="sep">, </span>{/if}
+              {@const p = movePart(cmd.movement)}
+              <span class="cell">{p.text}</span>
+            {/each}
+            {#if tapeCount > 1}<span class="brace">]</span>{/if}
+          </td>
+          <td class="name">{gotoName(row.highlight)}</td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>
+
+<style>
+  .trace-wrap {
+    /* Bundled showcases run short — most fit fully expanded. Longer programs
+       (Copy multi-tape and friends) cap here and scroll-into-view keeps the
+       current row visible. ~10 rows at the table's row height. */
+    max-height: 280px;
+    overflow-y: auto;
+    border: 1px solid var(--cell-border);
+    border-radius: 6px;
+    background: var(--editor-bg);
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+    font-size: 0.78rem;
+    color: var(--fg);
+  }
+
+  thead th {
+    /* Sticky header inside the scroll container. `background` is mandatory
+       so rows don't bleed through during scroll. */
+    position: sticky;
+    top: 0;
+    background: var(--editor-bg);
+    z-index: 1;
+    font-weight: 600;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: color-mix(in srgb, var(--fg) 65%, transparent);
+    text-align: left;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--cell-border);
+  }
+
+  tbody td {
+    padding: 4px 10px;
+    border-bottom: 1px solid color-mix(in srgb, var(--cell-border) 60%, transparent);
+    white-space: nowrap;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  tr.current {
+    /* Reuses the graph's pause-highlight token — same "current focus" accent
+       semantics, no new palette entry. */
+    background: var(--graph-highlight-soft-fill);
+  }
+
+  td.num {
+    text-align: right;
+    color: color-mix(in srgb, var(--fg) 60%, transparent);
+    width: 1%;
+  }
+
+  td.name {
+    font-weight: 500;
+  }
+
+  .cell.blank {
+    /* Mirrors Tape.svelte's `.cell.blank` policy: dim the literal blank
+       glyph so blank cells stay recognisable regardless of which character
+       the user chose as their blank. */
+    opacity: 0.5;
+  }
+
+  .brace,
+  .sep {
+    color: color-mix(in srgb, var(--fg) 50%, transparent);
+  }
+</style>

--- a/src/components/ExecutionTraceTable.test.ts
+++ b/src/components/ExecutionTraceTable.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/svelte';
+import type { Frame, Snippet } from '@turing-machine-js/visuals';
+import ExecutionTraceTable from './ExecutionTraceTable.svelte';
+
+afterEach(() => cleanup());
+
+type Props = {
+  frames: Frame[];
+  frameIndex: number;
+  graph: Snippet['graph'];
+  blanks: string[];
+};
+
+const SINGLE_TAPE_GRAPH = {
+  initialId: 1,
+  alphabets: [[' ', 'a', 'b']],
+  nodes: {
+    0: { id: 0, name: 'halt' },
+    1: { id: 1, name: 'S' },
+    2: { id: 2, name: 'T' },
+  },
+} as unknown as Snippet['graph'];
+
+function singleTapeFrames(): Frame[] {
+  return [
+    { step: 0, tape: [{ symbols: ['a', 'b'], position: 0 }], highlight: null },
+    {
+      step: 1,
+      tape: [{ symbols: ['b', 'b'], position: 1 }],
+      commands: [{ movement: 'R', read: 'a', write: 'b' }],
+      highlight: { fromId: 1, toId: 2, strong: 'from', paused: false },
+    },
+    {
+      step: 2,
+      tape: [{ symbols: ['b', 'b'], position: 1 }],
+      // write === read → "keep"
+      commands: [{ movement: 'L', read: 'b', write: 'b' }],
+      highlight: { fromId: 2, toId: 1, strong: 'from', paused: false },
+    },
+    {
+      step: 3,
+      tape: [{ symbols: ['b', ' '], position: 1 }],
+      // read is the blank
+      commands: [{ movement: 'S', read: ' ', write: ' ' }],
+      highlight: { fromId: 1, toId: 0, strong: 'from', paused: false },
+    },
+  ];
+}
+
+function renderTable(props: Partial<Props> = {}) {
+  return render(ExecutionTraceTable, {
+    frames: singleTapeFrames(),
+    frameIndex: 0,
+    graph: SINGLE_TAPE_GRAPH,
+    blanks: [' '],
+    ...props,
+  });
+}
+
+describe('ExecutionTraceTable', () => {
+  it('T-trace-skips-frame-0: emits one row per iter, not per frame', () => {
+    renderTable();
+    const rows = screen.getAllByTestId('trace-row');
+    // 4 frames → 3 rows (skip frame 0).
+    expect(rows).toHaveLength(3);
+    expect(rows[0].dataset.step).toBe('1');
+    expect(rows[2].dataset.step).toBe('3');
+  });
+
+  it('T-trace-current-row: highlights the row matching frameIndex via aria-current', () => {
+    renderTable({ frameIndex: 2 });
+    const current = document.querySelectorAll('[aria-current="step"]');
+    expect(current).toHaveLength(1);
+    expect((current[0] as HTMLElement).dataset.step).toBe('2');
+  });
+
+  it('T-trace-no-current-on-frame-0: when frameIndex is 0 no row is current', () => {
+    renderTable({ frameIndex: 0 });
+    expect(document.querySelector('[aria-current="step"]')).toBeNull();
+  });
+
+  it('T-trace-state-and-goto: looks up names from graph; halt resolves via node 0', () => {
+    renderTable({ frameIndex: 3 });
+    const halting = document.querySelector<HTMLTableRowElement>(
+      '[data-testid="trace-row"][data-step="3"]',
+    );
+    expect(halting).not.toBeNull();
+    const cells = halting!.querySelectorAll('td');
+    // Columns: step, state, reads, write, move, goto
+    expect(cells[1].textContent).toBe('S');
+    expect(cells[5].textContent).toBe('halt');
+  });
+
+  it('T-trace-write-keep: write === read renders "keep"', () => {
+    renderTable();
+    const row = document.querySelector<HTMLTableRowElement>(
+      '[data-testid="trace-row"][data-step="2"]',
+    );
+    const cells = row!.querySelectorAll('td');
+    // Write column index 3
+    expect(cells[3].textContent?.trim()).toBe('keep');
+  });
+
+  it('T-trace-blank-class: blank symbol cells carry the .blank class for dimming', () => {
+    renderTable();
+    const blankRow = document.querySelector<HTMLTableRowElement>(
+      '[data-testid="trace-row"][data-step="3"]',
+    );
+    // Reads column (index 2): inner span should have .blank
+    const readsSpan = blankRow!.querySelectorAll('td')[2].querySelector('.cell');
+    expect(readsSpan?.classList.contains('blank')).toBe(true);
+  });
+
+  it('T-trace-move: emits the literal movement letter', () => {
+    renderTable();
+    const row = document.querySelector<HTMLTableRowElement>(
+      '[data-testid="trace-row"][data-step="1"]',
+    );
+    const cells = row!.querySelectorAll('td');
+    expect(cells[4].textContent?.trim()).toBe('R');
+  });
+
+  it('T-trace-multi-tape-brackets: K>1 wraps cells in [a, b] form', () => {
+    const frames: Frame[] = [
+      {
+        step: 0,
+        tape: [
+          { symbols: ['a'], position: 0 },
+          { symbols: ['_'], position: 0 },
+        ],
+        highlight: null,
+      },
+      {
+        step: 1,
+        tape: [
+          { symbols: ['a'], position: 0 },
+          { symbols: ['_'], position: 0 },
+        ],
+        commands: [
+          { movement: 'R', read: 'a', write: 'b' },
+          { movement: 'L', read: '_', write: '_' },
+        ],
+        highlight: { fromId: 1, toId: 0, strong: 'from', paused: false },
+      },
+    ];
+    renderTable({ frames, frameIndex: 1, blanks: [' ', '_'] });
+    const row = document.querySelector<HTMLTableRowElement>(
+      '[data-testid="trace-row"][data-step="1"]',
+    );
+    const cells = row!.querySelectorAll('td');
+    // Reads cell: brackets around per-tape values, comma separator.
+    const readsText = cells[2].textContent?.replace(/\s+/g, '');
+    expect(readsText).toBe('[a,_]');
+    // Move cell: brackets around per-tape moves.
+    const moveText = cells[4].textContent?.replace(/\s+/g, '');
+    expect(moveText).toBe('[R,L]');
+  });
+
+  it('T-trace-unknown-node: falls back to #id when graph has no matching node', () => {
+    const sparseGraph = {
+      initialId: 1,
+      alphabets: [[' ']],
+      nodes: { 0: { id: 0, name: 'halt' } },
+    } as unknown as Snippet['graph'];
+    const frames: Frame[] = [
+      { step: 0, tape: [{ symbols: [' '], position: 0 }], highlight: null },
+      {
+        step: 1,
+        tape: [{ symbols: [' '], position: 0 }],
+        commands: [{ movement: 'S', read: ' ', write: ' ' }],
+        // fromId 99 isn't in nodes — should render as #99.
+        highlight: { fromId: 99, toId: 0, strong: 'from', paused: false },
+      },
+    ];
+    renderTable({ frames, frameIndex: 1, graph: sparseGraph });
+    const row = document.querySelector<HTMLTableRowElement>(
+      '[data-testid="trace-row"][data-step="1"]',
+    );
+    expect(row!.querySelectorAll('td')[1].textContent).toBe('#99');
+  });
+});

--- a/src/components/Landing.svelte
+++ b/src/components/Landing.svelte
@@ -7,16 +7,91 @@
 
   let engine = $state<Engine>('turing');
 
+  // Playback orchestration (#112 design point 5). One IntersectionObserver
+  // over all panel slots — the panel with the highest visible ratio becomes
+  // `active`; everyone else freezes at frame 0. Reduced motion is checked
+  // here too: under prefers-reduced-motion the IO is never created — every
+  // panel pins to its final frame on mount and there's nothing to orchestrate.
+  let activeSnippetId = $state<string | null>(null);
+  // Plain Maps — these are touched only inside imperative callbacks (the
+  // panelSlot action and IO entry handler), never read during render, so
+  // SvelteMap's reactivity overhead would be wasted. eslint's
+  // svelte/prefer-svelte-reactivity is over-eager here.
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  const slotEls = new Map<string, HTMLElement>();
+  let io: IntersectionObserver | null = null;
+  // Tracks the last reported ratio per snippet across IO callbacks (which
+  // report only entries that changed, not the global state).
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  const ratios = new Map<string, number>();
+
+  function recomputeActive() {
+    let bestId: string | null = null;
+    let bestRatio = 0;
+    for (const [id, ratio] of ratios) {
+      if (ratio > bestRatio) {
+        bestRatio = ratio;
+        bestId = id;
+      }
+    }
+    // Leave the current activeSnippetId in place if nothing is intersecting —
+    // a panel mid-playback shouldn't be yanked off when its top edge briefly
+    // leaves the viewport.
+    if (bestId) activeSnippetId = bestId;
+  }
+
+  function handleEntries(entries: IntersectionObserverEntry[]) {
+    for (const entry of entries) {
+      const id = (entry.target as HTMLElement).dataset.snippetId;
+      if (id) ratios.set(id, entry.isIntersecting ? entry.intersectionRatio : 0);
+    }
+    recomputeActive();
+  }
+
+  // Svelte action: registers a snippet-slot's DOM element with the parent
+  // map AND observes it via the shared IO. Tears down both on destroy.
+  function panelSlot(node: HTMLElement, id: string) {
+    slotEls.set(id, node);
+    io?.observe(node);
+    return {
+      destroy() {
+        io?.unobserve(node);
+        ratios.delete(id);
+        slotEls.delete(id);
+      },
+    };
+  }
+
   onMount(() => {
     engine = readEngineFromLandingQuery(window.location.search);
     const onPopState = () => { engine = readEngineFromLandingQuery(window.location.search); };
     window.addEventListener('popstate', onPopState);
-    return () => window.removeEventListener('popstate', onPopState);
+
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (!reducedMotion) {
+      io = new IntersectionObserver(handleEntries, {
+        threshold: [0.25, 0.5, 0.75, 1.0],
+      });
+      // Observe panels that registered before IO was created (children mount
+      // before the parent's onMount).
+      for (const el of slotEls.values()) io.observe(el);
+    }
+
+    return () => {
+      window.removeEventListener('popstate', onPopState);
+      io?.disconnect();
+      io = null;
+    };
   });
 
   function setEngine(next: Engine) {
     if (next === engine) return;
     engine = next;
+    // Engine switch remounts the panel slots; the action's destroy clears
+    // each slot's entry. Reset activeSnippetId so the new engine's snippets
+    // get a fresh IO claim.
+    activeSnippetId = null;
+    ratios.clear();
     const url = new URL(window.location.href);
     if (next === 'turing') url.searchParams.delete('engine');
     else url.searchParams.set('engine', next);
@@ -49,7 +124,13 @@
 
   <div class="snippet-grid">
     {#each currentSnippets as snippet (snippet.id)}
-      <SnippetPanel {snippet} />
+      <div
+        class="snippet-slot"
+        data-snippet-id={snippet.id}
+        use:panelSlot={snippet.id}
+      >
+        <SnippetPanel {snippet} active={activeSnippetId === snippet.id} />
+      </div>
     {/each}
   </div>
 </section>
@@ -57,6 +138,10 @@
 <style>
   .landing {
     flex: 1;
+    /* Same min-height:0 rationale as App.svelte's main — bounds .landing
+       inside main's flex allotment so overflow-y:auto scrolls inside
+       .landing rather than the body. */
+    min-height: 0;
     overflow-y: auto;
     padding: 32px 24px;
     display: flex;
@@ -127,13 +212,10 @@
   }
 
   .snippet-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(min(100%, 400px), 1fr));
-    gap: 20px;
-    align-items: start;
-
-    @media (max-width: 480px) {
-      grid-template-columns: 1fr;
-    }
+    /* One panel per row. Each SnippetPanel hosts an internal two-column
+       layout (player + lesson notes) that needs the full content width. */
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
   }
 </style>

--- a/src/components/SnippetPanel.svelte
+++ b/src/components/SnippetPanel.svelte
@@ -3,8 +3,10 @@
   import {
     SnippetPlayer,
     applyHighlight,
+    bareIdOf,
     indexGraph,
     tapeViewport,
+    type GraphHighlight,
     type GraphIndexes,
     type HighlightOps,
     type NodeKey,
@@ -12,7 +14,9 @@
   } from '@turing-machine-js/visuals';
   import MachineGraph from './MachineGraph.svelte';
   import TapesStack from './TapesStack.svelte';
+  import ExecutionTraceTable from './ExecutionTraceTable.svelte';
   import { VIEWPORT_WIDTH } from '../lib/caps.ts';
+  import { renderLessonMarkdown } from '../lib/lessonMarkdown.ts';
 
   // The Vite snippets plugin (`src/vite-plugins/snippets.ts`) attaches
   // `engine` / `id` / `description` / `intervalMs` to each `Snippet` as
@@ -23,11 +27,36 @@
     engine: 'turing' | 'post';
     id: string;
     description?: string;
+    /**
+     * Rich learning-oriented prose authored per showcase (markdown subset:
+     * paragraphs, bullet lists, inline code). Rendered into the right
+     * column of the panel.
+     */
+    lessonNotes?: string;
     intervalMs?: number;
+    // Raw `m.state.id` / `m.nextState.id` per iter (one entry per iter,
+    // indexed by `step - 1`). Captured by the snippets Vite plugin via a
+    // wrapper around `runStepByStep` so SnippetPanel can rebuild stepped-
+    // shaped before-pause highlights — `recordSnippet`'s `Frame.highlight`
+    // canonicalizes via `bareIdOf` and loses the wrapper info needed for
+    // §2 expansion in `applyHighlight`.
+    rawStateIds?: number[];
+    rawNextStateIds?: number[];
   };
 
-  type Props = { snippet: SnippetWithMeta };
-  let { snippet }: Props = $props();
+  type Props = {
+    snippet: SnippetWithMeta;
+    /**
+     * Playback gate — Landing's IntersectionObserver orchestrates which
+     * snippet is currently in focus so only one runs at a time. Default
+     * `false` means the panel renders at frame 0 statically; flipping to
+     * `true` resets the player and starts the timer. Ignored under
+     * `prefers-reduced-motion: reduce` (the panel pins to the final frame
+     * unconditionally).
+     */
+    active?: boolean;
+  };
+  let { snippet, active = false }: Props = $props();
 
   // Showcase palette mirrors MachineView's; only the first slot is used in
   // single-tape snippets (Phase 1 ships only single-tape). Kept inline to
@@ -57,13 +86,27 @@
   const engine = untrack(() => snippet.engine);
   const snippetId = untrack(() => snippet.id);
   const caption = untrack(() => snippet.description ?? snippet.id);
+  const lessonHtml = untrack(() =>
+    snippet.lessonNotes
+      ? renderLessonMarkdown(snippet.lessonNotes)
+      : `<p>${snippet.description ?? snippet.id}</p>`,
+  );
+  const rawStateIds: number[] | undefined = untrack(() => snippet.rawStateIds);
 
   let frameIndex = $state(0);
   let done = $state(false);
   let reducedMotion = $state(false);
   let graphReady = $state(false);
-
-  let panelEl: HTMLDivElement | undefined = $state();
+  // True after natural playback end. Nulls out the trace's current-row
+  // highlight so a finished panel reads as not-currently-playing — parallels
+  // the graph's neutral clear at the same moment (#108).
+  let cleared = $state(true);
+  // 4-state playback machine driven by `active` (see #112 "Playback
+  // orchestration"). Plain closure variable — not $state — because the
+  // active-toggle $effect reads AND writes it; making it reactive would
+  // make the effect re-fire on every transition and loop indefinitely. The
+  // template never reads it directly.
+  let playbackState: 'idle' | 'playing' | 'paused' | 'done' = 'idle';
   let machineGraphRef = $state<ReturnType<typeof MachineGraph> | undefined>();
   let tapesStackRef = $state<ReturnType<typeof TapesStack> | undefined>();
 
@@ -72,10 +115,12 @@
   // `lastPausedStrongId` for live runs).
   let prevStrongId: NodeKey | null = null;
 
-  // Replay timer is hoisted into a $state so it's clearable from both the
-  // AbortController abort listener (unmount during playback) AND `onReplay`
-  // (avoids stacking timers when the user spams Replay).
-  let replayTimerId: number | null = $state(null);
+  // Plain closure variable — not $state. The active-toggle $effect calls
+  // clearReplayTimer (which reads replayTimerId) AND startTimer (which
+  // writes it); making it reactive would form a read/write feedback loop
+  // and trip effect_update_depth_exceeded. Timer ID has no rendered
+  // consumer, so reactivity is unnecessary.
+  let replayTimerId: number | null = null;
 
   function clearReplayTimer(): void {
     if (replayTimerId !== null) {
@@ -99,9 +144,10 @@
     if (!ops) return;
     machineGraphRef.clearHighlights();
     const frame = player.currentFrame;
-    if (frame.highlight) {
+    const highlight = buildSteppedHighlight(frame.step);
+    if (highlight) {
       const { nextPrevStrongId } = applyHighlight(
-        frame.highlight,
+        highlight,
         initialGraph,
         graphIndexes,
         prevStrongId,
@@ -111,6 +157,41 @@
     } else {
       prevStrongId = null;
     }
+  }
+
+  // Stepped (live) execution emits before-pause highlights — `strong: 'to'`,
+  // `paused: true`, with `toId` as the RAW current state id so §2 expansion
+  // in `applyHighlight` lights up wrapper + bare for the call-entry iter
+  // (the subgraph cluster + `call` edge feel alive during the call). The
+  // recorded `Frame.highlight` from `recordSnippet` is the after-iter shape
+  // (`strong: 'from'`, bare-canonicalized fromId, no wrapper info) — using
+  // it directly leaves the wrapper dim during playback, mismatching the
+  // stepped ethalon. We rebuild here from the raw state-id sequence captured
+  // by the snippets Vite plugin (`rawStateIds` / `rawNextStateIds`).
+  //
+  // Step indexing: `step === 0` is frame 0 (initial, no highlight). For
+  // iter N (1-based), rawStateIds[N-1] = m.state.id, rawNextStateIds[N-1] =
+  // m.nextState.id. Previous iter's bare id (for the `fromId`) is
+  // `bareIdOf(rawStateIds[N-2])`, or `'idle'` for the first iter.
+  function buildSteppedHighlight(step: number): GraphHighlight | null {
+    if (step === 0 || !rawStateIds) {
+      // Frame 0 has no highlight by spec; if rawStateIds is absent (snippet
+      // produced by an older build) fall back to whatever recordSnippet
+      // emitted so playback still shows something reasonable.
+      if (step === 0) return null;
+      const fallback = player.currentFrame.highlight;
+      return fallback ?? null;
+    }
+    const idx = step - 1;
+    if (idx < 0 || idx >= rawStateIds.length) return null;
+    const currentRawId = rawStateIds[idx];
+    const prevRawId = idx > 0 ? rawStateIds[idx - 1] : null;
+    return {
+      fromId: prevRawId === null ? 'idle' : bareIdOf(prevRawId, initialGraph),
+      toId: currentRawId,
+      strong: 'to',
+      paused: true,
+    };
   }
 
   function applyFrame(): void {
@@ -133,24 +214,39 @@
         // residual highlight from that frame so the graph returns to neutral
         // before the Replay control sits idle on it (#108).
         clearGraphHighlights();
+        cleared = true;
         clearReplayTimer();
+        playbackState = 'done';
         return;
       }
       applyFrame();
     }, intervalMs);
   }
 
-  function onReplay(): void {
-    // Recenter on the idle node BEFORE applying frame 0 so the viewport
-    // rewinds to the same anchor the user got on first mount, instead of
-    // staying parked at wherever the last halt-iter highlight had pushed
-    // it (machines-demo#110). applyFrame() then clears the residual
-    // highlight; the timer starts after.
-    machineGraphRef?.recenterOnIdle();
+  function startFresh(): void {
+    cleared = false;
     player.reset();
+    machineGraphRef?.recenterOnIdle();
     prevStrongId = null;
     applyFrame();
-    if (!reducedMotion) startTimer();
+    startTimer();
+    playbackState = 'playing';
+  }
+
+  function resumeTimer(): void {
+    // Resume mid-playback without touching the player position. The graph +
+    // tape state were preserved while paused, so just rearm the interval.
+    startTimer();
+    playbackState = 'playing';
+  }
+
+  function pauseTimer(): void {
+    clearReplayTimer();
+    playbackState = 'paused';
+  }
+
+  function onReplay(): void {
+    startFresh();
   }
 
   function onGraphReady(): void {
@@ -162,71 +258,95 @@
     applyGraph();
   }
 
-  onMount(() => {
-    const controller = new AbortController();
-    const { signal } = controller;
+  // Landing's IntersectionObserver drives `active`; this $effect dispatches
+  // the 4-state playback machine (see #112 "Playback orchestration"). Body
+  // wrapped in `untrack` so $state reads inside the dispatch helpers
+  // (`machineGraphRef`, `tapesStackRef`, `graphReady`) don't become effect
+  // deps and trip an infinite update loop. Reduced motion short-circuits
+  // entirely — the panel pins to the final frame on mount and ignores
+  // active changes.
+  $effect(() => {
+    const isActive = active;
+    const isReduced = reducedMotion;
+    untrack(() => {
+      if (isReduced) return;
+      if (isActive) {
+        if (playbackState === 'idle') startFresh();
+        else if (playbackState === 'paused') resumeTimer();
+        // 'playing' and 'done' → no-op (already playing, or finished and
+        // awaiting an explicit Replay click).
+      } else {
+        if (playbackState === 'playing') pauseTimer();
+        // 'idle' / 'paused' / 'done' → no-op.
+      }
+    });
+  });
 
+  onMount(() => {
     reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
     if (reducedMotion) {
       player.goTo(finalFrameIndex);
+      cleared = false;
       applyFrame();
-      signal.addEventListener('abort', () => clearReplayTimer(), { once: true });
-      return () => controller.abort();
+      return () => clearReplayTimer();
     }
 
-    // Frame 0 visible immediately before any scroll-in.
+    // Initial paint at frame 0; the $effect above will pick up `active` and
+    // either keep us at frame 0 (inactive) or kick off playback.
     applyFrame();
-
-    const io = new IntersectionObserver(
-      ([entry]) => {
-        if (!entry.isIntersecting) return;
-        io.disconnect();
-        startTimer();
-      },
-      { threshold: 0.5 },
-    );
-    if (panelEl) io.observe(panelEl);
-    signal.addEventListener('abort', () => {
-      io.disconnect();
-      clearReplayTimer();
-    }, { once: true });
-
-    return () => controller.abort();
+    return () => clearReplayTimer();
   });
 </script>
 
-<div class="snippet-panel" bind:this={panelEl} data-testid="snippet-panel">
+<div class="snippet-panel" data-testid="snippet-panel">
   <!-- a11y: page heading hierarchy is <h1> (Landing) → <h2> (per snippet panel). -->
   <h2 class="caption">{caption}</h2>
-  <div class="graph">
-    <MachineGraph
-      bind:this={machineGraphRef}
-      graph={initialGraph}
-      collapsed={false}
-      onToggleCollapsed={() => {}}
-      onReady={onGraphReady}
-      readOnly
-    />
-  </div>
-  <div class="tapes">
-    <TapesStack
-      bind:this={tapesStackRef}
-      {tapeCount}
-      caretColors={CARET_COLORS}
-      readOnly
-    />
-  </div>
-  <div class="meta" data-testid="snippet-frame-index">{frameIndex}</div>
-  <div class="controls">
-    {#if done}
-      <button type="button" class="replay" onclick={onReplay}>
-        {reducedMotion ? 'Play' : 'Replay'}
-      </button>
-    {/if}
-    <a href={`/${engine}?example=${snippetId}`} class="open-in-editor">
-      Open in editor
-    </a>
+  <div class="body">
+    <div class="player">
+      <div class="graph">
+        <MachineGraph
+          bind:this={machineGraphRef}
+          graph={initialGraph}
+          collapsed={false}
+          onToggleCollapsed={() => {}}
+          onReady={onGraphReady}
+          readOnly
+        />
+      </div>
+      <div class="tapes">
+        <TapesStack
+          bind:this={tapesStackRef}
+          {tapeCount}
+          caretColors={CARET_COLORS}
+          readOnly
+        />
+      </div>
+      <ExecutionTraceTable
+        frames={snippet.frames}
+        frameIndex={cleared ? null : frameIndex}
+        graph={initialGraph}
+        {blanks}
+      />
+      <div class="controls">
+        {#if done}
+          <button type="button" class="replay" onclick={onReplay}>
+            {reducedMotion ? 'Play' : 'Replay'}
+          </button>
+        {/if}
+        <a href={`/${engine}?example=${snippetId}`} class="open-in-editor">
+          Open in editor
+        </a>
+      </div>
+    </div>
+    <aside class="lesson" aria-label="Lesson notes">
+      <!-- Content is build-time author input from `defaultCode.ts` (per the
+           demo's existing {@html}-for-build-time-content policy used for SVG
+           icons). Renderer in `lib/lessonMarkdown.ts` escapes the source
+           first; only paragraphs, bullet lists, and inline code are emitted. -->
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      {@html lessonHtml}
+    </aside>
   </div>
 </div>
 
@@ -234,23 +354,27 @@
   .snippet-panel {
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    padding: 16px;
+    gap: 16px;
+    padding: 20px;
     background: var(--editor-bg);
     border: 1px solid var(--cell-border);
     border-radius: var(--surface-radius);
     /* Tape's intrinsic width (--visible-cells * cell-width) can exceed the
-       grid-track width on narrow layouts; clip rather than letting cells
+       column-track width on narrow layouts; clip rather than letting cells
        escape past the panel's border. */
     overflow: hidden;
 
-    /* Showcase context — fewer cells visible than the engine pages (default
-       --visible-cells is 19 desktop / 17 tablet / 11 phone). 13 fits a
-       400-pixel-min grid track comfortably with room for head context on
-       both sides. The mask in Tape.svelte fades edge cells, so partial
-       symbols don't pop in/out as the head moves. */
+    /* Showcase context. With the panel now full-width and split into player
+       + lesson columns, the player track is wide enough to show more cells
+       than the previous narrow grid allowed. 17 desktop / 13 tablet / 9 phone
+       lines up with the engine-page Tape defaults at each breakpoint. The
+       mask in Tape.svelte fades edge cells, so partial symbols don't pop. */
     :global(.ui-belt) {
-      --visible-cells: 13;
+      --visible-cells: 17;
+
+      @media (max-width: 768px) {
+        --visible-cells: 13;
+      }
 
       @media (max-width: 480px) {
         --visible-cells: 9;
@@ -265,6 +389,35 @@
     color: var(--fg);
   }
 
+  .body {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 24px;
+    align-items: start;
+
+    /* Stack on narrow viewports — player on top, lesson notes below. */
+    @media (max-width: 768px) {
+      grid-template-columns: 1fr;
+      gap: 16px;
+    }
+  }
+
+  .player {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    min-width: 0;
+    /* Base background frames the player as a distinct surface within the
+       outer panel — visually separates "the thing running" from the lesson
+       prose next to it. `--bg` is the page surface (lighter than the
+       panel's `--editor-bg`), which reads as an embedded screen rather
+       than a continuation of the card. */
+    background: var(--bg);
+    border: 1px solid var(--cell-border);
+    border-radius: var(--surface-radius);
+    padding: 14px;
+  }
+
   .graph {
     /* MachineGraph manages its own height (fixed 360px by default); this
        wrapper lets snippet-panel control the slot without re-styling the
@@ -273,15 +426,44 @@
   }
 
   .tapes {
+    /* Player fills the column at 100% width (#112 design point 3) — let the
+       tape stretch the full track rather than centering with slack. */
     min-width: 0;
-    display: flex;
-    justify-content: center;
   }
 
-  .meta {
-    font-size: 0.75rem;
-    color: color-mix(in srgb, var(--fg) 60%, transparent);
-    font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+  .lesson {
+    min-width: 0;
+    font-size: 0.9375rem;
+    line-height: 1.55;
+    color: var(--fg);
+
+    :global(p) {
+      margin: 0 0 0.85em;
+    }
+
+    :global(p:last-child),
+    :global(ul:last-child) {
+      margin-bottom: 0;
+    }
+
+    :global(ul) {
+      margin: 0 0 0.85em;
+      padding-left: 1.4em;
+    }
+
+    :global(ul li) {
+      margin: 0.25em 0;
+    }
+
+    :global(code) {
+      font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+      font-size: 0.88em;
+      padding: 1px 5px;
+      border-radius: 4px;
+      background: var(--cell-bg);
+      color: color-mix(in srgb, var(--fg) 92%, transparent);
+      border: 1px solid color-mix(in srgb, var(--cell-border) 70%, transparent);
+    }
   }
 
   .controls {

--- a/src/components/SnippetPanel.test.ts
+++ b/src/components/SnippetPanel.test.ts
@@ -37,46 +37,47 @@ function stubSnippet(overrides: Partial<SnippetWithMeta> = {}): SnippetWithMeta 
     engine: 'turing',
     id: 'showcase-1',
     description: 'A test snippet',
-    graph: { initialId: 0, alphabets: [[' ', 'a', 'b']], nodes: {} } as never,
+    graph: {
+      initialId: 1,
+      alphabets: [[' ', 'a', 'b']],
+      nodes: {
+        0: { id: 0, name: 'halt', transitions: [], isWrapper: false, isHaltMarker: false, tags: [] },
+        1: { id: 1, name: 'S', transitions: [], isWrapper: false, isHaltMarker: false, tags: [] },
+      },
+    } as never,
     alphabets: [[' ', 'a', 'b']],
     frames: [
       { step: 0, tape: [{ symbols: ['a', 'b'], position: 0 }], highlight: null },
-      { step: 1, tape: [{ symbols: ['b', 'b'], position: 1 }], highlight: null },
-      { step: 2, tape: [{ symbols: ['b', 'a'], position: 1 }], highlight: null },
+      {
+        step: 1,
+        tape: [{ symbols: ['b', 'b'], position: 1 }],
+        commands: [{ movement: 'R', read: 'a', write: 'b' }],
+        highlight: { fromId: 1, toId: 1, strong: 'from', paused: false },
+      },
+      {
+        step: 2,
+        tape: [{ symbols: ['b', 'a'], position: 1 }],
+        commands: [{ movement: 'L', read: 'b', write: 'a' }],
+        highlight: { fromId: 1, toId: 0, strong: 'from', paused: false },
+      },
     ],
     ...overrides,
   };
 }
 
-// IntersectionObserver test double: stores the callback on the constructed
-// instance so a test can `instance.fire(true)` to simulate scroll-into-view.
-class FakeIntersectionObserver {
-  static instances: FakeIntersectionObserver[] = [];
-  callback: IntersectionObserverCallback;
-  observed: Element[] = [];
-  disconnected = false;
-  constructor(cb: IntersectionObserverCallback) {
-    this.callback = cb;
-    FakeIntersectionObserver.instances.push(this);
-  }
-  observe(el: Element) { this.observed.push(el); }
-  disconnect() { this.disconnected = true; }
-  unobserve() {}
-  takeRecords() { return []; }
-  root = null;
-  rootMargin = '';
-  thresholds: number[] = [];
-  fire(isIntersecting: boolean) {
-    this.callback(
-      [{ isIntersecting } as IntersectionObserverEntry],
-      this as unknown as IntersectionObserver,
-    );
-  }
+// `aria-current="step"` is set on the trace row whose `data-step` matches the
+// current `frameIndex`. Frame 0 has no row (no transition fired yet); frames
+// 1..N each get a row. Helper returns the highlighted row's `data-step` value,
+// or null when no row is current.
+function currentStep(): number | null {
+  const row = document.querySelector<HTMLTableRowElement>(
+    '[data-testid="trace-row"][aria-current="step"]',
+  );
+  if (!row) return null;
+  return Number(row.dataset.step);
 }
 
 beforeEach(() => {
-  FakeIntersectionObserver.instances = [];
-  vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver);
   // Default to motion ON; individual tests can override matchMedia.
   vi.stubGlobal('matchMedia', (query: string) => ({
     matches: false,
@@ -100,68 +101,121 @@ afterEach(() => {
 describe('SnippetPanel', () => {
   it('S-snippet-panel-renders-caption: renders the snippet description', () => {
     render(SnippetPanel, { snippet: stubSnippet() });
-    expect(screen.getByText('A test snippet')).toBeInTheDocument();
+    // Caption renders in <h2> AND in the lesson-notes placeholder — scope to
+    // the heading so the assertion picks the right element.
+    expect(
+      screen.getByRole('heading', { name: 'A test snippet' }),
+    ).toBeInTheDocument();
   });
 
   it('S-snippet-panel-renders-caption: falls back to id when description is absent', () => {
     render(SnippetPanel, {
       snippet: stubSnippet({ description: undefined, id: 'fallback-id' }),
     });
-    expect(screen.getByText('fallback-id')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'fallback-id' }),
+    ).toBeInTheDocument();
   });
 
-  it('S-snippet-panel-static-on-mount: sits on frame 0 until IO fires', () => {
+  it('S-snippet-panel-static-on-mount: sits on frame 0 when inactive', () => {
     render(SnippetPanel, { snippet: stubSnippet() });
-    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('0');
+    // Default active=false → no row carries aria-current.
+    expect(currentStep()).toBe(null);
   });
 
-  it('S-snippet-panel-autoplay-on-intersect: advances frames after intersect', () => {
-    render(SnippetPanel, { snippet: stubSnippet({ intervalMs: 100 }) });
-    expect(FakeIntersectionObserver.instances).toHaveLength(1);
-    const io = FakeIntersectionObserver.instances[0];
-    io.fire(true);
-    expect(io.disconnected).toBe(true);
-    // Advance interval — should step to frame 1.
+  it('S-snippet-panel-active-plays: advances frames once active is set', () => {
+    render(SnippetPanel, {
+      snippet: stubSnippet({ intervalMs: 100 }),
+      active: true,
+    });
+    // The active-toggle $effect resets the player and schedules the timer.
     vi.advanceTimersByTime(100);
     flushSync();
-    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('1');
+    expect(currentStep()).toBe(1);
     vi.advanceTimersByTime(100);
     flushSync();
-    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('2');
+    expect(currentStep()).toBe(2);
   });
 
-  it('S-snippet-panel-freeze-at-halt: timer stops at the last frame and Replay appears', () => {
-    render(SnippetPanel, { snippet: stubSnippet({ intervalMs: 50 }) });
-    FakeIntersectionObserver.instances[0].fire(true);
-    // 3 frames: index 0 → 1 → 2 (done). 2 ticks reach done.
+  it('S-snippet-panel-freeze-at-halt: timer stops at the last frame, highlight clears, Replay appears', () => {
+    render(SnippetPanel, {
+      snippet: stubSnippet({ intervalMs: 50 }),
+      active: true,
+    });
+    // 3 frames: index 0 → 1 → 2 (done). 2 ticks reach the last frame.
     vi.advanceTimersByTime(50);
     vi.advanceTimersByTime(50);
     flushSync();
-    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('2');
-    // Extra ticks must not advance past the last frame.
-    vi.advanceTimersByTime(500);
+    expect(currentStep()).toBe(2);
+    // One more tick: player.forward() returns false → highlight clears (#108 parity).
+    vi.advanceTimersByTime(50);
     flushSync();
-    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('2');
-    // Replay button appears when done.
+    expect(currentStep()).toBe(null);
+    // Replay button appears.
     expect(screen.getByRole('button', { name: /Replay/i })).toBeInTheDocument();
   });
 
   it('S-snippet-panel-replay-resets: Replay jumps back to frame 0 and replays', async () => {
-    render(SnippetPanel, { snippet: stubSnippet({ intervalMs: 50 }) });
-    FakeIntersectionObserver.instances[0].fire(true);
+    render(SnippetPanel, {
+      snippet: stubSnippet({ intervalMs: 50 }),
+      active: true,
+    });
     vi.advanceTimersByTime(50);
     vi.advanceTimersByTime(50);
     flushSync();
-    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('2');
+    expect(currentStep()).toBe(2);
     await fireEvent.click(screen.getByRole('button', { name: /Replay/i }));
     flushSync();
-    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('0');
+    expect(currentStep()).toBe(null);
     vi.advanceTimersByTime(50);
     flushSync();
-    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('1');
+    expect(currentStep()).toBe(1);
   });
 
-  it('S-snippet-panel-reduced-motion: jumps to the final frame on mount, no IO', () => {
+  it('S-snippet-panel-inactive-pauses: inactive mid-playback preserves the current row', async () => {
+    const snippet = stubSnippet({ intervalMs: 50 });
+    const { rerender } = render(SnippetPanel, { snippet, active: true });
+    vi.advanceTimersByTime(50);
+    flushSync();
+    expect(currentStep()).toBe(1);
+    // Pause: highlight stays at frame 1, timer stops, no further advance.
+    await rerender({ snippet, active: false });
+    flushSync();
+    expect(currentStep()).toBe(1);
+    vi.advanceTimersByTime(500);
+    flushSync();
+    expect(currentStep()).toBe(1);
+    // Resume: ticks pick up from where we paused — next tick lands on 2.
+    await rerender({ snippet, active: true });
+    flushSync();
+    vi.advanceTimersByTime(50);
+    flushSync();
+    expect(currentStep()).toBe(2);
+  });
+
+  it('S-snippet-panel-done-no-autoreplay: a finished snippet does not auto-replay on re-activation', async () => {
+    const snippet = stubSnippet({ intervalMs: 50 });
+    const { rerender } = render(SnippetPanel, { snippet, active: true });
+    // Run to completion: 2 advances reach the last frame, a 3rd triggers
+    // the natural-end cleanup that flips state to 'done'.
+    vi.advanceTimersByTime(50);
+    vi.advanceTimersByTime(50);
+    vi.advanceTimersByTime(50);
+    flushSync();
+    expect(currentStep()).toBe(null);
+    expect(screen.getByRole('button', { name: /Replay/i })).toBeInTheDocument();
+    // Scroll away and back — no auto-replay, no highlight.
+    await rerender({ snippet, active: false });
+    flushSync();
+    await rerender({ snippet, active: true });
+    flushSync();
+    vi.advanceTimersByTime(500);
+    flushSync();
+    expect(currentStep()).toBe(null);
+    expect(screen.getByRole('button', { name: /Replay/i })).toBeInTheDocument();
+  });
+
+  it('S-snippet-panel-reduced-motion: jumps to the final frame on mount, ignores active', () => {
     vi.stubGlobal('matchMedia', (query: string) => ({
       matches: query.includes('reduce'),
       media: query,
@@ -172,10 +226,10 @@ describe('SnippetPanel', () => {
       removeListener: vi.fn(),
       dispatchEvent: vi.fn(),
     }));
-    render(SnippetPanel, { snippet: stubSnippet() });
-    expect(screen.getByTestId('snippet-frame-index').textContent).toBe('2');
-    // No IntersectionObserver should have been created under reduced motion.
-    expect(FakeIntersectionObserver.instances).toHaveLength(0);
+    // Even with active=false, reduced motion pins to the final frame —
+    // matches the graph's static final-frame snapshot.
+    render(SnippetPanel, { snippet: stubSnippet(), active: false });
+    expect(currentStep()).toBe(2);
     // Play button shown (instead of Replay) under reduced motion.
     expect(screen.getByRole('button', { name: /Play/i })).toBeInTheDocument();
   });

--- a/src/lib/defaultCode.ts
+++ b/src/lib/defaultCode.ts
@@ -8,6 +8,10 @@ export type Example = {
   // as the panel caption; intervalMs overrides the playback default (800ms).
   showcase?: boolean;
   description?: string;
+  // Rich learning-oriented prose shown beside the player in showcase panels.
+  // Supports a tight markdown subset: paragraphs (blank-line separated),
+  // bullet lists (lines starting with `- `), inline code (backticks).
+  lessonNotes?: string;
   intervalMs?: number;
 };
 
@@ -310,6 +314,15 @@ const TURING_EXAMPLES: readonly Example[] = [
     code: TURING_REPLACE_B,
     showcase: true,
     description: "Replace each 'b' with '*'; halt at blank.",
+    lessonNotes: `A single-pass rewrite. The head walks rightward across the tape; every \`b\` it sees becomes \`*\`, everything else is left alone. The first blank cell stops the program.
+
+One state \`S\` does all the work. Its outgoing arcs are:
+
+- on \`b\` — write \`*\`, move right, stay in \`S\`.
+- on any other letter — keep the symbol, move right, stay in \`S\`.
+- on blank — halt.
+
+On the graph this reads as a single self-loop carrying the rewrite cases and one halt-bound arc. There is no branching — just a streaming pass.`,
   },
   {
     id: 'toggle-bits',
@@ -317,6 +330,15 @@ const TURING_EXAMPLES: readonly Example[] = [
     code: TURING_TOGGLE_BITS,
     showcase: true,
     description: 'Flip each bit (0↔1); halt at blank.',
+    lessonNotes: `A binary NOT pass. Every \`0\` becomes \`1\` and every \`1\` becomes \`0\` until the head meets a blank.
+
+The single state \`S\` has three arcs:
+
+- on \`0\` — write \`1\`, move right, stay in \`S\`.
+- on \`1\` — write \`0\`, move right, stay in \`S\`.
+- on blank — halt.
+
+Same shape as \`replace-b\` but with the rewrite split across two literal cases instead of one. Watch the tape cells flash as each bit toggles — the head never reads back, so every cell is touched exactly once.`,
   },
   {
     id: 'callable-subtree',
@@ -324,6 +346,16 @@ const TURING_EXAMPLES: readonly Example[] = [
     code: TURING_CALLABLE_SUBTREE,
     showcase: true,
     description: 'Subroutine: walk to blank, then mark; the subgraph frame highlights during the call.',
+    lessonNotes: `A composed program: the main flow calls a reusable subroutine and then continues. The subroutine \`walkToBlank\` self-loops on letters until it meets a blank; the continuation \`writeMarker\` stamps \`*\` and halts for real.
+
+The call is set up with \`State.withOverriddenHaltState\`. Halting INSIDE the subroutine is reinterpreted as "return to the wrapper's continuation" — the engine never actually halts on the first blank, it pops out to \`writeMarker\`, which marks and then halts at the top level.
+
+What to look for on the graph:
+
+- The dashed cluster around \`walkToBlank\` IS the callable subtree. Its border lights up while execution is inside the subroutine.
+- The composite \`walkToBlank(writeMarker)\` node is the wrapper — the entry handle for the call. It lights up alongside the bare on the call-entry iter.
+- The bold \`call\` arrow (wrapper → bare) is the call edge.
+- The dotted \`return\` arrow leaves the cluster back out to \`writeMarker\` — that's the path the engine takes when the bare halts inside the subroutine.`,
   },
   { id: 'copy-two-tapes', title: 'Copy tape (multi-tape)', code: TURING_COPY_TWO_TAPES },
 ];
@@ -335,6 +367,11 @@ const POST_EXAMPLES: readonly Example[] = [
     code: POST_MARK_AND_STEP,
     showcase: true,
     description: 'Mark, step right, repeat — pure sequential, no branches.',
+    lessonNotes: `A straight-line Post program with no branching: \`mark\`, step right, \`mark\`, step right, \`mark\`. Three rewrites and the program halts.
+
+Each numbered instruction in the program becomes a node on the graph; transitions are unconditional \`goto next\`. There are no \`check\` instructions, so no decisions — the entire flow is one chain from start to halt.
+
+Compared to the Turing examples, the Post-instruction → state-graph mapping is laid bare here: one instruction, one node, one outgoing arc.`,
   },
   {
     id: 'walk-mark',
@@ -342,6 +379,14 @@ const POST_EXAMPLES: readonly Example[] = [
     code: POST_WALK_MARK,
     showcase: true,
     description: 'Skip past marks; mark the first blank cell.',
+    lessonNotes: `A scanning loop. The head walks rightward past any \`*\` already on the tape, then drops a \`*\` on the first blank cell it finds and halts.
+
+The structure is one \`check\` (branch on "is this cell marked?") plus two short paths:
+
+- marked → \`right\`, then jump back to the check — keep scanning.
+- blank → \`mark\`, then halt — done.
+
+On the graph, the cycle is the scanning loop; the halt-bound branch is the "found a blank" exit. This is the smallest Post program that exhibits a real loop.`,
   },
   {
     id: 'call-subroutine',
@@ -349,6 +394,17 @@ const POST_EXAMPLES: readonly Example[] = [
     code: POST_CALL_SUBROUTINE,
     showcase: true,
     description: 'Subroutine: walk to a blank and mark it; called twice from main.',
+    lessonNotes: `A Post program that defines a reusable subroutine and CALLS it twice. The subroutine body is the same scanning loop as \`walk-mark\` above.
+
+The main program is just two \`call\` instructions in sequence; the subroutine walks rightward over any existing marks and stamps \`*\` on the first blank, then trails into a halt. Each \`call\` from main:
+
+- enters the subroutine (engine pushes the return address onto its call stack).
+- runs the subroutine to its trailing halt.
+- pops the call stack — execution returns to the instruction AFTER the call in main.
+
+Between the two calls, the head sits on the cell just marked by the first call, so the second call resumes scanning rightward from there.
+
+On the graph, the dashed cluster bundles the subroutine instructions — that's the callable subtree. Two separate \`call\` sites in main produce two separate wrapper-entries into the cluster, but the body inside is shared.`,
   },
 ];
 

--- a/src/lib/lessonMarkdown.test.ts
+++ b/src/lib/lessonMarkdown.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { renderLessonMarkdown } from './lessonMarkdown';
+
+describe('renderLessonMarkdown', () => {
+  it('R-lesson-md-paragraph: wraps a single block in <p>', () => {
+    expect(renderLessonMarkdown('hello world')).toBe('<p>hello world</p>');
+  });
+
+  it('R-lesson-md-multi-paragraph: splits on blank lines', () => {
+    expect(renderLessonMarkdown('one\n\ntwo')).toBe('<p>one</p><p>two</p>');
+  });
+
+  it('R-lesson-md-bullets: renders a `- ` block as <ul><li>', () => {
+    expect(renderLessonMarkdown('- a\n- b')).toBe('<ul><li>a</li><li>b</li></ul>');
+  });
+
+  it('R-lesson-md-inline-code: backticks become <code>', () => {
+    expect(renderLessonMarkdown('use `foo` here')).toBe(
+      '<p>use <code>foo</code> here</p>',
+    );
+  });
+
+  it('R-lesson-md-escape: escapes HTML in source', () => {
+    expect(renderLessonMarkdown('a < b & c > d')).toBe(
+      '<p>a &lt; b &amp; c &gt; d</p>',
+    );
+  });
+
+  it('R-lesson-md-mixed: paragraph then list then paragraph', () => {
+    const src = 'intro paragraph\n\n- one\n- two\n\nclosing';
+    expect(renderLessonMarkdown(src)).toBe(
+      '<p>intro paragraph</p><ul><li>one</li><li>two</li></ul><p>closing</p>',
+    );
+  });
+
+  it('R-lesson-md-inline-code-in-bullet: backticks inside list items', () => {
+    expect(renderLessonMarkdown('- on `0` — write `1`')).toBe(
+      '<ul><li>on <code>0</code> — write <code>1</code></li></ul>',
+    );
+  });
+});

--- a/src/lib/lessonMarkdown.ts
+++ b/src/lib/lessonMarkdown.ts
@@ -1,0 +1,56 @@
+// Minimal markdown subset for snippet lesson notes (#112).
+// Author-controlled content from defaultCode.ts only — no user input. The
+// renderer covers exactly what the showcase notes need: paragraphs, bullet
+// lists, and inline-code spans. Everything else is left as plain text.
+
+const ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+function escapeHtml(text: string): string {
+  return text.replace(/[&<>"']/g, (ch) => ESCAPE_MAP[ch]);
+}
+
+function inlineCode(text: string): string {
+  return text.replace(/`([^`]+)`/g, (_, code) => `<code>${code}</code>`);
+}
+
+function isBulletBlock(block: string): boolean {
+  const lines = block.split('\n');
+  return lines.length > 0 && lines.every((l) => l.trim().startsWith('- '));
+}
+
+/**
+ * Renders a small markdown subset to HTML. Intended for `{@html}` injection
+ * of build-time author content (per the demo's existing `{@html}` policy
+ * for SVG icon strings). Do NOT call on user-provided text without
+ * sanitization — this only does HTML-entity escaping, not full sanitization.
+ *
+ * Supported:
+ *   - Paragraphs (split on one-or-more blank lines).
+ *   - Bullet lists (a block where every line starts with `- `).
+ *   - Inline code via backticks.
+ */
+export function renderLessonMarkdown(source: string): string {
+  // Escape FIRST, then apply formatters that emit HTML. The inline-code
+  // replacement inserts `<code>` tags into already-escaped text, which is
+  // safe because the inner content was already escaped before tagging.
+  const escaped = escapeHtml(source.trim());
+  const blocks = escaped.split(/\n\s*\n+/);
+  return blocks
+    .map((block) => {
+      if (isBulletBlock(block)) {
+        const items = block
+          .split('\n')
+          .map((l) => `<li>${inlineCode(l.trim().slice(2).trim())}</li>`)
+          .join('');
+        return `<ul>${items}</ul>`;
+      }
+      return `<p>${inlineCode(block)}</p>`;
+    })
+    .join('');
+}

--- a/src/vite-plugins/snippets.ts
+++ b/src/vite-plugins/snippets.ts
@@ -4,6 +4,8 @@ import * as turing from '@turing-machine-js/machine';
 import * as post from '@post-machine-js/machine';
 import type { Example } from '../lib/defaultCode.ts';
 
+const RAW_STATE_STEPS_LIMIT = 1000;
+
 type Engine = 'turing' | 'post';
 
 type Options = {
@@ -95,20 +97,54 @@ export function createSnippetsPlugin(opts: Options = {}): Plugin {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               (t: any) => [...t.alphabet.symbols] as string[],
             );
+            // `recordSnippet` derives each frame's `highlight.fromId` via
+            // `bareIdOf`, which canonicalizes wrapper states (CallFrame) to
+            // their bare's id — so the raw `m.state.id` for wrapper-entry
+            // iters is lost. SnippetPanel needs the raw value to construct
+            // stepped-shaped before-pause highlights at render time (so the
+            // wrapper node + `call` edge light up during the call iter, like
+            // they do in live stepped execution).
+            //
+            // Capture the raw ids by wrapping `machine.runStepByStep` BEFORE
+            // calling `recordSnippet`, so we ride the SAME iteration and
+            // share the same `State` id assignments as the `graph` built
+            // above. A second eval would mint fresh State ids that don't
+            // line up with `graph.nodes`.
+            const rawStateIds: number[] = [];
+            const rawNextStateIds: number[] = [];
+            const haltSentinel =
+              engine === 'post' ? post.haltState : turing.haltState;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const originalRunStepByStep = (machine as any).runStepByStep.bind(machine);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (machine as any).runStepByStep = function* (args: unknown) {
+              for (const m of originalRunStepByStep(args)) {
+                rawStateIds.push(m.state.id);
+                rawNextStateIds.push(
+                  m.nextState === haltSentinel ? 0 : m.nextState.id,
+                );
+                yield m;
+              }
+            };
+
             const snippet = recordSnippet({
               machine,
               initialState,
               graph,
               alphabets,
               name: example.title,
-              maxSteps: 1000,
+              maxSteps: RAW_STATE_STEPS_LIMIT,
             });
+
             out[engine].push({
               ...snippet,
               engine,
               id: example.id,
               description: example.description,
+              lessonNotes: example.lessonNotes,
               intervalMs: example.intervalMs,
+              rawStateIds,
+              rawNextStateIds,
             });
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

Landing-page snippet showcases were a single column with a `{frameIndex}` counter under each animation. Reworked around stepped-equivalent learning artifacts: a per-iter trace table, prose lesson notes beside the player, and Landing-orchestrated playback so only one snippet runs at a time.

Closes #112.

## Execution-trace table

New `src/components/ExecutionTraceTable.svelte` — six columns (`Step | State | Head reads | Write | Move | Goto`), same shape as the [engine README's trace example](https://github.com/mellonis/turing-machine-js#readme) minus the `Tape after` column (the live tape strip already covers that). Current row carries `aria-current="step"` + the `--graph-highlight-soft-fill` background. Sticky thead inside `max-height: 280px` / `overflow-y: auto`.

**Scroll-into-view is scoped to the trace's wrap container** via manual `scrollTop` math — `Element.scrollIntoView` would propagate up every overflow ancestor (the page included) and yank the whole landing layout each time a partially-visible panel ticked. The wrap-only adjustment stays put.

Multi-tape cells render as bracketed arrays (`[a, _]` / `[*, b]` / `[R, L]`). Blank cells use a `.blank` dimmed class (matches `Tape.svelte` — no UI substitution). Halt resolves `toId === 0 → 'halt'` directly so the engine graph node's literal `id:0` placeholder name doesn't leak through.

## Two-column SnippetPanel + lesson notes

- Below the caption: a CSS grid — **left column** is the player (graph + tapes + trace + controls) on a framed surface (`background: var(--bg)` + border + radius — reads as an embedded screen within the outer card); **right column** carries lesson prose. Stacks to a single column at `<=768px`.
- Landing's snippet grid switched from a multi-column `auto-fill` track to one panel per row so the internal two-column layout has room. Showcase Tape viewport widened to 17 / 13 / 9 cells across the desktop / tablet / phone breakpoints.
- New `Example.lessonNotes?: string` field carries the prose. All six showcases got multi-paragraph notes — what the program does, the role of each state or instruction, and (for `callable-subtree` / `call-subroutine`) the subroutine boundary, the call/return arrows, and the wrapper-vs-bare distinction.
- `src/lib/lessonMarkdown.ts` renders a tight subset (paragraphs, bullet lists, inline backtick code) — HTML-escapes input then emits the formatted block. Injected with `{@html}` under the demo's existing build-time-author-content policy (same as the SVG-icon `{@html}` use).

## Single-snippet playback orchestration

`Landing.svelte` owns a single `IntersectionObserver` across all rendered panels (one observer; ratios tracked across callbacks since IO reports only what changed). A Svelte `use:panelSlot` action registers each panel's slot wrapper with the parent registry on mount. The panel with the highest visible ratio becomes `active`. Engine switch clears `activeSnippetId` + ratios. Under `prefers-reduced-motion: reduce` the IO is never created.

`SnippetPanel` becomes a controlled playback consumer — internal IO is gone. Receives an `active: boolean` prop and dispatches a 4-state playback machine through one `\$effect`:

| state    | becomes active                                  | becomes inactive               |
|----------|-------------------------------------------------|--------------------------------|
| `idle`   | reset to frame 0 + start timer → `playing`      | stays `idle`                   |
| `playing`| (already playing — no-op)                       | clear timer → `paused`         |
| `paused` | resume timer from current frame → `playing`     | stays `paused`                 |
| `done`   | **no auto-replay** — Replay only                | stays `done`                   |

First viewing plays from the top; scroll-away pauses without reset; scroll-back resumes. Finished snippets sit at end-state until the visitor clicks Replay — re-scrolling past a completed snippet doesn't restart it. Reduced motion pins to the final frame on mount.

The active-toggle `\$effect`'s body wraps in `untrack()` so `\$state` reads inside dispatch helpers (`machineGraphRef`, `tapesStackRef`, `graphReady`) don't become effect deps and form an infinite loop. `replayTimerId` was demoted from `\$state` to plain `let` to break a separate read/write feedback loop on the timer handle.

Trace-row highlight clears at natural playback end — parallels the graph-highlight clear at the same moment (#108). Under reduced motion the last row stays highlighted to mirror the graph holding the final-frame snapshot.

## Stepped-shaped graph highlight during snippet playback

`recordSnippet` emits after-iter-shaped highlights (`strong: 'from'`, `paused: false`, `fromId = bareIdOf(m.state.id)` already canonicalized). For wrapper-entry iters that canonicalization discards the wrapper info — so on the `callable-subtree` showcase, the wrapper node `walkToBlank(writeMarker)` + the bold `call` arrow stayed dim even though the cluster lit up via §9.

Fix lives entirely in the demo, no upstream visuals change:

- `src/vite-plugins/snippets.ts` wraps `machine.runStepByStep` **before** calling `recordSnippet` so the wrapper rides the SAME iteration and shares the same `State` id space the `graph` was built from. Captures `m.state.id` / `m.nextState.id` per iter into `rawStateIds` / `rawNextStateIds`, attached to each snippet as extension fields.
- `SnippetPanel.applyGraph` builds the highlight from `rawStateIds`: `fromId = bareIdOf(rawStateIds[step - 2], graph)` (or `'idle'` for the first iter), `toId = rawStateIds[step - 1]` raw, `strong: 'to'`, `paused: true` — the before-pause shape live stepped execution emits. §2 expansion in `applyHighlight` lights up `[wrapper, bare]` and §10 lights the call edge during the wrapper-entry iter. The recorded `Frame.highlight` stays untouched (the trace table reads it as-is).

A first attempt re-eval'd the example to capture raw ids in a separate machine — that minted fresh `State` runtime ids that didn't match `graph.nodes` keys, and the symptom was "only `idle` highlighted, nothing else." Wrapping the same machine fixed it.

## Layout plumbing

- `src/app.css` `body` gets `overflow: hidden` + the flex chain (`body → main → .landing`) gains explicit `min-height: 0` so internal containers bound correctly and `.landing`'s `overflow-y: auto` owns the only vertical scroll. Without it, Safari's rubber-band overscroll exposes empty page-background area below the footer when content is short.

## Docs

- `CLAUDE.md` component tree: added `Landing.svelte` / `SnippetPanel.svelte` / `ExecutionTraceTable.svelte` / `lessonMarkdown.ts` with new responsibilities (IO orchestration, 4-state machine, manual `scrollTop`, lesson-prose policy).
- `README.md` intro opens with the landing page; layout tree gets the three new components + `lessonMarkdown.ts`; e2e section lists all three spec files.
- `docs/execution-model.md` gains §1.1 "Scope: engine pages only" — SnippetPanel playback is orthogonal to MachineView's `DebugSession` modes.
- `docs/machine-graph-palette.md` highlight-tokens table notes `ExecutionTraceTable` reuses `--graph-highlight-soft-fill` so the trace and graph stay in lockstep when re-tuning.

Time-stamped specs/plans under `docs/superpowers/` left as historical artifacts per the project convention.

## Versioning

`1.0.0-alpha.24` → `1.0.0-alpha.25`. No engine / visuals / post peer-dep changes — still on `^7.0.0` for all three.

## Test plan

- [x] `npm run check` (svelte-check + tsc): 649 files / 0 errors / 0 warnings
- [x] `npm run lint`: clean
- [x] `npm test`: 288 tests across 28 files pass
- [x] `npm run build`: production bundle builds
- [x] `npm run test:e2e`: 18 Playwright scenarios pass (landing.spec.ts unchanged)
- [ ] Smoke-test on the dev server: callable-subtree showcase lights up the wrapper + `call` edge during the wrapper-entry iter; trace-row highlight clears at natural end; pause/resume on scroll preserves frame position; `done` state requires explicit Replay.