### PR TITLE
docs: forge-agnostic content sweep

### DIFF
--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -1,10 +1,10 @@
 # Execution model and debugger semantics
 
-> Canonical reference for what each mode does, what each user action triggers, and where the machine lands. Tests in [#47](https://github.com/mellonis/machines-demo/issues/47) cite the scenario IDs (`S-...`) defined throughout. Working conventions and file structure remain in [`CLAUDE.md`](../CLAUDE.md).
+> Canonical reference for what each mode does, what each user action triggers, and where the machine lands. The test suites cite the scenario IDs (`S-...`) defined throughout. Working conventions and file structure remain in [`CLAUDE.md`](../CLAUDE.md).
 
 ## 1. Overview
 
-The demo runs user-typed JavaScript inside a Web Worker that drives a `@turing-machine-js/machine` v7.0.0-alpha.6 machine through a **`DebugSession`** ([engine #102](https://github.com/mellonis/turing-machine-js/issues/102)). The engine's v7 `run()` is sync + callback-free; all interactive observation (breakpoints, step controls, click-pause, throttle) moved into the session. The worker constructs one — `machine.debugRun(...)` for Post (returns a `PostDebugSession`), `new DebugSession(machine, ...)` for Turing — and listens to its `step` / `pause` / `iter` / `halt` events. The main thread tracks the worker's progress with a 5-mode state machine: one resting state (MANUAL), three running states (RUNNING_AUTO, RUNNING_CONTINUOUS, RUNNING_PAUSED), and one terminal (HALTED).
+The demo runs user-typed JavaScript inside a Web Worker that drives a `@turing-machine-js/machine` v7.0.0-alpha.6 machine through a **`DebugSession`**. The engine's v7 `run()` is sync + callback-free; all interactive observation (breakpoints, step controls, click-pause, throttle) moved into the session. The worker constructs one — `machine.debugRun(...)` for Post (returns a `PostDebugSession`), `new DebugSession(machine, ...)` for Turing — and listens to its `step` / `pause` / `iter` / `halt` events. The main thread tracks the worker's progress with a 5-mode state machine: one resting state (MANUAL), three running states (RUNNING_AUTO, RUNNING_CONTINUOUS, RUNNING_PAUSED), and one terminal (HALTED).
 
 Engine pages (`/turing`, `/post`) mount in MANUAL. Initial editor content follows a 4-tier boot priority: `?example=<id>` query > `?snippet=<uuid>` query > localStorage `code` > first bundled example for the engine. Implementation lives in `src/lib/initialBoot.ts` as the pure helper `computeInitialBoot(...)`. No tape animation runs until the user clicks Step or Run.
 
@@ -211,7 +211,7 @@ Each Step advances exactly one iter, same as before — but the displayed pause 
 
 **Edge cases**
 - `debug=on`: a user-authored `.before` breakpoint on the next iter's state lands on the same moment the step would. The engine fires a single `pause` event and resolves the `breakpoint > step > manual` precedence in favor of `cause: 'breakpoint'`; the step mode is still consumed (one-shot rule). The long-format log line reads the same `before` side either way.
-- Stepping onto the halt-triggering iter: when `haltState.debug` is on the worker labels the resulting after-side halt pause "paused before halt (after X)" (engine #207 — `m.state` is the triggering state, `m.pause.side === 'after'`). When the halt breakpoint is off, the run simply finishes and the worker sends `ran` → HALTED.
+- Stepping onto the halt-triggering iter: when `haltState.debug` is on the worker labels the resulting after-side halt pause "paused before halt (after X)" (`m.state` is the triggering state, `m.pause.side === 'after'`). When the halt breakpoint is off, the run simply finishes and the worker sends `ran` → HALTED.
 
 The sequence diagram below shows the complete cycle: Run (debug=on) → break → Step → re-pause → Continue → halt or further breaks.
 
@@ -341,7 +341,7 @@ Both surface as `WorkerError` in the runner; main thread's `failHalted` rebuilds
 
 A run that doesn't halt naturally hits `MAX_STEPS = 100_000` inside the worker's `runToEnd` cap. Worker sends `ran` with `truncated: true`.
 
-- `S-truncate-auto` / `S-truncate-cont` — main thread receives `ran`. → HALTED with `truncated: did not halt within MAX_STEPS steps` log entry. Per-step entries are **suppressed** when `truncated: true` (band-aid until [#45](https://github.com/mellonis/machines-demo/issues/45) lands; rendering 100k log entries freezes the main thread for seconds).
+- `S-truncate-auto` / `S-truncate-cont` — main thread receives `ran`. → HALTED with `truncated: did not halt within MAX_STEPS steps` log entry. Per-step entries are **suppressed** when `truncated: true` (band-aid until the Log can render huge traces efficiently; rendering 100k log entries freezes the main thread for seconds).
 
 **Log entries**
 - `truncated: did not halt within MAX_STEPS steps`
@@ -362,26 +362,24 @@ A run that doesn't halt naturally hits `MAX_STEPS = 100_000` inside the worker's
 
 ## 9. Current divergences from spec
 
-A punchlist of where today's code differs from the spec, each with a tracking-issue link. Acts as a TODO list for follow-up PRs; #47 cites scenario IDs and `it.skip` divergent ones until they close.
+A punchlist of where today's code differs from the spec. Acts as a TODO list for follow-up work; the test suites cite scenario IDs and `it.skip` divergent ones until they close.
 
 - **Take Control's scope narrowed** — only meaningful from RUNNING_* (terminate the worker and land MANUAL, distinct from Stop which lands HALTED). Hidden from MANUAL (already the resting mode) and HALTED (terminal — nothing to take). Open design question: should Take Control collapse into Stop with a "preserve mirror" flag, or stay as its own affordance to keep the user-visible semantics ("take control of this partial run" vs "abandon this run") distinct? No tracking issue yet.
 
-> ⚠️ The former entries here — "IDLE mode does not exist", "halting iter's `state.debug.after` never fires", "`haltState.debug.after` silently ignored" — are all **resolved**. IDLE was retired entirely with the DEMO + IDLE removal; Step no longer arms `.after` (it uses the engine's `stepIn()`, before-side); `haltState.debug` is now a `boolean` ([turing-machine-js#207](https://github.com/mellonis/turing-machine-js/issues/207)) whose pause fires reliably on the after-side of the halt-triggering iter. None of these divergences apply anymore.
+> ⚠️ The former entries here — "IDLE mode does not exist", "halting iter's `state.debug.after` never fires", "`haltState.debug.after` silently ignored" — are all **resolved**. IDLE was retired entirely with the DEMO + IDLE removal; Step no longer arms `.after` (it uses the engine's `stepIn()`, before-side); `haltState.debug` is now a `boolean` upstream whose pause fires reliably on the after-side of the halt-triggering iter. None of these divergences apply anymore.
 
 ## 10. Engine quirks
 
 Upstream behaviors the spec encodes (won't change without a major upstream version, so the spec works around them):
 
-- The `DebugSession` `step` event is fire-and-forget and synchronous (per-iter, mid-iter, between any before-pause and after-pause). The demo's `step` listener uses it purely to buffer commands / reads / match-kinds and track `prevYieldedStateId` — it never awaits. Per-iter **awaited** coordination lives on the `iter` event (the engine awaits it, sequenced after any after-pause), which the demo uses for the RUNNING_AUTO throttle. The `pause` event is also awaited (the engine blocks on its internal resume-promise until `continue` / `stepIn` / `stop`). Cross-ref [turing-machine-js#102](https://github.com/mellonis/turing-machine-js/issues/102) for the `DebugSession` reshape.
+- The `DebugSession` `step` event is fire-and-forget and synchronous (per-iter, mid-iter, between any before-pause and after-pause). The demo's `step` listener uses it purely to buffer commands / reads / match-kinds and track `prevYieldedStateId` — it never awaits. Per-iter **awaited** coordination lives on the `iter` event (the engine awaits it, sequenced after any after-pause), which the demo uses for the RUNNING_AUTO throttle. The `pause` event is also awaited (the engine blocks on its internal resume-promise until `continue` / `stepIn` / `stop`). This is the engine's v7 `DebugSession` contract.
 
 §9 vs §10: §9 lists demo-side gaps to be closed; §10 lists engine semantics that won't change. Items can move from §10 to §9 if the upstream issue lands and a corresponding demo-side simplification becomes possible.
 
 ## 11. Cross-references
 
 - [`CLAUDE.md`](../CLAUDE.md) — working conventions, file structure, build commands. Runtime-behavior content moved here.
-- [`docs/superpowers/specs/2026-05-08-worker-run-mode-design.md`](superpowers/specs/2026-05-08-worker-run-mode-design.md) — the [#40](https://github.com/mellonis/machines-demo/issues/40) design; gives the *why* behind RUNNING_PAUSED and the worker contract.
-- [#47](https://github.com/mellonis/machines-demo/issues/47) — test infrastructure that consumes the scenario IDs defined in this doc.
-- [#46](https://github.com/mellonis/machines-demo/issues/46) — issue this spec resolves.
+- [`docs/superpowers/specs/2026-05-08-worker-run-mode-design.md`](superpowers/specs/2026-05-08-worker-run-mode-design.md) — the worker-run-mode design; gives the *why* behind RUNNING_PAUSED and the worker contract.
 
 ## 12. Scenario ID grammar
 
@@ -409,5 +407,5 @@ Conventions:
 Where IDs live:
 - **Matrix cells** (§6): `S-step-paused-off: arm .after, resume(step), → PAUSED`. Text after `:` is the one-line outcome.
 - **Walk-throughs** (§8): each opens with `### \`S-step-paused-off\` / \`S-step-paused-on\` — Step from break` so the ID is the section anchor.
-- **Tests** ([#47](https://github.com/mellonis/machines-demo/issues/47)): each `it()` cites at least one ID. UI-flow tests cite `S-...` (component / E2E layers); runner / worker / helper tests cite `R-...`. Failing tests point straight at the spec rule they broke.
+- **Tests**: each `it()` cites at least one ID. UI-flow tests cite `S-...` (component / E2E layers); runner / worker / helper tests cite `R-...`. Failing tests point straight at the spec rule they broke.
 - **§9 entries**: cite the IDs they affect when describing today's divergences.

--- a/docs/palette-sandbox/variant-a.html
+++ b/docs/palette-sandbox/variant-a.html
@@ -282,7 +282,7 @@ body {
   background-color: transparent !important;
 }
 
-/* Highlight rules (mirror MachineGraph #10 — debugger pause "you are here").
+/* Highlight rules (mirror MachineGraph's debugger-pause "you are here" highlight).
    Classes (`mg-highlight-from`, `-to`, `-strong`, `-edge`) are added
    imperatively at runtime in production; the sandbox replays that via
    the "Toggle debugger pause" button. */

--- a/e2e/cold-start.spec.ts
+++ b/e2e/cold-start.spec.ts
@@ -39,7 +39,7 @@ test.describe('cold-start', () => {
   test('E-cold-start-step-debug-on: Step+debug=on parks at iter-1 with state info', async ({ page }) => {
     await page.getByRole('checkbox', { name: /^debug$/i }).check();
     await page.getByRole('button', { name: /^step$/i }).click();
-    // Step is driven by the engine's stepIn() (engine #102) — a before-side
+    // Step is driven by the engine's stepIn() — a before-side
     // pause: it parks BEFORE applying iter 1's command. With debug=on any
     // user-set breaks would also fire, but the example has none, so the
     // step pause is what surfaces.
@@ -178,7 +178,7 @@ test.describe('cold-start', () => {
     // flip to a pause glyph and the word "Pause". Target by the rendered
     // label to assert it's actually labelled correctly AND enabled (this
     // button is what the user clicks to pause an auto run). Pause is the
-    // engine's external pause() (engine #102) — a before-side pause
+    // engine's external pause() — a before-side pause
     // (cause: 'manual') at the next iter, so the line reads "before applying
     // command".
     await expect(page.getByRole('button', { name: /^pause$/i })).toBeEnabled();

--- a/src/app.css
+++ b/src/app.css
@@ -38,7 +38,7 @@
   --anim-button-hover-ms: 120ms;
   --anim-cell-write-ms: 320ms;
 
-  /* state-graph palette (machines-demo#9 / #10). The demo owns the look
+  /* state-graph palette. The demo owns the look
      of the rendered diagram — engine-emitted classDefs are stripped at
      render time so these tokens drive everything. Generic `--graph-tag-*`
      covers any `tag_<name>` class; `--graph-tag-main-*` overrides for the
@@ -76,7 +76,7 @@
   --graph-highlight: #f59e0b;
   --graph-highlight-soft-fill: color-mix(in srgb, #f59e0b 22%, var(--graph-node-fill));
   --graph-highlight-strong-fill: color-mix(in srgb, #f59e0b 40%, var(--graph-node-fill));
-  /* machines-demo#37 layer 1 — distinct from --graph-highlight (amber, used
+  /* Breakpoint indicator — distinct from --graph-highlight (amber, used
      for the running-machine cue) so users can tell "this state has a
      breakpoint" apart from "the machine is currently at this state" when
      both apply. Red palette by convention (gutter dots in major IDEs). */

--- a/src/components/ExecutionTraceTable.svelte
+++ b/src/components/ExecutionTraceTable.svelte
@@ -6,7 +6,7 @@
     /**
      * Step number to highlight. `null` clears the highlight entirely —
      * used by SnippetPanel to mirror the graph's neutral state after
-     * playback finishes naturally (parallels #108).
+     * playback finishes naturally (parallels the graph-highlight clear).
      */
     frameIndex: number | null;
     graph: Snippet['graph'];

--- a/src/components/Landing.svelte
+++ b/src/components/Landing.svelte
@@ -7,7 +7,7 @@
 
   let engine = $state<Engine>('turing');
 
-  // Playback orchestration (#112 design point 5). One IntersectionObserver
+  // Playback orchestration. One IntersectionObserver
   // over all panel slots — the panel with the highest visible ratio becomes
   // `active`; everyone else freezes at frame 0. Reduced motion is checked
   // here too: under prefers-reduced-motion the IO is never created — every

--- a/src/components/MachineGraph.svelte
+++ b/src/components/MachineGraph.svelte
@@ -21,10 +21,10 @@
   type Props = {
     graph: Graph | null;
     /** `from + edge + to` triple to highlight in the SVG. `null` clears any
-     *  active highlight. Driven by MachineView mode + pause-response data
-     *  (machines-demo#10). */
+     *  active highlight. Driven by MachineView mode + pause-response
+     *  data. */
     highlight?: GraphHighlight | null;
-    /** Monotonic per-event counter from the worker (machines-demo#10). Used
+    /** Monotonic per-event counter from the worker. Used
      *  as a reactivity tick: when two consecutive paused events have
      *  structurally identical highlights (Copy-tape step-mode looping on
      *  id:1), the $derived wouldn't re-run and this $effect wouldn't
@@ -38,7 +38,7 @@
      *  breakpoint right-click context menu is suppressed (no debugger
      *  flow in a prerecorded panel). Zoom / aim / pan / wheel-zoom stay
      *  available — the user still wants to look around big showcase
-     *  graphs (machines-demo#110). The imperative render pipeline is
+     *  graphs. The imperative render pipeline is
      *  unaffected. Default `false` preserves the full interactive
      *  behaviour for `MachineView`. */
     readOnly?: boolean;
@@ -55,8 +55,8 @@
      *  error in the main log (not just in this panel's own error slot).
      *  Optional — caller can omit if they don't need it. */
     onRenderError?: (message: string) => void;
-    /** Set of canonical bare ids with at least one active breakpoint kind
-     *  (machines-demo#37). Read by the indicator effect to render the
+    /** Set of canonical bare ids with at least one active breakpoint
+     *  kind. Read by the indicator effect to render the
      *  visual mark on toggled nodes; reactive via SvelteSet. Empty /
      *  omitted when the parent hasn't wired breakpoints yet. */
     breakpoints?: ReadonlySet<number>;
@@ -66,7 +66,7 @@
      *  `onToggleBreakpoint` is set. */
     breakpointKinds?: ReadonlyMap<number, { before: boolean; after: boolean }>;
     /** Called with the engine `GraphNode.id` + kind when the user picks a
-     *  context-menu item over a state node (machines-demo#37). Halt-marker
+     *  context-menu item over a state node. Halt-marker
      *  (negative ids) and the halt singleton (id 0) are filtered out before
      *  this fires — the consumer can assume `stateId` references a regular,
      *  bare, or wrapper State. Omitted when the parent doesn't want clicks
@@ -96,7 +96,7 @@
     onReady,
   }: Props = $props();
 
-  // Screen-reader-friendly summary of the graph (machines-demo#95 B1).
+  // Screen-reader-friendly summary of the graph.
   // The rendered SVG carries no text alternative; this is the parallel
   // structural view AT users get. Rendered into the `.sr-only` block
   // below — visible UI unchanged.
@@ -324,10 +324,10 @@
   // the SVG re-render when the source is byte-identical, so the same DOM
   // elements persist across cache-build re-fires — without this controller,
   // `addEventListener` calls stack up on the same `g.node` and a single
-  // user right-click would fire N menu handlers (machines-demo#37 follow-up).
+  // user right-click would fire N menu handlers.
   let clickListenersController: AbortController | null = null;
 
-  // Context-menu state (machines-demo#37). When set, the menu is open over
+  // Context-menu state. When set, the menu is open over
   // the state node identified by `menuStateId` at viewport coordinates
   // (menuX, menuY). Closing happens via outside-click, ESC, or item-pick.
   // The clamped position is computed after the menu mounts (we need to
@@ -411,7 +411,7 @@
     menuClampedY = y;
   });
 
-  // Strong-node id from the most recent PAUSED apply (machines-demo#10).
+  // Strong-node id from the most recent PAUSED apply.
   // The pulse condition is "paused on the same state as the previous
   // paused event" — idles never trigger or update this. Reset to null on
   // highlight-clear so a mode transition doesn't leave stale state matching
@@ -543,7 +543,7 @@
   }
 
   // Center an element inside the scrollable ancestor when it isn't sitting
-  // comfortably inside the viewport (machines-demo#110). "Comfortable" means
+  // comfortably inside the viewport. "Comfortable" means
   // fully inside the inner 80% of the body (10% inset on each side); a node
   // that drifts into the edge band or off-screen gets pulled back to the
   // center on that axis. Per-axis check is independent — a node fine
@@ -554,7 +554,7 @@
   // Previous policy (`scrollIntoViewIfNeeded`) only fired when the node was
   // FULLY outside the body — a node sitting at the edge with a sliver still
   // visible never triggered, so showcase snippet playback "looked frozen"
-  // for big graphs (#110).
+  // for big graphs.
   function centerIfNeeded(scroller: HTMLElement, el: Element, behavior: ScrollBehavior = 'smooth'): void {
     const target = computeCenterScroll(
       scroller.getBoundingClientRect(),
@@ -725,7 +725,7 @@
       // source state lives inside frame N, so the visible edge ends at the
       // in-frame marker rather than the outside real-halt singleton.
       // `idle` → synthetic entry sentinel. `w_N` → subgraph wrapper (the
-      // cluster IS user-facing for #10 frame-active border, but that lookup
+      // cluster IS user-facing for the frame-active border, but that lookup
       // uses clusterCache, not nodeCache).
       const m = el.id.match(/-flowchart-(s\d+|idle|c\d+|w_\d+)-/);
       if (!m) return;
@@ -737,13 +737,13 @@
         : null; // w_N skipped here — clusterCache handles those.
       if (key === null) return;
       if (!nodeCache.has(key)) nodeCache.set(key, el);
-      // machines-demo#37 — attach a contextmenu (right-click) listener for
+      // Attach a contextmenu (right-click) listener for
       // breakpoint-eligible nodes. Left-click stays native (text selection,
       // focus, etc); the menu opens at cursor coords with per-kind items.
       // Skip only the `'idle'` sentinel (no underlying State). Halt
       // singleton (id 0) and halt markers (negative ids) ARE clickable —
       // they all map to the haltState class via `bareIdOf`, surfacing the
-      // global breakpoint info in the menu (machines-demo#37 layer 2).
+      // global breakpoint info in the menu.
       if (!readOnly && onToggleBreakpoint && typeof key === 'number') {
         el.style.cursor = 'context-menu';
         el.classList.add('node-clickable');
@@ -769,8 +769,8 @@
       if (frameId === undefined) return;
       if (!clusterCache.has(frameId)) clusterCache.set(frameId, el);
     });
-    // Materialize highlight-color variants of mermaid's shared markers
-    // (machines-demo#10). Mermaid emits one `<marker>` per arrowhead shape
+    // Materialize highlight-color variants of mermaid's shared
+    // markers. Mermaid emits one `<marker>` per arrowhead shape
     // and colors them all from `#mg-N .marker { fill: lightgrey; ... }`, so
     // every arrowhead is grey regardless of its referencing edge's stroke.
     // `context-stroke` would fix this declaratively but isn't reliable
@@ -796,7 +796,7 @@
 
   // After each new render: pick a zoom that keeps ≥60% of the SVG's area
   // visible inside the body, then center the `idle` entry node so the user
-  // lands on the diagram's start (machines-demo#110).
+  // lands on the diagram's start.
   //
   // Why both passes share an effect:
   //   - The zoom adjustment changes `.svg-host`'s laid-out width / height,
@@ -911,7 +911,7 @@
 
   /**
    * Imperative API: scroll the synthetic `idle` entry node to the center of
-   * the body viewport (machines-demo#110). Called by `SnippetPanel.onReplay`
+   * the body viewport. Called by `SnippetPanel.onReplay`
    * so a Replay-clicked panel rewinds the scroll position to the same view
    * the user got on first mount, instead of resuming from wherever the last
    * frame's highlight had pushed the viewport. No-op when the SVG / cache
@@ -997,12 +997,12 @@
     onReady?.();
   });
 
-  // Breakpoint indicator effect (machines-demo#37 layer 1). Runs on
+  // Breakpoint indicator effect. Runs on
   // `breakpoints` change AND on `svg` change (cache repopulates on SVG
   // re-render). Delegates the rule logic to `applyIndicator`; the ops
   // object below is a thin DOM adapter that toggles `mg-breakpoint` per
-  // node. See the rules doc (now in `@turing-machine-js/visuals`):
-  // https://github.com/mellonis/turing-machine-js/blob/v7/packages/visuals/docs/graph-highlight-and-breakpoints.md §2 + §12.
+  // node. See the rules doc `docs/graph-highlight-and-breakpoints.md`
+  // shipped in `@turing-machine-js/visuals`, §2 + §12.
   $effect(() => {
     const bps = breakpoints;
     void svg;
@@ -1102,7 +1102,7 @@
         if (!el) return;
         // Delegates to `centerIfNeeded` (defined above) so a paused state
         // sitting in the edge band gets pulled back to the center
-        // (machines-demo#110) — the previous "fully outside" policy left
+        // — the previous "fully outside" policy left
         // partially-visible nodes alone, which read as a frozen viewport
         // on long subroutine chains. Manual offset math (vs
         // `Element.scrollIntoView`) avoids browser quirks around scrolling
@@ -1216,7 +1216,7 @@
   </header>
 
   {#if summary}
-    <!-- a11y: text alternative for the rendered SVG (machines-demo#95 B1).
+    <!-- a11y: text alternative for the rendered SVG.
          Always rendered when a graph exists — must remain available when
          visually collapsed, since the rendered SVG is the only path for
          sighted users and this is the only path for AT users. Derived
@@ -1309,7 +1309,7 @@
          other kind in the same gesture without re-opening. Dismiss
          channels are still: outside-click, Esc, or selecting another
          node (which opens a new menu at the new position). -->
-    <!-- For halt: a single "Pause" checkbox — turing-machine-js#207 collapsed
+    <!-- For halt: a single "Pause" checkbox — the engine collapsed
          haltState.debug to a boolean (one meaningful pause moment, fires on
          the AFTER side of the halt-triggering iter). The toggle still routes
          through the `before` kind name in the worker protocol for backward
@@ -1392,7 +1392,7 @@
   }
 
   /* Expanded ("modal") mode: the parent renders this component inside a
-     native <dialog> (machines-demo#9 → #95 B2). The dialog provides the
+     native <dialog>. The dialog provides the
      centered 80vw × 80vh box, focus trap, Escape, and ::backdrop dimmer;
      all this component does in expanded mode is fill its container and
      drop the inline 360px body cap so the graph uses the modal's full
@@ -1757,7 +1757,7 @@
     stroke: var(--graph-edge-dotted) !important;
   }
 
-  /* Highlight rules (machines-demo#10).
+  /* Highlight rules.
      Listed AFTER the tag + edge rules so source order wins on fill.
      `!important` still required on stroke / stroke-width to beat
      mermaid's per-id selectors injected into the SVG's own <style>
@@ -1812,7 +1812,7 @@
     transition: stroke 150ms ease, stroke-width 150ms ease;
   }
 
-  /* Breakpoint indicator (machines-demo#37 layer 1). A red stroke on the
+  /* Breakpoint indicator. A red stroke on the
      node's outer shape signals an active `state.debug.before = true`
      breakpoint. Decoupled from `--graph-highlight` (which is amber/orange
      for the running-machine cue) and from `--head` (the tape head marker)
@@ -1902,7 +1902,7 @@
     transition: opacity 150ms ease;
   }
 
-  /* Breakpoint context menu (machines-demo#37). Positioned fixed at the
+  /* Breakpoint context menu. Positioned fixed at the
      viewport coordinates the right-click reported (clamped by the
      `menuClampedX/Y` effect so it never spills off an edge). Floats above
      everything else via a high z-index; matches the demo's surface tokens

--- a/src/components/MachineGraph.test.ts
+++ b/src/components/MachineGraph.test.ts
@@ -29,7 +29,7 @@ const STUB_GRAPH = {
   nodes: {},
 } as never; // structural-cast — the component only forwards to toMermaid
 
-// Minimal two-state graph for the text-alternative test (#95 B1). Shape
+// Minimal two-state graph for the text-alternative test. Shape
 // mirrors the engine's `Graph` type — see `@turing-machine-js/machine`'s
 // `utilities/graph.d.ts`. `pattern` / `command[].symbol` / `.movement`
 // strings are the engine's pre-decoded edge-label vocabulary.

--- a/src/components/MachineView.svelte
+++ b/src/components/MachineView.svelte
@@ -72,14 +72,14 @@
   let alphabets = $state<Alphabets>([]);
   const log = new LogStore();
   let lastSnapshots = $state<TapeSnapshot[] | null>(null);
-  // State-graph panel (machines-demo#9). `graph` is the engine-v7 Graph
+  // State-graph panel. `graph` is the engine-v7 Graph
   // snapshot captured at Build via State.toGraph; null pre-Build.
   // `graphCollapsed` defaults to "open on desktop, closed on mobile" per
   // the issue's UX note; `graphModalOpen` drives the expand-to-modal view.
   let graph = $state<Graph | null>(null);
   let graphCollapsed = $state(untrack(() => initialGraphCollapsed(engine)));
   let graphModalOpen = $state(false);
-  // Native <dialog> ref for the expanded-graph modal (machines-demo#95 B2).
+  // Native <dialog> ref for the expanded-graph modal.
   // Replaces the previous `<div role="presentation">` backdrop + manual
   // Escape / outside-click handlers — `showModal()` gives focus trap,
   // Escape, return-focus to the opener, and scroll-lock for free, and
@@ -101,7 +101,7 @@
   // forces the effect to re-fire per event.
   let stepsApplied = $state(0);
 
-  // machines-demo#37 — per-state breakpoint kinds, keyed by canonical
+  // Per-state breakpoint kinds, keyed by canonical
   // bare id (wrapper and bare share `#debugRef` engine-side; they're one
   // breakpoint from the user's POV — see `bareIdOf`). Each entry is the
   // current `{ before, after }` state for that equivalence class.
@@ -131,7 +131,7 @@
   $effect(() => {
     saveGraphCollapsed(engine, graphCollapsed);
   });
-  // Highlight state (#10). Carried through from the paused response:
+  // Highlight state. Carried through from the paused response:
   //   - `prevStateId` is the state we just left (= FROM of the just-fired
   //     transition that brought us to `currentStateId`). Null only at the
   //     very first iter's before-pause; treated as the synthetic `idle`
@@ -208,7 +208,7 @@
 
   const runner = new MachineRunner(untrack(() => engine), () => new MachineWorker());
 
-  // machines-demo#37 — install the breakpoint-echo callback once at runner
+  // Install the breakpoint-echo callback once at runner
   // construction. The worker emits `breakpointToggled` after each
   // toggleBreakpoint mutation (with the same `kind`); the UI updates its
   // per-state Map in lockstep so context-menu checkmarks feel synchronous
@@ -267,7 +267,7 @@
     executionMode !== 'RUNNING_PAUSED',
   );
 
-  // State-graph highlight (#10): mirrors the LAST FIRED transition (so the
+  // State-graph highlight: mirrors the LAST FIRED transition (so the
   // graph stays in lockstep with the most recent log entry). Strong on
   // m.state in all cases — "you are here".
   //
@@ -468,7 +468,7 @@
       // fresh worker. Each toggle flips off→on (fresh States have no debug
       // set), so we issue one `toggleBreakpoint` per stored kind per class.
       //
-      // machines-demo#78: user code may have programmatically set
+      // User code may have programmatically set
       // `state.debug`. Those entries arrive in `res.codeSetBreakpoints` —
       // they're ALREADY applied in the fresh worker so we skip the replay
       // for those ids (replaying would flip them OFF), and we write them
@@ -510,7 +510,7 @@
     }
   }
 
-  // machines-demo#37 — toggle a state-level breakpoint (kind: 'before' or
+  // Toggle a state-level breakpoint (kind: 'before' or
   // 'after') by engine `GraphNode.id`. Fire-and-forget; the worker echoes
   // a `breakpointToggled` response which updates the `breakpoints` Map via
   // the runner.onBreakpointToggled hook above. Invoked from MachineGraph's
@@ -682,7 +682,7 @@
       );
       renderChain = renderChain.then(() => renderFromMirror(commands, animate));
     }
-    // Drive the per-iter graph highlight (#10). Iter-end semantics: we
+    // Drive the per-iter graph highlight. Iter-end semantics: we
     // just landed in `currentStateId`, and `nextStateId` is where the
     // next iter would go. The RUNNING_AUTO branch of `graphHighlight`
     // reads these without touching `pauseBefore`.
@@ -692,7 +692,7 @@
   }
 
   function onPausedHandler(paused: PausedResponse): void {
-    // Highlight (#10): capture prev / current / next so the graph can light
+    // Highlight: capture prev / current / next so the graph can light
     // up the JUST-FIRED transition triple (matching the last logged step).
     // `pauseBefore` selects which triple to use — see graphHighlight derived.
     prevStateId = paused.prevStateId;
@@ -1039,8 +1039,7 @@
   <div class="panel-tape">
     <TapesStack bind:this={tapesStackRef} {tapeCount} caretColors={CARET_COLORS} />
 
-    <!-- Expanded ("modal") graph (machines-demo#9 + post-#37, reshaped
-         for #95 B2). Native <dialog> opened via `showModal()` — browser
+    <!-- Expanded ("modal") graph. Native <dialog> opened via `showModal()` — browser
          provides focus trap, Escape, return-focus to the opener, and
          scroll-lock. `oncancel`/`onclose` mirror user-driven closes
          (Escape, ::backdrop programmatic close) back to `graphModalOpen`
@@ -1212,14 +1211,14 @@
     }
   }
 
-  /* State-graph row (machines-demo#9) — sits between TapesStack and the
+  /* State-graph row — sits between TapesStack and the
      control panel. Just a top-margin spacer so the collapsible card has
      air around it; the card owns its own border/background. */
   .machine-graph-row {
     margin-top: 12px;
   }
 
-  /* Native <dialog> for the expanded MachineGraph (#9 → #95 B2). Sized
+  /* Native <dialog> for the expanded MachineGraph. Sized
      to mirror the previous fixed-positioned panel (80vw × 80vh, centered).
      `<dialog>` opened via `showModal()` is placed in the browser's top
      layer with implicit aria-modal + focus trap + Escape; the centering

--- a/src/components/SnippetPanel.svelte
+++ b/src/components/SnippetPanel.svelte
@@ -99,10 +99,10 @@
   let graphReady = $state(false);
   // True after natural playback end. Nulls out the trace's current-row
   // highlight so a finished panel reads as not-currently-playing — parallels
-  // the graph's neutral clear at the same moment (#108).
+  // the graph's neutral clear at the same moment.
   let cleared = $state(true);
-  // 4-state playback machine driven by `active` (see #112 "Playback
-  // orchestration"). Plain closure variable — not $state — because the
+  // 4-state playback machine driven by `active` (see the "Playback
+  // orchestration" $effect below). Plain closure variable — not $state — because the
   // active-toggle $effect reads AND writes it; making it reactive would
   // make the effect re-fire on every transition and loop indefinitely. The
   // template never reads it directly.
@@ -212,7 +212,7 @@
       if (!player.forward()) {
         // Playback reached the last frame on the previous tick. Clear the
         // residual highlight from that frame so the graph returns to neutral
-        // before the Replay control sits idle on it (#108).
+        // before the Replay control sits idle on it.
         clearGraphHighlights();
         cleared = true;
         clearReplayTimer();
@@ -258,8 +258,8 @@
     applyGraph();
   }
 
-  // Landing's IntersectionObserver drives `active`; this $effect dispatches
-  // the 4-state playback machine (see #112 "Playback orchestration"). Body
+  // Landing's IntersectionObserver drives `active`; this $effect is the
+  // "Playback orchestration" dispatcher of the 4-state playback machine. Body
   // wrapped in `untrack` so $state reads inside the dispatch helpers
   // (`machineGraphRef`, `tapesStackRef`, `graphReady`) don't become effect
   // deps and trip an infinite update loop. Reduced motion short-circuits
@@ -426,7 +426,7 @@
   }
 
   .tapes {
-    /* Player fills the column at 100% width (#112 design point 3) — let the
+    /* Player fills the column at 100% width — let the
        tape stretch the full track rather than centering with slack. */
     min-width: 0;
   }
@@ -487,7 +487,7 @@
     background: color-mix(in srgb, var(--cell-bg) 80%, var(--fg));
   }
 
-  /* Sibling-to-Replay button styling (machines-demo#110): the link sits
+  /* Sibling-to-Replay button styling: the link sits
      next to the .replay <button> when playback is done, so the underline-
      link look read as mismatched. Keep it an <a> for keyboard / right-click
      / open-in-new-tab semantics — just match the button's surface. */

--- a/src/components/SnippetPanel.test.ts
+++ b/src/components/SnippetPanel.test.ts
@@ -147,7 +147,7 @@ describe('SnippetPanel', () => {
     vi.advanceTimersByTime(50);
     flushSync();
     expect(currentStep()).toBe(2);
-    // One more tick: player.forward() returns false → highlight clears (#108 parity).
+    // One more tick: player.forward() returns false → highlight clears (natural-end parity).
     vi.advanceTimersByTime(50);
     flushSync();
     expect(currentStep()).toBe(null);

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -94,7 +94,7 @@
   let saveName = $state('');
   let pendingOverwrite = $state(false);
   let nameInputEl = $state<HTMLInputElement | undefined>(undefined);
-  // Native <dialog> ref for the save popover (machines-demo#95 M4).
+  // Native <dialog> ref for the save popover.
   // Opened via showModal() so the browser handles focus trap, native
   // Escape (via the cancel event), return-focus to the save button on
   // close, and scroll-lock. Positioning uses CSS anchor positioning
@@ -803,7 +803,7 @@
   .save-menu {
     display: inline-flex;
 
-    /* Anchor target for the save popover dialog (machines-demo#95 M4).
+    /* Anchor target for the save popover dialog.
        The popover is a native <dialog> opened via showModal(), so it
        renders in the top layer and uses CSS anchor positioning to
        attach below the save button. Firefox without anchor-positioning

--- a/src/lib/breakpointCoordination.test.ts
+++ b/src/lib/breakpointCoordination.test.ts
@@ -5,15 +5,15 @@ import type { Graph } from '@turing-machine-js/machine';
 
 /**
  * Unit tests for the pure worker-side coordination helpers. Companion to
- * the highlight + breakpoints rules doc (now in `@turing-machine-js/visuals`):
- * https://github.com/mellonis/turing-machine-js/blob/v7/packages/visuals/docs/graph-highlight-and-breakpoints.md
+ * the highlight + breakpoints rules doc shipped in
+ * `@turing-machine-js/visuals` (`docs/graph-highlight-and-breakpoints.md`).
  *
  *   §15  → mergeDebugKinds (per-kind toggle that preserves the other bit)
  *
  * (Removed: `decideJoinedBare` + `decideOnIter` tests — both helpers were
  * deleted. `decideOnIter` drove the synthetic step-boundary dispatch, which
  * is gone now that Step / click-Pause run through the engine's stepIn() /
- * pause() (engine #102). See the comment in `breakpointCoordination.ts`.)
+ * pause(). See the comment in `breakpointCoordination.ts`.)
  */
 
 describe('mergeDebugKinds (§15 per-kind toggle)', () => {
@@ -75,7 +75,7 @@ describe('mergeDebugKinds (§15 per-kind toggle)', () => {
   });
 });
 
-describe('scanCanonicalBreakpoints (machines-demo#78)', () => {
+describe('scanCanonicalBreakpoints', () => {
   it('returns [] for an empty state map', () => {
     const stateMap = new Map();
     const graph: Graph = { initialId: 0, alphabets: [[' ']], nodes: {} } as Graph;

--- a/src/lib/breakpointCoordination.ts
+++ b/src/lib/breakpointCoordination.ts
@@ -53,13 +53,13 @@ export function mergeDebugKinds(
 // (Removed: `decideJoinedBare` and `decideOnIter`. `decideOnIter` drove the
 // worker's synthetic step-boundary dispatch + the after-fire-Step suppression
 // rule; both are gone now that Step / click-Pause are driven through the
-// engine's `stepIn()` / `pause()` (engine #102) and surface via the single
+// engine's `stepIn()` / `pause()` and surface via the single
 // `pause` event. Step is now before-side, so it never collides with an
 // after-side breakpoint and needs no dedup.)
 
 /**
- * One entry per logical breakpoint found by the post-build scan
- * (machines-demo#78). `stateId` is canonicalized: wrapper/bare pairs
+ * One entry per logical breakpoint found by the post-build
+ * scan. `stateId` is canonicalized: wrapper/bare pairs
  * fold to the bare's id; halt-class negative ids fold to `0`.
  * `before` / `after` mirror the bits of `state.debug.{before,after}`
  * read from the engine; both `false` is never emitted (the helper
@@ -92,7 +92,7 @@ export function scanCanonicalBreakpoints(
   const seen = new Set<number>();
   const entries: CanonicalBreakpointEntry[] = [];
 
-  // haltState (engine #207) — debug is a single boolean, not a DebugConfig.
+  // haltState — debug is a single boolean, not a DebugConfig.
   // Surface as a `before: true` entry under canonical id 0 (matches the UI's
   // single "Pause" toggle for halt and the toggleBreakpoint handler's
   // stateId 0 normalization).

--- a/src/lib/caps.ts
+++ b/src/lib/caps.ts
@@ -40,7 +40,7 @@ export const BELT_ANIMATION_MIN_INTERVAL_MS = 400;
 /** Render-view cap: `Log.svelte` only ever renders this many entries.
  *  Anything older lives in the LogStore's non-reactive buffer and is
  *  summarized by a synthetic overflow header. Bounds the DOM cost of a
- *  large-trace flush; configurable in the future via #65. */
+ *  large-trace flush; may become user-configurable in the future. */
 export const LOG_RENDER_CAP = 5000;
 
 /** Flush interval for the LogStore's buffer-to-view recompute. `report` /

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { commandsEntry } from './format.ts';
 import type { Command } from './types.ts';
 
-// Engine edge-label notation (machines-demo#69): `[reads] → [writes]/[moves]`.
+// Engine edge-label notation: `[reads] → [writes]/[moves]`.
 // Read cells: literal-quoted `'X'` or `B` (blank). Write cells: literal-quoted
 // or `K` (keep, command.symbol === null) or `E` (erase, command.symbol equals
 // blank). Move cells: bare `L`/`R`/`S`.
@@ -102,12 +102,12 @@ describe('commandsEntry — edge-label notation', () => {
   });
 
   // Wildcard marker (`*='X'`) — driven by per-tape matchKinds sourced from
-  // engine `MachineState.matchedTransition.matchKinds` (turing-machine-js
-  // #205). Position renders as `*='<lit>'` iff the firing alternative
+  // engine `MachineState.matchedTransition.matchKinds`.
+  // Position renders as `*='<lit>'` iff the firing alternative
   // matched via `ifOtherSymbol` at that tape index. The literal symbol
   // is always shown (no `B` shortcut for blanks) so the user can see
   // WHAT the catch-all caught — that's the whole point of the marker.
-  describe('wildcard read marker (#205)', () => {
+  describe('wildcard read marker', () => {
     it('renders single-tape wildcard read as `*=<lit>`', () => {
       const reads = ['1'];
       const commands: Command[] = [{ movement: 'R', symbol: null }];

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -62,7 +62,7 @@ export type CommandsApplication = { stepNumber: number } | 'applied';
 
 /**
  * One log entry rendering an applied step in engine edge-label notation
- * (`[reads] → [writes]/[moves]`, machines-demo#69). Single-tape gets a
+ * (`[reads] → [writes]/[moves]`). Single-tape gets a
  * one-line header + inline notation; multi-tape gets a header line with
  * `- Tape N: …` rows per tape.
  *

--- a/src/lib/graphSummary.ts
+++ b/src/lib/graphSummary.ts
@@ -1,6 +1,6 @@
 // Pure-function helper that turns an engine v7 `Graph` snapshot into a
 // readable, screen-reader-friendly summary. Used by `MachineGraph.svelte`'s
-// `.sr-only` text alternative (machines-demo#95 B1) — the rendered SVG
+// `.sr-only` text alternative — the rendered SVG
 // carries no `<title>`/`<desc>`/text alternative, so without this the
 // central simulator artifact is opaque to assistive tech.
 //

--- a/src/lib/imminentHalt.ts
+++ b/src/lib/imminentHalt.ts
@@ -7,7 +7,7 @@ import type { Graph } from '@turing-machine-js/machine';
  * value, return the imminentHalt tag (or undefined for "not halt-imminent").
  *
  * Gating rules:
- * 1. Only fires on `after` pauses (#207's halt timing). Before-pauses cannot
+ * 1. Only fires on `after` pauses (the engine's halt timing). Before-pauses cannot
  *    be halt-imminent under the new engine — halt fires on the after side.
  * 2. Only fires when `haltState.debug === true` — the user has armed the
  *    halt-BP. A regular per-state `state.debug.after` BP firing on an iter
@@ -46,7 +46,7 @@ export function computeImminentHalt(args: {
   /** Engine `Graph` snapshot. Used to look up the source state's `frameId`
    *  to distinguish in-frame from real halt. */
   currentGraph: Graph | null;
-  /** Current value of `turing.haltState.debug` (boolean post-#207). The
+  /** Current value of `turing.haltState.debug` (a plain boolean). The
    *  gate that prevents halt-imminent wording from firing on plain
    *  state-level after-pauses. */
   haltStateDebug: boolean;

--- a/src/lib/lessonMarkdown.ts
+++ b/src/lib/lessonMarkdown.ts
@@ -1,4 +1,4 @@
-// Minimal markdown subset for snippet lesson notes (#112).
+// Minimal markdown subset for snippet lesson notes.
 // Author-controlled content from defaultCode.ts only — no user input. The
 // renderer covers exactly what the showcase notes need: paragraphs, bullet
 // lists, and inline-code spans. Everything else is left as plain text.

--- a/src/lib/machineRunner.ts
+++ b/src/lib/machineRunner.ts
@@ -60,7 +60,7 @@ export class MachineRunner {
   private runPending: RunPending | null = null;
   /**
    * Caller-set callback that fires whenever the worker echoes a
-   * `breakpointToggled` response (machines-demo#37 layer 1). The toggle
+   * `breakpointToggled` response. The toggle
    * request itself is fire-and-forget on the runner side; the UI updates
    * its indicator state on receipt of this echo rather than awaiting a
    * Promise, because toggles can land mid-run (parallel to the run loop)
@@ -316,7 +316,7 @@ export class MachineRunner {
 
   /**
    * Toggle a `before` or `after` breakpoint on the State whose engine
-   * `GraphNode.id` matches `stateId` (machines-demo#37). The OTHER kind's
+   * `GraphNode.id` matches `stateId`. The OTHER kind's
    * current bit is preserved worker-side. Fire-and-forget; the worker
    * echoes a `breakpointToggled` response (with the same `kind`) which
    * routes to `onBreakpointToggled`. No-op if the worker hasn't been

--- a/src/lib/machineWorker.ts
+++ b/src/lib/machineWorker.ts
@@ -106,8 +106,8 @@ const _clearTimeout: typeof clearTimeout = globalThis.clearTimeout.bind(globalTh
  * Function constructor evaluates in global scope, escaping the parameter
  * shadow), and `(0, eval)('globalThis')`. `Promise` stays available — the
  * engine is synchronous so `await` is a no-op for stepping anyway, but
- * blocking it would make most JS unwriteable. For airtight isolation see
- * issue #18 (ShadowRealm).
+ * blocking it would make most JS unwriteable. Airtight isolation would
+ * need a ShadowRealm-based sandbox.
  */
 
 const SANDBOX_BLOCKED_GLOBALS = [
@@ -152,7 +152,7 @@ let pendingCommand: MachineYield | null = null;
 // Engine v7 Graph snapshot captured at build, retained so onPause can ask
 // "is this state a wrapper?" and skip dispatch — wrappers are structural
 // devices (call-stack push), not meaningful program points, so a breakpoint
-// on a shared #debugRef pauses only at the bare (machines-demo#37 layer 1).
+// on a shared #debugRef pauses only at the bare.
 let currentGraph: Graph | null = null;
 
 /** Resolve the display name for an engine State, collapsing wrappers to
@@ -177,8 +177,8 @@ function resolveDisplayName(stateId: number, fallback: string): string {
 let resumeResolve: (() => void) | null = null;
 
 // Structural view of both the engine `DebugSession` and `PostDebugSession`.
-// The worker drives the engine's native pause/step controls directly (engine
-// #102) rather than synthesizing pauses: Step → stepIn(), click-Pause →
+// The worker drives the engine's native pause/step controls
+// directly rather than synthesizing pauses: Step → stepIn(), click-Pause →
 // pause(), Continue → continue(). All pauses (breakpoint / step / manual) come
 // back through the single `pause` event.
 type SessionLike = {
@@ -205,10 +205,10 @@ let resumeAction: 'continue' | 'step' | 'stop' = 'continue';
 // Per-run buffer of commands captured by onStep. Drained on `paused` (sent
 // in the response), on `idle` per-iter (auto mode), and on `ran` (sent in
 // the response). `runReadsBuffer` is the parallel array of pre-step head
-// symbols (machines-demo#69) — same length, same per-step index.
+// symbols — same length, same per-step index.
 // `runMatchKindsBuffer` is the parallel array of per-tape match kinds
 // (`'wildcard' | 'literal'`) sourced from
-// `MachineState.matchedTransition.matchKinds` (turing-machine-js#205) so
+// `MachineState.matchedTransition.matchKinds` so
 // the log can render `[*='X']` for wildcard reads — same length, same
 // per-step index.
 let runCommandBuffer: Command[][] = [];
@@ -220,7 +220,7 @@ let runStartStep = 0;
 // At the moment a BEFORE-pause fires for iter K, this holds iter K-1's
 // state.id — i.e. the source of the transition that just brought us into
 // iter K's state. That's the FROM of the "just-fired" triple the demo
-// highlights on the graph (machines-demo#10). Cleared on reset / run-
+// highlights on the graph. Cleared on reset / run-
 // start so the very first iter's before-pause sees null → main thread
 // uses the synthetic `idle` sentinel as FROM.
 let prevYieldedStateId: number | null = null;
@@ -372,7 +372,7 @@ function step(): {
   }
   phase = { kind: 'built', halted };
   const nextCommands = pendingCommand ? commandsFromYield(pendingCommand) : null;
-  // Highlight data (machines-demo#10). After the step, `pendingCommand` (if
+  // Highlight data. After the step, `pendingCommand` (if
   // not halted) is the NEXT yield — its `state` is the state about to fire
   // on the next Step click. That's our `from`; nextStateId is computed via
   // engine `getNextState(getSymbol(tapeBlock))`.
@@ -515,7 +515,7 @@ async function run(
 
   // onIter: engine fires this awaited callback at end of every iter. With
   // Step / click-Pause / breakpoints all driven through the engine's pause
-  // controls (engine #102), the only thing left here is the RUNNING_AUTO
+  // controls, the only thing left here is the RUNNING_AUTO
   // throttle: drain the command buffer → `idle` (suspends the runner's
   // WORKER_TIMEOUT_MS) → setTimeout(intervalMs) → `busy`. Cancellable
   // mid-throttle via `cancelThrottle()` from the `pause` request handler.
@@ -554,7 +554,7 @@ async function run(
     }
   };
 
-  // v7 adoption: drive the run through DebugSession (engine #102) instead
+  // v7 adoption: drive the run through DebugSession instead
   // of `machine.run({onPause, onStep, onIter})`. The engine's v7 run() is
   // sync + callback-free; all observation moved into the session.
   //
@@ -653,10 +653,10 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
     if (req.type === 'build') {
       build(req.engine, req.code);
       const built = phase as Extract<WorkerPhase, { kind: 'built' }>;
-      // Compute the engine-v7 Graph snapshot once at Build (machines-demo#9).
+      // Compute the engine-v7 Graph snapshot once at Build.
       // JSON-serializable; safe across the worker boundary. Main thread feeds
       // this to `toMermaid(graph)` for SVG rendering and uses the per-edge
-      // `GraphTransition.id`s for future highlight + breakpoint work (#10, #37).
+      // `GraphTransition.id`s for future highlight + breakpoint work.
       // Retained in `currentGraph` so onPause can ask `isWrapper?` and skip
       // wrapper-entry pauses (see onPauseFn in run()).
       currentGraph = turing.State.toGraph(
@@ -664,7 +664,7 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
         machine!.tapeBlock as unknown as turing.TapeBlock,
       ) as Graph;
 
-      // machines-demo#78: mirror code-set state.debug writes into the UI.
+      // Mirror code-set state.debug writes into the UI.
       // User code in the worker may have set state.debug programmatically
       // during `userFn`. Scan the state map for non-empty bits and bundle
       // them in the `built` response (NOT as separate unsolicited
@@ -772,7 +772,7 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
     }
 
     if (req.type === 'toggleBreakpoint') {
-      // machines-demo#37 — UI right-click context menu toggles the
+      // UI right-click context menu toggles the
       // requested kind (`before` or `after`) on the State whose engine
       // GraphNode.id matches `stateId`. The OTHER kind's current bit is
       // preserved — toggling `after` while `before` is on must not lose
@@ -798,7 +798,7 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
         });
         return;
       }
-      // haltState (turing-machine-js#207): `debug` is a single boolean,
+      // haltState: `debug` is a single boolean,
       // not a DebugConfig — the menu shows one "Pause" toggle for halt.
       // Branch out before reading per-side bits, since `boolean.before`
       // would be `undefined` and `mergeDebugKinds` would flip "on" every

--- a/src/lib/pauseLineFormat.ts
+++ b/src/lib/pauseLineFormat.ts
@@ -10,7 +10,7 @@ import type { PausedResponse } from './types.ts';
  * 1. Halt-imminent (after-pause where worker tagged `imminentHalt`) —
  *    fires only when halt-BP is on AND the iter's transition resolves to
  *    haltState. Wording: `"paused before halt (after X)"`. "(after X)" is
- *    accurate under the new engine timing (#207): X's iter just ran.
+ *    accurate under the new engine timing: X's iter just ran.
  * 2. Before-pause — surface head symbols (the step-log line for this
  *    iter hasn't landed yet). Encoding matches `formatStepNotation`
  *    byte-for-byte so the pause line + step line use the same glyph

--- a/src/lib/scenarioRunner.test.ts
+++ b/src/lib/scenarioRunner.test.ts
@@ -57,8 +57,8 @@ describe('scenario: callable-subtree (walkToBlank wrapping writeMarker)', () => 
     expect(result.logs.map((l) => `[${l.kind}] ${l.text}`)).toEqual([
       "[step] step 1: [*='a'] → [K='a']/[R]",
       // iter 1's source state is the wrapper 'walkToBlank' (the
-      // call site) — its #debugRef is shared with the bare 'walkToBlank' via
-      // engine #150, so walkToBlank.after firing also fires here.
+      // call site) — the engine shares its #debugRef with the bare
+      // 'walkToBlank', so walkToBlank.after firing also fires here.
       '[pause] paused at state walkToBlank after applying command',
       "[step] step 2: [*='b'] → [K='b']/[R]",
       '[pause] paused at state walkToBlank after applying command',

--- a/src/lib/scenarioRunner.ts
+++ b/src/lib/scenarioRunner.ts
@@ -52,7 +52,7 @@ export type ScenarioBPConfig = {
   /** Per-state BPs. State names must match the engine's `state.name`
    *  exactly (incl. composite wrapper names like `'walkToBlank(writeMarker)'`). */
   states?: Record<string, StateBPConfig>;
-  /** Halt-BP — `haltState.debug = boolean` (turing-machine-js#207). */
+  /** Halt-BP — `haltState.debug = boolean` (the engine's halt debug flag). */
   halt?: boolean;
 };
 
@@ -158,7 +158,7 @@ export async function runScenario(input: ScenarioInput): Promise<ScenarioOutput>
     }
   }
 
-  // Halt-BP (turing-machine-js#207: boolean).
+  // Halt-BP (`haltState.debug` is a plain boolean).
   (turing.haltState as { debug: boolean }).debug = input.bp.halt === true;
 
   // Tracking: prev state id (for before-pause's prevStateId), step counter.

--- a/src/lib/scrollCenter.ts
+++ b/src/lib/scrollCenter.ts
@@ -1,4 +1,4 @@
-// Pure viewport-math helpers for the machine-graph panel (machines-demo#110).
+// Pure viewport-math helpers for the machine-graph panel.
 //
 // - `computeCenterScroll` decides where to scroll a container so a target
 //   element sits at the visible center, but only when the element has
@@ -76,7 +76,7 @@ export function computeCenterScroll(
 
 /**
  * Pick the largest zoom ≤ 1 such that at least `minVisibleAreaRatio` of the
- * SVG's intrinsic area fits inside the body's content box (machines-demo#110).
+ * SVG's intrinsic area fits inside the body's content box.
  * Returns `1` when the SVG already fits comfortably at full size.
  *
  * The visible-area ratio is a strictly decreasing function of zoom — larger

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,7 +40,7 @@ export type WorkerRequest =
   | { type: 'resume'; step?: boolean; intervalMs?: number | null } // step?: true → advance one iteration, then re-pause; intervalMs: convey the current withPause at Continue time (spec §3 reads withPause at click, not at run-start)
   | { type: 'pause' } // click-pause from RUNNING_AUTO — worker cancels throttle and dispatches a synthetic `paused` from the next onStep
   | { type: 'setDebug'; on: boolean } // runtime-toggle debug-break pausing during a run
-  | { type: 'toggleBreakpoint'; stateId: number; kind: BreakpointKind }; // machines-demo#37: flip `state.debug.before` or `state.debug.after` on the State whose engine GraphNode.id matches `stateId`. Worker merges with the OTHER kind's current bit so toggling one doesn't clobber the other; resolves via `State.collectStates`. Main thread reflects the new state in the UI via the `breakpointToggled` response.
+  | { type: 'toggleBreakpoint'; stateId: number; kind: BreakpointKind }; // Flip `state.debug.before` or `state.debug.after` on the State whose engine GraphNode.id matches `stateId`. Worker merges with the OTHER kind's current bit so toggling one doesn't clobber the other; resolves via `State.collectStates`. Main thread reflects the new state in the UI via the `breakpointToggled` response.
 
 export type BreakpointKind = 'before' | 'after';
 
@@ -54,7 +54,7 @@ export type BuiltResponse = {
   halted: boolean;
   /**
    * Engine-v7 `Graph` snapshot for the assembled state graph, computed once
-   * at Build via `State.toGraph(initialState, tapeBlock)` (machines-demo#9).
+   * at Build via `State.toGraph(initialState, tapeBlock)`.
    * Main thread feeds this to `toMermaid(graph)` for SVG rendering. The
    * Graph type is JSON-serializable — safe to send across the worker
    * boundary. `null` when build failed (the `error` response is used in
@@ -62,7 +62,7 @@ export type BuiltResponse = {
    */
   graph: Graph;
   /**
-   * Breakpoints set by user code during `userFn` (machines-demo#78). One
+   * Breakpoints set by user code during `userFn`. One
    * entry per canonical bare-state id with at least one of `before` /
    * `after` set. Bundled in the `built` response (rather than emitted as
    * separate unsolicited `breakpointToggled` messages) so the main
@@ -88,7 +88,7 @@ export type SteppedResponse = {
   /**
    * Per-tape symbols read at each head BEFORE this step applied. Parallel to
    * `commands`; one entry per tape. Drives `[reads] → [writes]/[moves]`
-   * edge-label-style log rendering (machines-demo#69). `null` when
+   * edge-label-style log rendering. `null` when
    * `commands` is `null` (halted, no step ran).
    */
   reads: string[] | null;
@@ -96,8 +96,8 @@ export type SteppedResponse = {
    * Per-tape match kind for the firing alternative's selector at each head
    * position (`'wildcard'` iff the engine matched via `ifOtherSymbol` at
    * that position, `'literal'` otherwise). Parallel to `reads`; sourced
-   * from `MachineState.matchedTransition.matchKinds`
-   * (turing-machine-js#205). Drives the `[*='X']` wildcard read marker
+   * from `MachineState.matchedTransition.matchKinds`.
+   * Drives the `[*='X']` wildcard read marker
    * in the log. `null` when `commands` is `null` (halted, no step ran).
    */
   matchKinds: ('wildcard' | 'literal')[] | null;
@@ -105,14 +105,14 @@ export type SteppedResponse = {
   /**
    * Engine State.id of the state the machine is currently in AFTER this step
    * (i.e., the state that will fire on the next Step click). Drives current-
-   * state highlighting in the rendered graph (machines-demo#10). `null` at
+   * state highlighting in the rendered graph. `null` at
    * halt (no further step possible).
    */
   currentStateId: number | null;
   /**
    * Engine State.id of the state that will follow `currentStateId` on the
-   * next step. Drives `from + edge + to` triple highlight in the graph
-   * (machines-demo#10). `null` at halt or when `currentStateId` is `null`.
+   * next step. Drives `from + edge + to` triple highlight in the
+   * graph. `null` at halt or when `currentStateId` is `null`.
    */
   nextStateId: number | null;
   stepsApplied: number;
@@ -126,13 +126,13 @@ export type RanResponse = {
   /** Per-step, per-tape reads captured before each step. Parallel to `commands`. */
   reads: string[][];
   /** Per-step, per-tape match kinds captured before each step (parallel to
-   *  `reads`). Sourced from `MachineState.matchedTransition.matchKinds`
-   *  (turing-machine-js#205) — drives the `[*='X']` wildcard read marker. */
+   *  `reads`). Sourced from `MachineState.matchedTransition.matchKinds` —
+   *  drives the `[*='X']` wildcard read marker. */
   matchKinds: ('wildcard' | 'literal')[][];
   /**
    * Engine State.id of the final state at run end (typically the halt state).
    * Drives the snap-to-result current-state highlight in `RUNNING_CONTINUOUS`
-   * mode (machines-demo#10). `null` if the run produced no steps.
+   * mode. `null` if the run produced no steps.
    */
   currentStateId: number | null;
   startStep: number;
@@ -159,12 +159,12 @@ export type PausedResponse = {
   /** Per-step, per-tape reads captured before each step. Parallel to `commands`. */
   reads: string[][];
   /** Per-step, per-tape match kinds captured before each step (parallel to
-   *  `reads`). Sourced from `MachineState.matchedTransition.matchKinds`
-   *  (turing-machine-js#205) — drives the `[*='X']` wildcard read marker. */
+   *  `reads`). Sourced from `MachineState.matchedTransition.matchKinds` —
+   *  drives the `[*='X']` wildcard read marker. */
   matchKinds: ('wildcard' | 'literal')[][];
   /**
-   * Engine State.id at the moment of pause — m.state per the engine
-   * (machines-demo#10). The "you are here" anchor.
+   * Engine State.id at the moment of pause — m.state per the
+   * engine. The "you are here" anchor.
    */
   currentStateId: number | null;
   /**
@@ -193,7 +193,7 @@ export type PausedResponse = {
    *  wildcard marker in the pause-line's "for symbols: …" group so it
    *  matches the step-log line for the same iter. */
   currentMatchKinds: ('wildcard' | 'literal')[];
-  /** Pause descriptor (mirrors the engine's `m.pause`, engine #102).
+  /** Pause descriptor (mirrors the engine's `m.pause`).
    * - `side` — `'before'` / `'after'` for an engine breakpoint pause. ABSENT
    *   for a worker-synthesized boundary (a Step-button stop or a click-pause
    *   from RUNNING_AUTO), which has no before/after timing — formatPauseLine
@@ -215,7 +215,7 @@ export type PausedResponse = {
    *
    * Highlight projection was previously driven from this field (the
    * deleted §7' rule in `applyHighlight.ts`), but under the new engine
-   * timing (turing-machine-js#207, halt-imminent on AFTER side) the
+   * timing (halt-imminent on the AFTER side) the
    * standard §3 + §7 rules naturally show the right thing at the right
    * moment; this field is purely a wording cue now.
    */
@@ -240,21 +240,21 @@ export type IdleResponse = {
   /** Per-step, per-tape reads captured before each step. Parallel to `commands`. */
   reads: string[][];
   /** Per-step, per-tape match kinds captured before each step (parallel to
-   *  `reads`). Sourced from `MachineState.matchedTransition.matchKinds`
-   *  (turing-machine-js#205) — drives the `[*='X']` wildcard read marker. */
+   *  `reads`). Sourced from `MachineState.matchedTransition.matchKinds` —
+   *  drives the `[*='X']` wildcard read marker. */
   matchKinds: ('wildcard' | 'literal')[][];
   /**
    * Engine State.id of the state about to fire on the next iteration
    * (post-throttle resume) — i.e. m.state after the just-applied iter.
    * Drives the `from + edge + to` triple highlight per iter during
-   * `RUNNING_AUTO` (machines-demo#10), strong on FROM (= m.state, "you
+   * `RUNNING_AUTO`, strong on FROM (= m.state, "you
    * are here looking forward"). `null` if the run halted.
    */
   currentStateId: number | null;
   /**
    * Engine State.id of the state that will follow `currentStateId` on the
    * next iter. Drives the `to` end of the per-iter triple highlight in
-   * `RUNNING_AUTO` (machines-demo#10). `null` at halt or when
+   * `RUNNING_AUTO`. `null` at halt or when
    * `currentStateId` is `null`.
    */
   nextStateId: number | null;
@@ -264,13 +264,13 @@ export type BusyResponse = { type: 'busy' };
 
 /**
  * Echo of a `toggleBreakpoint` request after the worker mutates
- * `state.debug` (machines-demo#37 layer 1). `value` is the new state of the
+ * `state.debug`. `value` is the new state of the
  * breakpoint on the targeted `stateId` — `'on'` after toggling a previously-
  * absent breakpoint, `'off'` after toggling a previously-present one. The
  * main thread updates its `breakpointsByStateId` registry on receipt so the
  * indicator dot in the rendered graph reflects the engine's actual state.
  *
- * Code-set breakpoints (machines-demo#78 — user code in the worker doing
+ * Code-set breakpoints (user code in the worker doing
  * `state.debug = { before: true }` programmatically) do NOT flow through
  * this response. They're bundled in `BuiltResponse.codeSetBreakpoints`
  * and applied directly to the main-thread map after build, avoiding the

--- a/src/lib/workerHelpers.ts
+++ b/src/lib/workerHelpers.ts
@@ -17,13 +17,13 @@ export type MachineYield = {
   nextSymbols: string[];
   /** Engine State object. Only `id` plus the `getSymbol`/`getNextState`
    *  methods are read on the demo side, used to drive `from + edge + to`
-   *  graph highlight (machines-demo#10). */
+   *  graph highlight. */
   state: {
     id: number;
     getSymbol: (tapeBlock: unknown) => symbol;
     getNextState: (sym: symbol) => { ref: { id: number } };
   };
-  /** Engine per-iter `matchedTransition` (turing-machine-js#205). Drives the
+  /** Engine per-iter `matchedTransition`. Drives the
    *  `[*='X']` wildcard read marker in the log when the firing alternative
    *  matched via `ifOtherSymbol` at a tape position. */
   matchedTransition: {
@@ -45,7 +45,7 @@ export function commandsFromYield(y: MachineYield): Command[] {
 
 /** Per-tape read symbols at the heads BEFORE the yielded step applied.
  *  Parallel to `commandsFromYield`; defensive-copies so the caller can
- *  mutate without aliasing the engine's array (machines-demo#69). */
+ *  mutate without aliasing the engine's array. */
 export function readsFromYield(y: MachineYield): string[] {
   return [...y.currentSymbols];
 }
@@ -55,8 +55,8 @@ export function readsFromYield(y: MachineYield): string[] {
  *  `'literal'` otherwise). Parallel to `readsFromYield` and
  *  `commandsFromYield`; defensive-copies so the caller can mutate the
  *  array without aliasing the engine's. Sourced from
- *  `MachineState.matchedTransition.matchKinds` (turing-machine-js#205) —
- *  drives the `[*='X']` wildcard read marker in the log. */
+ *  `MachineState.matchedTransition.matchKinds` — drives the `[*='X']`
+ *  wildcard read marker in the log. */
 export function matchKindsFromYield(y: MachineYield): ('wildcard' | 'literal')[] {
   return [...y.matchedTransition.matchKinds];
 }
@@ -64,8 +64,8 @@ export function matchKindsFromYield(y: MachineYield): ('wildcard' | 'literal')[]
 /** Engine State.id of the next state the yielded transition will land on.
  *  Computed via `state.getNextState(state.getSymbol(tapeBlock)).ref.id` —
  *  the same lookup the engine performs internally each iter, just executed
- *  on demand here so the demo can drive the `from → to` graph highlight
- *  (machines-demo#10). Returns `null` if the lookup throws (defensive). */
+ *  on demand here so the demo can drive the `from → to` graph
+ *  highlight. Returns `null` if the lookup throws (defensive). */
 export function nextStateIdFromYield(y: MachineYield, tapeBlock: unknown): number | null {
   try {
     const sym = y.state.getSymbol(tapeBlock);


### PR DESCRIPTION
Docs-only sweep enforcing the family content-reference policy (mellonis/machines#4, as refined 2026-07-06 by the published-docs reference policy). machines-demo publishes no npm package, so the swept "published" surface is the public-facing repo docs.

- **Public-facing docs** — `README.md`, `docs/execution-model.md`, `docs/palette-sandbox/variant-a.html` — no longer carry tracker references in any form, including cross-repo engine refs. Behavior-doc links were retargeted to relative living docs; two pure-tracker bullets in execution-model §11 were dropped, with the spec bullet keeping its relative link only.
- **Source comments + test titles** (~20 files across `src/` and `e2e/`): all `machines-demo#N` / `turing-machine-js#N` / `engine #N` refs rewritten in prose or dropped (e.g. "may become user-configurable", "airtight isolation would need a ShadowRealm-based sandbox", "the engine shares its #debugRef with the bare").
- **Deliberate keeps**: the README shields badge; the App.svelte footer "View source on GitHub" link + its icon (in-app UI affordance, host-bound surface updated on migration); npmjs.com links; `CLAUDE.md` and `docs/superpowers/` untouched (internal dev artifacts are unrestricted).

Verification: `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings; post-sweep grep shows the badge and footer href as the only forge URLs and zero tracker-shaped refs in the swept surfaces.

Closes #123.
